### PR TITLE
Lay out the task form in shared named sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Creating a task and editing one now lay the fields out the same way.** The two screens share the same set of fields but arranged them differently, and the order had stopped meaning anything — Assignees and Tags sat between the dates and the Repeat rule that is worked out from the due date. Both screens now use the same named sections in the same order — Tracking, Schedule, People & labels, Properties — with the create dialog collapsing all but the title and description. Start date, due date and Repeat finally sit together under Schedule.
+
+- **The task editor stops repeating itself.** The title was on screen three times over — in the breadcrumb, as the heading, and in the Title box — with the heading and the box showing the same live value, so typing in one retitled the other. The status was on screen twice for the same reason. Above the first field sat two separate lines explaining that this is where you edit a task. The Title box is now the heading itself, the status is stated once by its own picker, and both explanatory lines are gone.
+
 - **A task's editor ends in two buttons, not six.** Save, cancel, move to project, duplicate, archive and delete all sat in one row at the foot of the task editor, so the action you almost always want looked exactly like the ones you almost never do — and delete sat two buttons from save. Save and cancel keep their place; move, duplicate, archive and delete moved behind a single "…" menu at the end of the row, with delete set apart below a divider.
 
 - **"Browse the marketplace" is out of the overflow menu.** Adding a ready-made dashboard is the same kind of answer as making one from scratch, but only one of the two was on the page — the other sat behind the "…" button, where someone who has never opened it never learns the shelf exists. It now sits next to the create button on the dashboards list, at every width, and beside "Create your first dashboard" in an initiative that has none yet.

--- a/frontend/public/locales/de/tasks.json
+++ b/frontend/public/locales/de/tasks.json
@@ -63,12 +63,8 @@
     "noAccessDescription": "Du hast keine Berechtigung, diese Aufgabe anzuzeigen. Bitte einen Projektleiter, dir Zugriff zu gewähren.",
     "backToProjects": "← Zurück zu den Projekten",
     "loadProjectError": "Der Projektkontext für diese Aufgabe konnte nicht geladen werden.",
-    "statusBadge": "Status",
     "createdBy": "Erstellt von {{name}} · {{time}}",
     "createdAt": "Erstellt {{time}}",
-    "subtitle": "Bearbeite jedes Detail dieser Aufgabe.",
-    "detailsTitle": "Aufgabendetails",
-    "detailsDescription": "Aktualisiere die Felder unten und speichere deine Änderungen.",
     "readOnlyNoAccess": "Du hast nur Lesezugriff auf dieses Projekt, daher sind die Aufgabenfelder deaktiviert.",
     "readOnlyArchived": "Dieses Projekt ist archiviert. Hebe die Archivierung in den Projekteinstellungen auf, um Aufgaben zu bearbeiten.",
     "titleLabel": "Titel",
@@ -289,6 +285,11 @@
     "startDateLabel": "Startdatum",
     "dueDateLabel": "Fälligkeitsdatum",
     "tagsLabel": "Tags",
-    "tagsPlaceholder": "Tags hinzufügen"
+    "tagsPlaceholder": "Tags hinzufügen",
+    "sections": {
+      "tracking": "Nachverfolgung",
+      "schedule": "Zeitplan",
+      "people": "Personen & Tags"
+    }
   }
 }

--- a/frontend/public/locales/en/tasks.json
+++ b/frontend/public/locales/en/tasks.json
@@ -63,12 +63,8 @@
     "noAccessDescription": "You don’t have permission to view this task. Ask a project manager to grant you access.",
     "backToProjects": "← Back to projects",
     "loadProjectError": "Unable to load project context for this task.",
-    "statusBadge": "Status",
     "createdBy": "Created by {{name}} · {{time}}",
     "createdAt": "Created {{time}}",
-    "subtitle": "Edit every detail of this task.",
-    "detailsTitle": "Task details",
-    "detailsDescription": "Update the fields below and save your changes.",
     "readOnlyNoAccess": "You only have read access to this project, so task fields are disabled.",
     "readOnlyArchived": "This project is archived. Unarchive it from project settings to edit tasks.",
     "titleLabel": "Title",
