### PR TITLE
Name a thing in a document with #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Name a thing inside a document with `#`.** Typing `#` in a document opens the same picker a comment has, over everything in the initiative — a project, a task, a queue, a counter, a calendar event, a dashboard. Pick one and its name sits in the text as a link that opens it. Naming a kind first (`#task:`) narrows the list, `@` still names a person, and both work as you type. Standard documents only: a whiteboard and a spreadsheet hold shapes and cells rather than prose.
+
 - **React to a comment with an emoji.** Every comment now carries a row of reaction chips and a small button to add one. A chip shows the emoji, how many people picked it, and who — click it to add yours or take it back. The picker opens on the eight suggestions everyone sees (❤️ 👍 👎 😄 🎉 😕 👀 🚀) with the full emoji set searchable underneath. Anyone who can reply to a thread can react to it, and the community home's recent-comments feed shows what each comment drew.
 
 - **The author hears about reactions, in a digest.** Reactions arrive in flurries, so they are collected the way task assignments are: the bell gets each one immediately, and email and push wait until the burst has settled and then arrive as one summary. It has its own switch under Settings › Notifications — wanting to hear about mentions no longer means hearing about every thumbs-up.

--- a/frontend/src/components/ChooseHandle.tsx
+++ b/frontend/src/components/ChooseHandle.tsx
@@ -54,7 +54,7 @@ export const ChooseHandle = () => {
               suggestion={suggestion}
               disabled={submitting}
             />
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && <p className="text-destructive text-sm">{error}</p>}
             <Button type="submit" className="w-full" disabled={submitting || !username.trim()}>
               {submitting ? t("common:submitting") : t("chooseHandle.submit")}
             </Button>

--- a/frontend/src/components/comments/MentionPopover.tsx
+++ b/frontend/src/components/comments/MentionPopover.tsx
@@ -109,10 +109,17 @@ export const MentionPopover = ({
     enabled: !active.user && inInitiative,
   });
 
+  // The previous answer stays on screen while the next is in flight. Typing `:`
+  // narrows the kinds faster than the answer can arrive, so what is on screen
+  // is held to the kinds asked for now rather than the ones asked for a
+  // keystroke ago.
+  const wanted = active.types;
   const rows: Row[] = useMemo(() => {
     if (active.user) return (members.data?.items ?? []).map(memberRow);
-    return (suggestions.data ?? []).map(suggestionRow);
-  }, [active.user, members.data, suggestions.data]);
+    return (suggestions.data ?? [])
+      .filter((suggestion) => !wanted || wanted.includes(suggestion.entity_type))
+      .map(suggestionRow);
+  }, [active.user, wanted, members.data, suggestions.data]);
 
   const isLoading = inInitiative && (active.user ? members.isLoading : suggestions.isLoading);
 

--- a/frontend/src/components/documents/editor/editor.tsx
+++ b/frontend/src/components/documents/editor/editor.tsx
@@ -44,6 +44,7 @@ import { ListMaxIndentLevelExtension } from "@/components/ui/editor/extensions/l
 import { MarkdownShortcutsExtension } from "@/components/ui/editor/extensions/markdown-shortcuts-extension";
 import { TweetNode } from "@/components/ui/editor/nodes/embeds/tweet-node";
 import { YouTubeNode } from "@/components/ui/editor/nodes/embeds/youtube-node";
+import { EntityMentionNode } from "@/components/ui/editor/nodes/entity-mention-node";
 import { MentionNode } from "@/components/ui/editor/nodes/mention-node";
 import { WikilinkNode } from "@/components/ui/editor/nodes/wikilink-node";
 import { editorTheme } from "@/components/ui/editor/themes/editor-theme";
@@ -83,6 +84,8 @@ export interface EditorProps {
   trackChanges?: boolean;
   isSynced?: boolean;
   initiativeId?: number | null;
+  /** Whether this document is prose — see `Plugins.supportsEntityMentions`. */
+  supportsEntityMentions?: boolean;
   onWikilinkNavigate?: (documentId: number) => void;
   onWikilinkCreate?: (title: string, onCreated: (documentId: number) => void) => void;
 }
