### PR TITLE
Show the repeat summary only when a rule exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Repeat field no longer tells you twice that a task does not repeat.** A summary line sat under the Repeat picker restating whatever the picker already showed, so every task that does not repeat said "Does not repeat" twice in a row. The summary now appears only when there is a real schedule to spell out — "Every 2 weeks on Monday" — and Repeat has lost the dashed box that made the least-used field on the form the heaviest thing on the page.
+
 - **A task description with a code block no longer stretches its board card out of the column.** Code fences, tables, images and unbroken strings were rendered at whatever width they wanted, so one task with a snippet in its description pushed its card past the edge of the column and left the whole board scrolling sideways. Code now wraps, wide tables and images stay inside the card, and a long title breaks rather than pushing. The same containment applies everywhere a description is rendered, so the task detail page and the hover preview get it too — and code blocks and inline code now read as code, on a tinted, rounded background.
 
 - **Renaming a spreadsheet sheet keeps what you type.** The tab's rename box re-selected the whole name after every keystroke, so each new character wiped out the one before it and the sheet ended up named after the last letter typed. The name is now selected once when the box opens, as intended, and typing behaves normally from there.

--- a/frontend/src/components/projects/TaskRecurrenceSelector.test.tsx
+++ b/frontend/src/components/projects/TaskRecurrenceSelector.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * What the Repeat field says when it has nothing to say.
+ *
+ * The summary line under the preset select restated the select's own value:
+ * an untouched form read "Does not repeat" twice over. It now appears only
+ * once there is a real rule for it to describe.
+ */
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders } from "@/__tests__/helpers/render";
+import type { TaskRecurrenceOutput } from "@/api/generated/initiativeAPI.schemas";
+import { TaskRecurrenceSelector } from "@/components/projects/TaskRecurrenceSelector";
+
+const renderSelector = (recurrence: TaskRecurrenceOutput | null) =>
+  renderWithProviders(
+    <TaskRecurrenceSelector
+      recurrence={recurrence}
+      onChange={() => {}}
+      strategy="fixed"
+      onStrategyChange={() => {}}
+      referenceDate={null}
+    />
+  );
+
+describe("TaskRecurrenceSelector", () => {
+  it("says 'Does not repeat' once, in the select, when there is no rule", async () => {
+    renderSelector(null);
+
+    // The select still carries the label; what is gone is the paragraph under
+    // it that used to repeat the same words.
+    expect(await screen.findAllByText(/does not repeat/i)).toHaveLength(1);
+  });
+
+  it("summarises a real rule beneath the select", async () => {
+    renderSelector({
+      frequency: "weekly",
+      interval: 2,
+      weekdays: ["monday"],
+      ends: "never",
+    } as TaskRecurrenceOutput);
+
+    expect(await screen.findByText(/every 2 weeks/i)).toBeInTheDocument();
+    expect(screen.queryByText(/does not repeat/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/projects/TaskRecurrenceSelector.tsx
+++ b/frontend/src/components/projects/TaskRecurrenceSelector.tsx
@@ -289,9 +289,11 @@ export const TaskRecurrenceSelector = ({
     [i18n.language, t]
   );
 
+  // Null whenever there is no rule worth describing — the select already says
+  // "Does not repeat", so a summary repeating it verbatim is pure noise.
   const summary = useMemo(() => {
     if (!recurrence) {
-      return t("recurrence.doesNotRepeat");
+      return null;
     }
     const rule = recurrence;
     const interval = rule.interval;
@@ -360,11 +362,11 @@ export const TaskRecurrenceSelector = ({
       }
     }
 
-    return base || t("recurrence.doesNotRepeat");
+    return base || null;
   }, [recurrence, referenceDate, t, formatWeekdayList]);
 
   return (
-    <div className="space-y-4 rounded-md border border-border/70 border-dashed p-4">
+    <div className="space-y-4">
       <div className="space-y-2">
         <Label>{t("recurrence.repeat")}</Label>
         <Select
@@ -383,7 +385,7 @@ export const TaskRecurrenceSelector = ({
             ))}
           </SelectContent>
         </Select>
-        <p className="text-muted-foreground text-sm">{summary}</p>
+        {summary ? <p className="text-muted-foreground text-sm">{summary}</p> : null}
       </div>
 
       {showCustomFields && recurrence ? (


### PR DESCRIPTION
## Problem

The summary line under the Repeat picker restated whatever the picker already displayed, so an untouched task form read:

> Repeat: [ Does not repeat ▾ ]
> Does not repeat

And Repeat was the only bordered field on the task form — a dashed box around the least-used control on the page.

## Changes

[TaskRecurrenceSelector.tsx](frontend/src/components/projects/TaskRecurrenceSelector.tsx)

- `summary` returns `null` with no rule instead of `t("recurrence.doesNotRepeat")`, and the `<p>` renders conditionally. The select still carries the label; the paragraph no longer parrots it.
- The `base || t("recurrence.doesNotRepeat")` fallback became `base || null`. That path fires for a monthly rule with neither `day_of_month` nor `weekday_position` set — captioning a rule that *does* repeat as "Does not repeat". It now says nothing rather than something false.
- Dropped `rounded-md border border-border/70 border-dashed p-4` from the wrapper, so Repeat sits at the same weight as Start date and Due date. The inner bordered panel stays: it appears only once a custom schedule is chosen, and it is a real sub-editor.

Both surfaces get this at once — the create dialog and the edit page share the component.

No i18n changes: `recurrence.doesNotRepeat` is still used by the select's option label and placeholder.

## Testing

[TaskRecurrenceSelector.test.tsx](frontend/src/components/projects/TaskRecurrenceSelector.test.tsx) is new — the component had no tests. Two cases: "Does not repeat" appears exactly once with no rule (two before this change), and a real rule renders its summary with no "Does not repeat" anywhere.

- `pnpm typecheck` — clean
- `pnpm biome check` — clean
- `./scripts/test-changed.sh` — 185 files, 2126 passed

Task: https://initiative.morels.me/g/3/i/5/projects/1/tasks/2759