@@ -289,6 +285,11 @@
     "startDateLabel": "Start date",
     "dueDateLabel": "Due date",
     "tagsLabel": "Tags",
-    "tagsPlaceholder": "Add tags"
+    "tagsPlaceholder": "Add tags",
+    "sections": {
+      "tracking": "Tracking",
+      "schedule": "Schedule",
+      "people": "People & labels"
+    }
   }
 }

--- a/frontend/public/locales/es/tasks.json
+++ b/frontend/public/locales/es/tasks.json
@@ -63,12 +63,8 @@
     "noAccessDescription": "No tienes permiso para ver esta tarea. Pide a un administrador del proyecto que te otorgue acceso.",
     "backToProjects": "← Volver a proyectos",
     "loadProjectError": "No se pudo cargar el contexto del proyecto para esta tarea.",
-    "statusBadge": "Estado",
     "createdBy": "Creada por {{name}} · {{time}}",
     "createdAt": "Creada {{time}}",
-    "subtitle": "Edita todos los detalles de esta tarea.",
-    "detailsTitle": "Detalles de la tarea",
-    "detailsDescription": "Actualiza los campos a continuación y guarda tus cambios.",
     "readOnlyNoAccess": "Solo tienes acceso de lectura a este proyecto, por lo que los campos de la tarea están deshabilitados.",
     "readOnlyArchived": "Este proyecto está archivado. Desarchívalo desde la configuración del proyecto para editar tareas.",
     "titleLabel": "Título",
@@ -289,6 +285,11 @@
     "startDateLabel": "Fecha de inicio",
     "dueDateLabel": "Fecha de vencimiento",
     "tagsLabel": "Etiquetas",
-    "tagsPlaceholder": "Añadir etiquetas"
+    "tagsPlaceholder": "Añadir etiquetas",
+    "sections": {
+      "tracking": "Seguimiento",
+      "schedule": "Programación",
+      "people": "Personas y etiquetas"
+    }
   }
 }

--- a/frontend/public/locales/fr/tasks.json
+++ b/frontend/public/locales/fr/tasks.json
@@ -63,12 +63,8 @@
     "noAccessDescription": "Vous n'avez pas la permission de consulter cette tâche. Demandez à un gestionnaire de projet de vous accorder l'accès.",
     "backToProjects": "← Retour aux projets",
     "loadProjectError": "Impossible de charger le contexte du projet pour cette tâche.",
-    "statusBadge": "Statut",
     "createdBy": "Créée par {{name}} · {{time}}",
     "createdAt": "Créée {{time}}",
-    "subtitle": "Modifiez chaque détail de cette tâche.",
-    "detailsTitle": "Détails de la tâche",
-    "detailsDescription": "Mettez à jour les champs ci-dessous et enregistrez vos modifications.",
     "readOnlyNoAccess": "Vous n'avez qu'un accès en lecture à ce projet, les champs de la tâche sont donc désactivés.",
     "readOnlyArchived": "Ce projet est archivé. Désarchivez-le depuis les paramètres du projet pour modifier les tâches.",
     "titleLabel": "Titre",
@@ -289,6 +285,11 @@
     "startDateLabel": "Date de début",
     "dueDateLabel": "Date d'échéance",
     "tagsLabel": "Étiquettes",
-    "tagsPlaceholder": "Ajouter des étiquettes"
+    "tagsPlaceholder": "Ajouter des étiquettes",
+    "sections": {
+      "tracking": "Suivi",
+      "schedule": "Planification",
+      "people": "Personnes et étiquettes"
+    }
   }
 }