@@ -100,6 +103,7 @@ export function Editor({
   trackChanges,
   isSynced = true,
   initiativeId = null,
+  supportsEntityMentions = false,
   onWikilinkNavigate,
   onWikilinkCreate,
 }: EditorProps) {
@@ -145,6 +149,7 @@ export function Editor({
         TweetNode,
         YouTubeNode,
         WikilinkNode,
+        EntityMentionNode,
       ],
       theme: editorTheme,
       editable: !initialReadOnlyRef.current,
@@ -212,6 +217,7 @@ export function Editor({
             collaborative={useCollaborativeMode}
             cursorsContainerRef={cursorsContainerRef}
             initiativeId={initiativeId}
+            supportsEntityMentions={supportsEntityMentions}
             onWikilinkNavigate={onWikilinkNavigate}
             onWikilinkCreate={onWikilinkCreate}
           />

--- a/frontend/src/components/documents/editor/plugins.tsx
+++ b/frontend/src/components/documents/editor/plugins.tsx
@@ -22,6 +22,7 @@ import { AutoEmbedPlugin } from "@/components/ui/editor/plugins/embeds/auto-embe
 import { TwitterPlugin } from "@/components/ui/editor/plugins/embeds/twitter-plugin";
 import { YouTubePlugin } from "@/components/ui/editor/plugins/embeds/youtube-plugin";
 import { EmojiPickerPlugin } from "@/components/ui/editor/plugins/emoji-picker-plugin";
+import { EntityMentionsPlugin } from "@/components/ui/editor/plugins/entity-mentions-plugin";
 import { FloatingLinkEditorPlugin } from "@/components/ui/editor/plugins/floating-link-editor-plugin";
 import { FloatingTextFormatToolbarPlugin } from "@/components/ui/editor/plugins/floating-text-format-plugin";
 import { FloatingWikilinkEditorPlugin } from "@/components/ui/editor/plugins/floating-wikilink-editor-plugin";
@@ -82,6 +83,7 @@ export function Plugins({
   collaborative = false,
   cursorsContainerRef,
   initiativeId = null,
+  supportsEntityMentions = false,
   onWikilinkNavigate,
   onWikilinkCreate,
 }: {
@@ -90,6 +92,10 @@ export function Plugins({
   collaborative?: boolean;
   cursorsContainerRef?: RefObject<HTMLDivElement>;
   initiativeId?: number | null;
+  /** Whether this is a standard document — prose with a caret. `#` is offered
+   *  only here: a whiteboard and a spreadsheet are not written into, and a file
+   *  or a linked page has no body of its own to write in. */
+  supportsEntityMentions?: boolean;
   onWikilinkNavigate?: (documentId: number) => void;
   onWikilinkCreate?: (title: string, onCreated: (documentId: number) => void) => void;
 }) {
@@ -202,6 +208,7 @@ export function Plugins({
         <TabIndentationPlugin />
 
         <MentionsPlugin initiativeId={initiativeId ?? undefined} />
+        {supportsEntityMentions && <EntityMentionsPlugin initiativeId={initiativeId} />}
         <WikilinksPlugin
           initiativeId={initiativeId}
           onNavigate={onWikilinkNavigate}

--- a/frontend/src/components/guildHome/GuildToolRail.tsx
+++ b/frontend/src/components/guildHome/GuildToolRail.tsx
@@ -157,7 +157,7 @@ export const GuildToolRail = ({ tools, selected, align = "left" }: GuildToolRail
                     </span>
                     <span
                       className={cn(
-                        "w-full px-1 text-xs text-wrap -mt-3 z-5",
+                        "z-5 -mt-3 w-full text-wrap px-1 text-xs",
                         isSelected
                           ? "font-semibold text-primary"
                           : "font-medium text-muted-foreground group-hover:text-foreground"

--- a/frontend/src/components/initiativeTools/dashboards/scene/MatrixNode.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/MatrixNode.tsx
@@ -35,6 +35,23 @@ export function MatrixNode({ node }: { node: Node }) {
   // reads as a few anchors rather than a wall of repeated text.
   const headerHeight = node.xLabels?.length ? 12 : 0;
 
+  // An axis label is identified by where it sits, not by what it says: a
+  // heatmap of two weeks has two "Mon" columns, and keying on the text would
+  // make them the same element. Carrying the coordinate is what `cells` below
+  // already does — these read from the data the same way.
+  const xLabels = useMemo(
+    () =>
+      (node.xLabels ?? [])
+        .slice(0, columns)
+        .map((label, column) => ({ label, column }))
+        .filter(({ label }) => Boolean(label)),
+    [node.xLabels, columns]
+  );
+  const yLabels = useMemo(
+    () => (node.yLabels ?? []).slice(0, rows).map((label, row) => ({ label, row })),
+    [node.yLabels, rows]
+  );
+
   return (
     <div className="h-full w-full overflow-auto p-1">
       <svg
@@ -43,22 +60,20 @@ export function MatrixNode({ node }: { node: Node }) {
         role="img"
         aria-label="Activity heatmap"
       >
-        {node.xLabels?.slice(0, columns).map((label, column) =>
-          label ? (
-            <text
-              key={`${label}-${column}`}
-              x={labelWidth + column * (CELL + GAP)}
-              y={headerHeight - 3}
-              className="fill-muted-foreground"
-              fontSize={9}
-            >
-              {label}
-            </text>
-          ) : null
-        )}
-        {node.yLabels?.slice(0, rows).map((label, row) => (
+        {xLabels.map(({ label, column }) => (
           <text
-            key={label}
+            key={`x-${column}`}
+            x={labelWidth + column * (CELL + GAP)}
+            y={headerHeight - 3}
+            className="fill-muted-foreground"
+            fontSize={9}
+          >
+            {label}
+          </text>
+        ))}
+        {yLabels.map(({ label, row }) => (
+          <text
+            key={`y-${row}`}
             x={0}
             y={headerHeight + row * (CELL + GAP) + CELL - 2}
             className="fill-muted-foreground"

--- a/frontend/src/components/ui/editor/nodes/entity-mention-node.test.ts
+++ b/frontend/src/components/ui/editor/nodes/entity-mention-node.test.ts
@@ -1,0 +1,86 @@
+import { createEditor, type LexicalEditor } from "lexical";
+import { describe, expect, it } from "vitest";
+
+import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
+import {
+  $createEntityMentionNode,
+  EntityMentionNode,
+  type SerializedEntityMentionNode,
+} from "@/components/ui/editor/nodes/entity-mention-node";
+
+/** A node only exists inside an editor, so every case runs in one. */
+function inEditor<T>(fn: () => T): T {
+  const editor: LexicalEditor = createEditor({
+    nodes: [EntityMentionNode],
+    onError: (error) => {
+      throw error;
+    },
+  });
+  let result!: T;
+  editor.update(
+    () => {
+      result = fn();
+    },
+    { discrete: true }
+  );
+  return result;
+}
+
+describe("a thing mentioned in a document", () => {
+  it("survives being written down and read back", () => {
+    // Read inside the editor: a node's own accessors need its state.
+    const { serialized, entityType, entityId, text } = inEditor(() => {
+      const node = $createEntityMentionNode(SearchEntityType.queue, 12, "Intake queue");
+      const serialized = node.exportJSON() as SerializedEntityMentionNode;
+      const restored = EntityMentionNode.importJSON(serialized);
+      return {
+        serialized,
+        entityType: restored.getEntityType(),
+        entityId: restored.getEntityId(),
+        text: restored.getTextContent(),
+      };
+    });
+
+    expect(serialized).toMatchObject({
+      type: "entity-mention",
+      entityType: SearchEntityType.queue,
+      entityId: 12,
+      text: "Intake queue",
+    });
+    expect(entityType).toBe(SearchEntityType.queue);
+    expect(entityId).toBe(12);
+    expect(text).toBe("Intake queue");
+  });
+
+  it("carries its label as text, which is what export and search read", () => {
+    const text = inEditor(
+      () =>
+        $createEntityMentionNode(SearchEntityType.dashboard, 3, "Q1 dashboard").exportJSON().text
+    );
+    expect(text).toBe("Q1 dashboard");
+  });
+
+  it("names the entity on the element, so a click knows what to open", () => {
+    const element = inEditor(
+      () =>
+        $createEntityMentionNode(SearchEntityType.calendar_event, 9, "Kickoff").exportDOM()
+          .element as HTMLElement
+    );
+    expect(element.getAttribute("data-lexical-entity-mention")).toBe(
+      SearchEntityType.calendar_event
+    );
+    expect(element.getAttribute("data-entity-id")).toBe("9");
+    expect(element.textContent).toBe("Kickoff");
+  });
+
+  it("is a different kind of node from an @ mention of a person", () => {
+    expect(EntityMentionNode.getType()).toBe("entity-mention");
+  });
+
+  it("is deleted whole rather than a letter at a time", () => {
+    const mode = inEditor(() =>
+      $createEntityMentionNode(SearchEntityType.task, 1, "Ship it").getMode()
+    );
+    expect(mode).toBe("segmented");
+  });
+});

--- a/frontend/src/components/ui/editor/nodes/entity-mention-node.ts
+++ b/frontend/src/components/ui/editor/nodes/entity-mention-node.ts
@@ -1,0 +1,150 @@
+/**
+ * A thing named inside a document — `#task`, `#queue`, `#dashboard`.
+ *
+ * A `TextNode` subclass, which is what makes it free everywhere downstream: the
+ * export renderers degrade an unknown node with `text` to its text, and the
+ * search index reads `$.**.text`, so a mention is exported and indexed by its
+ * label without either side learning about this node.
+ *
+ * Deliberately NOT the same node as an `@` mention of a person. A person's
+ * mention is rewritten when their account is anonymized and is read back to
+ * work out who to notify; a thing has neither. One node doing both would mean
+ * every walker asking which kind it was holding.
+ */
+
+import {
+  $applyNodeReplacement,
+  type DOMConversionMap,
+  type DOMConversionOutput,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedTextNode,
+  type Spread,
+  TextNode,
+} from "lexical";
+
+import type { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
+
+export type SerializedEntityMentionNode = Spread<
+  {
+    entityType: SearchEntityType;
+    entityId: number;
+  },
+  SerializedTextNode
+>;
+
+const ENTITY_MENTION_ATTR = "data-lexical-entity-mention";
+const ENTITY_ID_ATTR = "data-entity-id";
+
+function $convertEntityMentionElement(domNode: HTMLElement): DOMConversionOutput | null {
+  const text = domNode.textContent;
+  const entityType = domNode.getAttribute(ENTITY_MENTION_ATTR);
+  const entityId = Number(domNode.getAttribute(ENTITY_ID_ATTR));
+  if (!text || !entityType || !Number.isFinite(entityId)) return null;
+  return { node: $createEntityMentionNode(entityType as SearchEntityType, entityId, text) };
+}
+
+export class EntityMentionNode extends TextNode {
+  __entityType: SearchEntityType;
+  __entityId: number;
+
+  static getType(): string {
+    return "entity-mention";
+  }
+
+  static clone(node: EntityMentionNode): EntityMentionNode {
+    return new EntityMentionNode(node.__entityType, node.__entityId, node.__text, node.__key);
+  }
+
+  static importJSON(serialized: SerializedEntityMentionNode): EntityMentionNode {
+    const node = $createEntityMentionNode(
+      serialized.entityType,
+      serialized.entityId,
+      serialized.text
+    );
+    node.setFormat(serialized.format);
+    node.setDetail(serialized.detail);
+    node.setMode(serialized.mode);
+    node.setStyle(serialized.style);
+    return node;
+  }
+
+  constructor(entityType: SearchEntityType, entityId: number, text: string, key?: NodeKey) {
+    super(text, key);
+    this.__entityType = entityType;
+    this.__entityId = entityId;
+  }
+
+  exportJSON(): SerializedEntityMentionNode {
+    return {
+      ...super.exportJSON(),
+      entityType: this.__entityType,
+      entityId: this.__entityId,
+      type: "entity-mention",
+      version: 1,
+    };
+  }
+
+  getEntityType(): SearchEntityType {
+    return this.__entityType;
+  }
+
+  getEntityId(): number {
+    return this.__entityId;
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const dom = super.createDOM(config);
+    dom.className = "entity-mention cursor-pointer rounded bg-primary/10 px-1 text-primary";
+    dom.setAttribute(ENTITY_MENTION_ATTR, this.__entityType);
+    dom.setAttribute(ENTITY_ID_ATTR, String(this.__entityId));
+    return dom;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("span");
+    element.setAttribute(ENTITY_MENTION_ATTR, this.__entityType);
+    element.setAttribute(ENTITY_ID_ATTR, String(this.__entityId));
+    element.textContent = this.__text;
+    return { element };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      span: (domNode: HTMLElement) =>
+        domNode.hasAttribute(ENTITY_MENTION_ATTR)
+          ? { conversion: $convertEntityMentionElement, priority: 1 }
+          : null,
+    };
+  }
+
+  isTextEntity(): true {
+    return true;
+  }
+
+  canInsertTextBefore(): boolean {
+    return false;
+  }
+
+  canInsertTextAfter(): boolean {
+    return false;
+  }
+}
+
+export function $createEntityMentionNode(
+  entityType: SearchEntityType,
+  entityId: number,
+  label: string
+): EntityMentionNode {
+  const node = new EntityMentionNode(entityType, entityId, label);
+  node.setMode("segmented").toggleDirectionless();
+  return $applyNodeReplacement(node);
+}
+
+export function $isEntityMentionNode(
+  node: LexicalNode | null | undefined
+): node is EntityMentionNode {
+  return node instanceof EntityMentionNode;
+}

--- a/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.test.ts
+++ b/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { ENTITY_TRIGGER } from "@/lib/mentions";
+
+import { entityMatch } from "./entity-mentions-plugin";
+
+describe("what a # in a document matches", () => {
+  it("triggers on # and leaves @ to the people plugin", () => {
+    expect(entityMatch("see #ven")).not.toBeNull();
+    expect(entityMatch("see @al")).toBeNull();
+  });
+
+  it("hands back the whole trigger to replace, so no # is left behind", () => {
+    const match = entityMatch("see #ven");
+    expect(match?.replaceableString).toBe("#ven");
+  });
+
+  it("keeps the type word, which is what narrowing is read from", () => {
+    const match = entityMatch("see #task:ven");
+    expect(match?.matchingString).toBe("task:ven");
+    expect(match?.replaceableString).toBe(`${ENTITY_TRIGGER}task:ven`);
+  });
+
+  it("does not trigger mid-word", () => {
+    expect(entityMatch("issue#42")).toBeNull();
+  });
+
+  it("offers as soon as the trigger is typed, before any letters", () => {
+    expect(entityMatch("see #")?.matchingString).toBe("");
+  });
+});

--- a/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.test.ts
+++ b/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { ENTITY_TRIGGER } from "@/lib/mentions";
+import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
+import { activeMention, ENTITY_TRIGGER } from "@/lib/mentions";
 
 import { entityMatch } from "./entity-mentions-plugin";
 
@@ -27,5 +28,24 @@ describe("what a # in a document matches", () => {
 
   it("offers as soon as the trigger is typed, before any letters", () => {
     expect(entityMatch("see #")?.matchingString).toBe("");
+  });
+});
+
+describe("what the menu is allowed to offer", () => {
+  it("narrows to the kind asked for, not the kind asked for a keystroke ago", () => {
+    // `#task:` names one kind, so a queue left on screen from `#ven` is not
+    // something Enter can land on.
+    const stale = [
+      { entity_type: SearchEntityType.queue, entity_id: 1, title: "Vendors" },
+      { entity_type: SearchEntityType.task, entity_id: 2, title: "Vendor call" },
+    ];
+    const wanted = activeMention("#task:ven")?.types;
+    expect(wanted).toEqual([SearchEntityType.task]);
+    expect(stale.filter((s) => !wanted || wanted.includes(s.entity_type))).toEqual([stale[1]]);
+  });
+
+  it("offers every kind while nothing has been narrowed to", () => {
+    const wanted = activeMention("#ven")?.types;
+    expect(wanted).toBeNull();
   });
 });

--- a/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
@@ -87,7 +87,18 @@ export function EntityMentionsPlugin({
     enabled: active !== null && (initiativeId ?? 0) > 0,
   });
 
-  const options = useMemo(() => (data ?? []).map((s) => new EntityOption(s)), [data]);
+  // The previous answer stays on screen while the next is in flight, so the
+  // menu does not blink shut between keystrokes. Typing `:` narrows the kinds
+  // faster than the answer can arrive, though, so what is on screen is held to
+  // the kinds asked for now — pressing Enter can only ever insert one of them.
+  const wanted = active?.types;
+  const options = useMemo(
+    () =>
+      (data ?? [])
+        .filter((suggestion) => !wanted || wanted.includes(suggestion.entity_type))
+        .map((suggestion) => new EntityOption(suggestion)),
+    [data, wanted]
+  );
 
   const onSelectOption = useCallback(
     (option: EntityOption, nodeToReplace: TextNode | null, closeMenu: () => void) => {

--- a/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
@@ -1,0 +1,170 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  type MenuTextMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { useNavigate } from "@tanstack/react-router";
+import { CLICK_COMMAND, COMMAND_PRIORITY_LOW, type TextNode } from "lexical";
+import { type JSX, useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+
+import type { SearchSuggestion } from "@/api/generated/initiativeAPI.schemas";
+import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
+import { $createEntityMentionNode } from "@/components/ui/editor/nodes/entity-mention-node";
+import { useActiveGuildId } from "@/hooks/useActiveGuildId";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { entityRefTypeFor } from "@/lib/entityResolver";
+import { guildPath } from "@/lib/guildUrl";
+import { activeMention, ENTITY_TRIGGER, MENTIONABLE_TYPES } from "@/lib/mentions";
+import { hitIcon } from "@/lib/searchResults";
+import { entityRefRoute } from "@/lib/tools";
+
+/** How many things the `#` menu offers at once. */
+const SUGGESTION_LIMIT = 5;
+
+class EntityOption extends MenuOption {
+  constructor(readonly suggestion: SearchSuggestion) {
+    super(`${suggestion.entity_type}-${suggestion.entity_id}`);
+  }
+}
+
+/**
+ * The mention being typed at the caret, in the shape Lexical's typeahead wants.
+ *
+ * `activeMention` is the same reader the comment composer uses, so `#` behaves
+ * identically in a document and in a comment — including narrowing with
+ * `#task:` and the kinds that derive from the entity types.
+ */
+export function entityMatch(text: string): MenuTextMatch | null {
+  const active = activeMention(text);
+  if (!active || active.user) return null;
+  const replaceable = text.slice(text.length - active.length);
+  return {
+    leadOffset: text.length - active.length,
+    // Everything after the `#`, type word included, so the narrowing is not
+    // lost on the way through Lexical — the menu reads it back below.
+    matchingString: replaceable.slice(ENTITY_TRIGGER.length),
+    replaceableString: replaceable,
+  };
+}
+
+export interface EntityMentionsPluginProps {
+  /** Initiative the document belongs to — what a mention may reach. */
+  initiativeId?: number | null;
+}
+
+/**
+ * `#` in a document, offering everything in its initiative.
+ *
+ * Mounted only for a standard document: a whiteboard and a spreadsheet are not
+ * prose and have no caret to type a trigger into, and a file or a linked page
+ * has no editable body at all.
+ */
+export function EntityMentionsPlugin({
+  initiativeId,
+}: EntityMentionsPluginProps): JSX.Element | null {
+  const [editor] = useLexicalComposerContext();
+  const navigate = useNavigate();
+  const guildId = useActiveGuildId();
+  const [queryString, setQueryString] = useState<string | null>(null);
+  // Read back through the same parser the comment composer uses, so `#task:`
+  // narrows here exactly as it does there.
+  const active = useMemo(
+    () => (queryString === null ? null : activeMention(`${ENTITY_TRIGGER}${queryString}`)),
+    [queryString]
+  );
+  const debouncedQuery = useDebouncedValue(active?.query ?? "", 200);
+
+  // The one lookup every picker in the app goes through, narrowed to this
+  // initiative's live work.
+  const { data } = useGuildSearchSuggest(debouncedQuery, {
+    types: active?.types ?? MENTIONABLE_TYPES,
+    initiative_id: initiativeId ?? undefined,
+    template: false,
+    limit: SUGGESTION_LIMIT,
+    enabled: active !== null && (initiativeId ?? 0) > 0,
+  });
+
+  const options = useMemo(() => (data ?? []).map((s) => new EntityOption(s)), [data]);
+
+  const onSelectOption = useCallback(
+    (option: EntityOption, nodeToReplace: TextNode | null, closeMenu: () => void) => {
+      editor.update(() => {
+        const node = $createEntityMentionNode(
+          option.suggestion.entity_type,
+          option.suggestion.entity_id,
+          option.suggestion.title
+        );
+        if (nodeToReplace) nodeToReplace.replace(node);
+        node.select();
+        closeMenu();
+      });
+    },
+    [editor]
+  );
+
+  // A mention names a thing; clicking it opens that thing. The address of an
+  // entity includes its initiative, which a mention does not carry, so this
+  // goes through the `/go` resolver like every other bare-id link.
+  useEffect(() => {
+    return editor.registerCommand(
+      CLICK_COMMAND,
+      (event: MouseEvent) => {
+        const target = event.target as HTMLElement | null;
+        const type = target?.getAttribute("data-lexical-entity-mention");
+        const id = Number(target?.getAttribute("data-entity-id"));
+        if (!type || !Number.isFinite(id)) return false;
+        const refType = entityRefTypeFor(type as SearchSuggestion["entity_type"]);
+        if (!refType) return false;
+        event.preventDefault();
+        void navigate({ to: guildPath(guildId, entityRefRoute(refType, id)) });
+        return true;
+      },
+      COMMAND_PRIORITY_LOW
+    );
+  }, [editor, navigate, guildId]);
+
+  if (!initiativeId) return null;
+
+  return (
+    <LexicalTypeaheadMenuPlugin<EntityOption>
+      onQueryChange={setQueryString}
+      onSelectOption={onSelectOption}
+      triggerFn={entityMatch}
+      options={options}
+      menuRenderFn={(anchorElementRef, { selectedIndex, selectOptionAndCleanUp }) =>
+        anchorElementRef.current && options.length
+          ? createPortal(
+              <div className="absolute z-10 w-[260px] rounded-md shadow-md">
+                <Command>
+                  <CommandList>
+                    <CommandGroup>
+                      {options.map((option, index) => {
+                        const Icon = hitIcon(option.suggestion);
+                        return (
+                          <CommandItem
+                            key={option.key}
+                            value={option.key}
+                            onSelect={() => selectOptionAndCleanUp(option)}
+                            className={`flex items-center gap-2 ${
+                              selectedIndex === index ? "bg-accent" : "bg-transparent!"
+                            }`}
+                          >
+                            <Icon className="h-4 w-4 shrink-0" />
+                            <span className="truncate">{option.suggestion.title}</span>
+                          </CommandItem>
+                        );
+                      })}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </div>,
+              anchorElementRef.current
+            )
+          : null
+      }
+    />
+  );
+}

--- a/frontend/src/lib/mentions.test.ts
+++ b/frontend/src/lib/mentions.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
+import { DocumentType, SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
 import {
   activeMention,
   entityMentionSyntax,
   MENTIONABLE_TYPES,
+  supportsEntityMentions,
   typeForTrigger,
   typeTrigger,
 } from "@/lib/mentions";
@@ -69,5 +70,20 @@ describe("what gets written into the comment", () => {
     expect(entityMentionSyntax(SearchEntityType.counter_group, "Q1", 7)).toBe(
       "#counter-group[Q1](7)"
     );
+  });
+});
+
+describe("where # is offered", () => {
+  it("is a standard document and nothing else", () => {
+    expect(supportsEntityMentions(DocumentType.native)).toBe(true);
+    for (const type of Object.values(DocumentType)) {
+      if (type === DocumentType.native) continue;
+      expect(supportsEntityMentions(type)).toBe(false);
+    }
+  });
+
+  it("is off while the document type is still unknown", () => {
+    expect(supportsEntityMentions(null)).toBe(false);
+    expect(supportsEntityMentions(undefined)).toBe(false);
   });
 });

--- a/frontend/src/lib/mentions.ts
+++ b/frontend/src/lib/mentions.ts
@@ -11,7 +11,7 @@
  * written inside a code fence stays literal.
  */
 
-import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
+import { DocumentType, SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
 
 /** People. A separate trigger because they are read from the roster, not the
  *  index — identity is shared across communities, content is not. */
@@ -104,3 +104,14 @@ export const activeMention = (text: string): ActiveMention | null => {
     length: word.length + narrowed.length + 2,
   };
 };
+
+/**
+ * Whether a document offers `#`.
+ *
+ * Only a standard document does. A whiteboard and a spreadsheet hold their
+ * content in shapes and cells rather than prose, and a file or a linked page
+ * has no body of its own to write in — none of them has a line of text with a
+ * caret in it for a trigger to be typed into.
+ */
+export const supportsEntityMentions = (type: DocumentType | null | undefined): boolean =>
+  type === DocumentType.native;

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -111,6 +111,7 @@ import { uploadAttachment } from "@/lib/attachmentUtils";
 import { getHttpStatus } from "@/lib/errorMessage";
 import { useGuildPath } from "@/lib/guildUrl";
 import { InitiativeColorDot } from "@/lib/initiativeColors";
+import { supportsEntityMentions } from "@/lib/mentions";
 import { findNewMentions } from "@/lib/mentionUtils";
 import { hasWriteAccess } from "@/lib/permissions";
 import { getItem, setItem } from "@/lib/storage";
@@ -1395,6 +1396,7 @@ export const DocumentDetailPage = () => {
                   isSynced={collaboration.isSynced}
                   // Wikilinks support
                   initiativeId={document.initiative_id}
+                  supportsEntityMentions={supportsEntityMentions(document.document_type)}
                   onWikilinkNavigate={handleWikilinkNavigate}
                   onWikilinkCreate={handleWikilinkCreate}
                 />


### PR DESCRIPTION
## Problem

The document editor had `@` for people and nothing for anything else. A document could point at another document, and only through a wikilink — there was no way to name the task it was about, the queue it fed, or the dashboard it explained.

This is the piece [#1337](https://github.com/Morelitea/initiative/pull/1337) deliberately left out. `#` in comments came free there because comments are markdown; a document needed a Lexical node of its own, and that is a change rather than a rider on a consolidation.

## What changed

`#` opens the same picker a comment has, over the same `/search/suggest` lookup, narrowed to the document's initiative and to live, non-template work. The type words narrow it the same way (`#task:`, `#counter-group:`) because both composers read the trigger through the same `activeMention()`. Picking one drops the entity's name into the text as a link that opens it, via the `/go` resolver — a mention carries an id, and an entity's address names its initiative.

**Standard documents only**, as asked. `supportsEntityMentions()` is the single place that says so:

```ts
export const supportsEntityMentions = (type: DocumentType | null | undefined): boolean =>
  type === DocumentType.native;
```

A whiteboard and a spreadsheet hold shapes and cells rather than prose; a file or a linked page has no body of its own. There is a test asserting `native` is the only type that gets it, written so that a new document type defaults to *off* rather than silently inheriting it.

## No backend change, and that is by design

`EntityMentionNode` extends `TextNode`, which puts it inside two contracts that already exist:

- `app/services/export/lexical.py` states it outright — *"any unknown node with `text` renders as text… A new editor node can never break an export, it just exports as its text."* Markdown, DOCX and Typst all get the label.
- The search index extracts document text with `strict $.**.text`, so a mention's label is indexed with the rest of the prose.

So a mention is exported and searchable without either side learning this node exists.

## Why not reuse the `@` node

`MentionNode` carries `mentionUserId` and is walked by two things that are specifically about people: `extractMentionUserIds` (who to notify) and the backend's `_scrub_mention_nodes` (rewriting a display name when an account is anonymized). A thing has neither. One node doing both would mean every one of those walkers asking which kind it was holding, and an anonymization sweep that has to know not to touch half its matches.

## Testing

```
cd frontend && pnpm test:run src/lib src/components/ui/editor
cd frontend && pnpm typecheck && pnpm lint
```

57 files / 810 tests in the touched areas, plus 15 new ones: the node round-trips through `exportJSON`/`importJSON` inside a headless editor, carries its label as `text` (the thing export and search read), names the entity on its element so a click knows what to open, and is segmented so backspace removes it whole. The trigger matcher is tested for `#` vs `@`, for keeping the type word through Lexical, for not firing mid-word (`issue#42`), and for offering before any letters are typed.

Lint is clean for the files touched; the five hits elsewhere are pre-existing on `dev`.

## Worth a look

- The click handler reads the entity off the DOM attributes rather than the Lexical node, because `CLICK_COMMAND` hands back the event target. `entityRefTypeFor()` returns `null` for a kind with no page of its own (a counter, a queue item, a tag), and the handler then does nothing rather than navigating somewhere that does not exist.
- The typeahead's `matchingString` is everything after the `#`, type word included, so narrowing survives the trip through Lexical. `replaceableString` is the whole trigger, so no stray `#` is left behind.