--- a/frontend/src/components/tasks/TaskForm.test.tsx
+++ b/frontend/src/components/tasks/TaskForm.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * The one thing that keeps creating and editing a task from drifting apart.
+ *
+ * Both surfaces render the same `TaskForm`, but each used to compose its own
+ * field list by hand, so a field could reach one and be forgotten on the
+ * other. Every layout is now a projection over `TASK_FORM_SECTIONS`, and this
+ * asserts that definition covers `TaskFormValue` exactly — add a field to the
+ * value without giving it a section and this fails.
+ */
+import { describe, expect, it } from "vitest";
+
+import { emptyTaskFormValue, TASK_FORM_SECTIONS } from "@/components/tasks/TaskForm";
+
+describe("TASK_FORM_SECTIONS", () => {
+  it("gives every field of a task form value exactly one section", () => {
+    const placed = TASK_FORM_SECTIONS.flatMap((section) => [...section.keys]);
+    const all = Object.keys(emptyTaskFormValue());
+
+    expect([...placed].sort()).toEqual([...all].sort());
+  });
+
+  it("places each field only once", () => {
+    const placed = TASK_FORM_SECTIONS.flatMap((section) => [...section.keys]);
+
+    expect(new Set(placed).size).toBe(placed.length);
+  });
+});

--- a/frontend/src/components/tasks/TaskForm.tsx
+++ b/frontend/src/components/tasks/TaskForm.tsx
@@ -93,6 +93,27 @@ export const emptyTaskFormValue = (overrides: Partial<TaskFormValue> = {}): Task
   ...overrides,
 });
 
+/**
+ * The form's sections, in render order, and the ``TaskFormValue`` keys each
+ * one owns. Every layout is a projection over this — the dialog collapses
+ * all but the first, the page lays them out flat — so a field cannot reach
+ * one surface and be forgotten on the other.
+ *
+ * ``taskForm.sections`` in ``TaskForm.test.tsx`` asserts these keys cover
+ * ``TaskFormValue`` exactly, so adding a field to the value without giving
+ * it a section fails CI.
+ */
+export const TASK_FORM_SECTIONS = [
+  { id: "details", keys: ["title", "description"] },
+  { id: "tracking", keys: ["statusId", "priority"] },
+  { id: "schedule", keys: ["startDate", "dueDate", "recurrence", "recurrenceStrategy"] },
+  { id: "people", keys: ["assigneeIds", "tags"] },
+  { id: "properties", keys: ["properties", "propertyValues"] },
+] as const satisfies readonly {
+  id: string;
+  keys: readonly (keyof TaskFormValue)[];
+}[];
+
 export interface TaskFormProps {
   value: TaskFormValue;
   onChange: (value: TaskFormValue) => void;
@@ -299,8 +320,7 @@ export const TaskForm = ({
   );
 
   const propertiesField = (
-    <section className="space-y-2">
-      <Label>{t("properties:title")}</Label>
+    <div className="space-y-2">
       <PropertyFields
         properties={value.properties}
         values={value.propertyValues}
@@ -315,7 +335,7 @@ export const TaskForm = ({
         onAdd={handlePropertyAdd}
         disabled={disabled || !initiativeId}
       />
-    </section>
+    </div>
   );
 
   const descriptionField = descriptionSlot ?? (
@@ -332,9 +352,13 @@ export const TaskForm = ({
     </div>
   );
 
+  // On the page the title IS the heading — the editor used to render it twice,
+  // once as an <h1> and once as this field, both bound to the same state.
   const titleField = (
     <div className="space-y-2">
-      <Label htmlFor="task-title">{t("taskForm.titleLabel")}</Label>
+      <Label htmlFor="task-title" className={layout === "page" ? "sr-only" : undefined}>
+        {t("taskForm.titleLabel")}
+      </Label>
       <Input
         id="task-title"
         value={value.title}
@@ -343,39 +367,71 @@ export const TaskForm = ({
         required
         disabled={disabled}
         autoFocus={autoFocusTitle}
+        className={
+          layout === "page"
+            ? "h-auto border-0 px-0 font-semibold text-3xl tracking-tight shadow-none focus-visible:ring-0 md:text-3xl"
+            : undefined
+        }
       />
     </div>
   );
 
-  const advancedFields = (
-    <>
-      {descriptionField}
-      {statusPriority}
-      {dates}
-      {assigneesTags}
-      {recurrenceField}
-      {propertiesField}
-    </>
+  const sectionContent: Record<(typeof TASK_FORM_SECTIONS)[number]["id"], ReactNode> = {
+    details: (
+      <>
+        {titleField}
+        {descriptionField}
+      </>
+    ),
+    tracking: statusPriority,
+    schedule: (
+      <>
+        {dates}
+        {recurrenceField}
+      </>
+    ),
+    people: assigneesTags,
+    properties: propertiesField,
+  };
+
+  // The leading section needs no heading: a title and a description under the
+  // form's own heading announce themselves.
+  const sectionHeading: Record<(typeof TASK_FORM_SECTIONS)[number]["id"], string | null> = {
+    details: null,
+    tracking: t("taskForm.sections.tracking"),
+    schedule: t("taskForm.sections.schedule"),
+    people: t("taskForm.sections.people"),
+    properties: t("properties:title"),
+  };
+
+  const renderSection = ({ id }: (typeof TASK_FORM_SECTIONS)[number]) => (
+    <section key={id} className="space-y-4">
+      {sectionHeading[id] ? (
+        <h2 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+          {sectionHeading[id]}
+        </h2>
+      ) : null}
+      {sectionContent[id]}
+    </section>
   );
+
+  const [leadSection, ...detailSections] = TASK_FORM_SECTIONS;
 
   if (layout === "dialog") {
     return (
       <div className="space-y-4">
-        {titleField}
+        {renderSection(leadSection)}
         <Accordion type="single" collapsible>
           <AccordionItem value="advanced">
             <AccordionTrigger>{t("taskForm.advancedDetails")}</AccordionTrigger>
-            <AccordionContent className="space-y-4">{advancedFields}</AccordionContent>
+            <AccordionContent className="space-y-6">
+              {detailSections.map(renderSection)}
+            </AccordionContent>
           </AccordionItem>
         </Accordion>
       </div>
     );
   }
 
-  return (
-    <div className="space-y-6">
-      {titleField}
-      {advancedFields}
-    </div>
-  );
+  return <div className="space-y-6">{TASK_FORM_SECTIONS.map(renderSection)}</div>;
 };

--- a/frontend/src/pages/TaskEditPage.test.tsx
+++ b/frontend/src/pages/TaskEditPage.test.tsx
@@ -26,7 +26,14 @@ const TASK_ID = 2726;
 const TASK_ROUTE = "/c/$guildId/i/$initiativeId/projects/$projectId/tasks/$taskId";
 
 /** The project the task actually belongs to, which a move can change. */
-const renderTaskPage = ({ taskProjectId = PROJECT_ID }: { taskProjectId?: number } = {}) => {
+const renderTaskPage = ({
+  taskProjectId = PROJECT_ID,
+  /** What the project reports; a column the task uses can be missing from it. */
+  statuses,
+}: {
+  taskProjectId?: number;
+  statuses?: unknown[];
+} = {}) => {
   const task = buildTask({ id: TASK_ID, project_id: taskProjectId, title: "Wire the doorbell" });
   const project = buildProject({
     id: taskProjectId,
@@ -42,6 +49,9 @@ const renderTaskPage = ({ taskProjectId = PROJECT_ID }: { taskProjectId?: number
     guildHttp.get("/projects/", () => HttpResponse.json([project])),
     guildHttp.get("/projects/writable", () => HttpResponse.json([project])),
     guildHttp.get("/projects/:projectId", () => HttpResponse.json(project)),
+    ...(statuses
+      ? [guildHttp.get("/projects/:id/task-statuses/", () => HttpResponse.json(statuses))]
+      : []),
     guildHttp.delete("/tasks/:taskId", () => {
       deleted();
       return new HttpResponse(null, { status: 204 });
@@ -107,6 +117,18 @@ describe("TaskEditPage", () => {
     // and duplicate opens no dialog — so the trigger has to carry the state.
     const trigger = await screen.findByRole("button", { name: /more actions/i });
     await waitFor(() => expect(trigger).toHaveAttribute("aria-busy", "true"));
+  });
+
+  it("still names a status the project has since dropped", async () => {
+    // The heading badge used to fall back to the task's own status snapshot.
+    // With the badge gone, the select is the only place the status is stated,
+    // so it has to resolve a column the project no longer lists.
+    renderTaskPage({ statuses: [] });
+
+    // Radix echoes the trigger's value into a hidden native select, so the
+    // name legitimately appears more than once; the placeholder is the tell.
+    expect(await screen.findAllByText("To Do")).not.toHaveLength(0);
+    expect(screen.queryByText(/select status/i)).not.toBeInTheDocument();
   });
 
   it("opens the move dialog from the actions menu", async () => {

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -619,6 +619,18 @@ export const TaskEditPage = () => {
   // otherwise read straight from task.task_status_id so the first render has
   // a value (the useEffect lag previously left the badge blank).
   const effectiveStatusId = statusId ?? task?.task_status_id ?? null;
+
+  // A task keeps the status it was given even after the project drops that
+  // column, and the select can only name a status the list contains. Carry the
+  // task's own snapshot into the options in that case, so the editor still
+  // says what status the task is in rather than falling back to a placeholder.
+  // Not a hook: this sits below the loading guards above, which return early.
+  const statusOptions =
+    task?.task_status &&
+    task.task_status.id === effectiveStatusId &&
+    !taskStatuses.some((item) => item.id === effectiveStatusId)
+      ? [...taskStatuses, task.task_status]
+      : taskStatuses;
   // Prefer the project's status list (authoritative; reflects renames/colors)
   // but fall back to the task's own embedded ``task_status`` snapshot so the
   // badge + select trigger render correctly during the window between
@@ -790,7 +802,7 @@ export const TaskEditPage = () => {
                 disabled={isReadOnly}
                 value={formValue}
                 onChange={handleFormChange}
-                statuses={taskStatuses}
+                statuses={statusOptions}
                 projectId={projectId ?? null}
                 initiativeId={project?.initiative_id ?? null}
                 currentUserId={currentUser?.id}

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -40,9 +40,8 @@ import { TaskChecklist } from "@/components/tasks/TaskChecklist";
 import { serializeTaskFormValue, TaskForm, type TaskFormValue } from "@/components/tasks/TaskForm";
 import { ToolBreadcrumb } from "@/components/tools/ToolBreadcrumb";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
   DropdownMenu,
@@ -625,10 +624,6 @@ export const TaskEditPage = () => {
   // badge + select trigger render correctly during the window between
   // "task loaded" and "project statuses loaded" — and as a safety net if
   // the status was archived out of the list since the task was last saved.
-  const currentStatus =
-    taskStatuses.find((item) => item.id === effectiveStatusId) ??
-    (task && task.task_status_id === effectiveStatusId ? task.task_status : null);
-
   // Delete and move are excluded: their confirm/move dialogs stay open and
   // already show the mutation's own loading state.
   const menuActionPending = duplicateTask.isPending || toggleArchive.isPending;
@@ -739,10 +734,11 @@ export const TaskEditPage = () => {
           { label: title || task?.title },
         ]}
       />
+      {/* The task's title and status are rendered once each, by the form's own
+          title field and status select. This row carries only the byline. */}
+      <h1 className="sr-only">{title || task?.title}</h1>
       <div className="space-y-3">
         <div className="flex flex-wrap items-center gap-3">
-          <h1 className="font-semibold text-3xl tracking-tight">{title || task?.title}</h1>
-          <Badge variant="secondary">{currentStatus?.name ?? t("edit.statusBadge")}</Badge>
           {creationMeta ? (
             <TooltipProvider delayDuration={200}>
               <Tooltip>
@@ -778,16 +774,11 @@ export const TaskEditPage = () => {
             </TooltipProvider>
           ) : null}
         </div>
-        <p className="text-muted-foreground text-sm">{t("edit.subtitle")}</p>
       </div>
 
       <div className="flex flex-wrap gap-6">
         <Card className="flex-1 shadow-sm sm:min-w-100">
-          <CardHeader>
-            <CardTitle>{t("edit.detailsTitle")}</CardTitle>
-            <CardDescription>{t("edit.detailsDescription")}</CardDescription>
-          </CardHeader>
-          <CardContent>
+          <CardContent className="pt-6">
             {isReadOnly && readOnlyMessage ? (
               <p className="rounded-md border border-border bg-muted/50 px-3 py-2 text-muted-foreground text-sm">
                 {readOnlyMessage}


### PR DESCRIPTION
Closes two tickets that turned out to interleave in the same hunks.

## Problem

**The two task surfaces had drifted.** Creating a task and editing one render the same `TaskForm`, but each composed its own field list by hand — the dialog was title + one "Advanced details" accordion, the page was title + everything flat. Nothing stopped a field reaching one and being forgotten on the other, and the order had stopped meaning anything: Assignees and Tags sat between the dates and the Repeat rule that is *derived from the due date* (`referenceDate={... ?? value.dueDate ?? value.startDate}`).

**The editor repeated itself four times** before the first usable field. The title appeared in the breadcrumb, in the `<h1>`, and in the Title input — and the `<h1>` rendered `{title || task?.title}` off the same form state, so typing in the box retitled the heading keystroke by keystroke. The status Badge did the same against the live `statusId`. Then two instructional subtitles stacked up: "Edit every detail of this task." followed by "Task details" / "Update the fields below and save your changes."

## Changes

### One definition, both surfaces — [TaskForm.tsx](frontend/src/components/tasks/TaskForm.tsx)

`TASK_FORM_SECTIONS` is now the single ordered definition of what lives where, each section declaring the `TaskFormValue` keys it owns:

| Section | Keys |
|---|---|
| `details` (no heading) | `title`, `description` |
| `tracking` | `statusId`, `priority` |
| `schedule` | `startDate`, `dueDate`, `recurrence`, `recurrenceStrategy` |
| `people` | `assigneeIds`, `tags` |
| `properties` | `properties`, `propertyValues` |

Both layouts are projections over it — the page maps all five flat, the dialog renders `details` flat and the rest inside the existing accordion. Same sections, same order, both screens. Start date, due date and Repeat finally sit together under Schedule, on the create dialog as well as the editor.

**Behaviour change worth a look:** the create dialog now shows Description alongside Title by default, since Description is in `details`. It was previously collapsed. Easy to move it into `tracking` if you would rather keep quick-create minimal.

### The editor stops repeating itself — [TaskEditPage.tsx](frontend/src/pages/TaskEditPage.tsx)

- The `<h1>` and the status `<Badge>` are gone. `titleField` gains a `page` variant — borderless, `text-3xl`, `sr-only` label — so the Title input *is* the heading. An `sr-only` `<h1>` stays for document structure.
- `currentStatus` existed only to feed that badge, so it goes too, along with the now-unused `Badge` / `CardHeader` / `CardTitle` / `CardDescription` imports.
- Both subtitles and the card header are gone; `CardContent` picks up `pt-6`. Only the created-by byline survives that block.
- Dropped the four dead keys (`edit.subtitle`, `edit.detailsTitle`, `edit.detailsDescription`, `edit.statusBadge`) and added `taskForm.sections.{tracking,schedule,people}` — **across all four locales**, so `locale-keys.test.ts` parity holds.

## Testing

[TaskForm.test.tsx](frontend/src/components/tasks/TaskForm.test.tsx) is new and is the actual anti-drift mechanism: it asserts the section keys cover `Object.keys(emptyTaskFormValue())` exactly, and that no key appears twice. Add a field to `TaskFormValue` without giving it a section and CI fails — the guarantee is a check, not developer discipline. Same shape as the backend's `INITIATIVE_PATHS` registry forcing every new table into a bucket.

- `pnpm typecheck` — clean
- `pnpm biome check` — clean
- `./scripts/test-changed.sh` — 186 files, 2128 passed
- `locale-keys.test.ts` — passes across de/es/fr

Tasks: https://initiative.morels.me/g/3/i/5/projects/1/tasks/2757 and https://initiative.morels.me/g/3/i/5/projects/1/tasks/2758