### PR TITLE
Say how you are around, or don't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **An initiative's status columns can be read in one request**, instead of asking project by project and stitching the answers together.
 
+- **Say how you're around, or don't.** A dot under your picture in the sidebar opens the four states: online, idle, busy, or offline. Offline means offline — nobody sees you as here, whatever you have open. Idle sets itself once nothing has been touched for a while, and you can also pick it outright to say you have stepped away. The same dot on your profile card in Settings › Profile opens the same menu.
+
 ### Changed
 
 - **The mushrooms grow properly now.** The Mushrooms pack was drawn on a pixel grid, which a mushroom does not have — a cap is a dome and a stem is a taper. It is all curves, and it is a forest floor rather than the same mushroom three times: a morel, a fly agaric, a cluster of little brown ones, and bracket fungus on a fallen log.
+
+- **The sidebar's status bubble moved over to make room.** It keeps the left, under the face it is a thought of, and gives up the width it was not using; the presence dot took the space that freed on the right. The picture above no longer carries a dot of its own, because the one below it is the one you can click.
 
 - **Your status is a thought bubble, and it sits with the face thinking it.** Two dots trail from the bubble toward your picture — above the picture on your profile, below it in the sidebar, so they always run the right way.
 

--- a/backend/alembic/versions/20260903_0216_user_presence.py
+++ b/backend/alembic/versions/20260903_0216_user_presence.py
@@ -1,0 +1,62 @@
+"""How a person chooses to appear
+
+Adds ``users.presence`` — the standing preference behind the dot beside
+someone's name. Whether they actually have Initiative open, and whether anyone
+has touched it lately, is live state no column could hold; this is the half
+that outlives every socket, so it is the half that is stored.
+
+``idle`` is in the type like any other value: an account left on ``online`` is
+shown it once its tabs go quiet, and one that picked it is shown it either way.
+
+Existing accounts get ``online``, which is what they have effectively had all
+along: shown while a tab is open, and not otherwise.
+
+The column is not added to ``public.user_profiles``. That view is the public
+projection of an account, and this is not read from a row — a reader is shown
+the preference already narrowed by what the process can see.
+
+The request path writes ``public.users`` through a **column-scoped** UPDATE
+(0144), so a new column is unwritable until it is named in that grant. This is
+one a person sets for themselves, so it is named. SELECT is table-wide and
+needs nothing.
+
+Revision ID: 20260903_0216
+Revises: 20260902_0215
+Create Date: 2026-09-03
+"""
+
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260903_0216"
+down_revision = "20260902_0215"
+branch_labels = None
+depends_on = None
+
+
+#: The request-path floors, which hold their UPDATE on ``users`` per column.
+def _write_roles() -> tuple[str, ...]:
+    return (
+        "app_guild_base",
+        f'"{settings.PLATFORM_ROLE_PREFIX}platform_base"',
+        "app_user",
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE TYPE user_presence AS ENUM ('online', 'idle', 'busy', 'offline')"
+    )
+    op.execute(
+        "ALTER TABLE public.users "
+        "ADD COLUMN presence user_presence NOT NULL DEFAULT 'online'"
+    )
+    for role in _write_roles():
+        op.execute(f"GRANT UPDATE (presence) ON TABLE public.users TO {role}")
+
+
+def downgrade() -> None:
+    # The grant goes with the column it names.
+    op.execute("ALTER TABLE public.users DROP COLUMN IF EXISTS presence")
+    op.execute("DROP TYPE IF EXISTS user_presence")

--- a/backend/app/api/v1/platform_endpoints/notifications.py
+++ b/backend/app/api/v1/platform_endpoints/notifications.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import logging
+from time import monotonic
 
 from fastapi import (
     APIRouter,
@@ -164,6 +165,9 @@ async def websocket_notifications(websocket: WebSocket):
         # since-dropped guild role would make the auth query error);
         # AsyncSessionLocal skips get_session's per-request reset.
         await session.exec(text(CONNECTION_RESET_SQL))
+        # Taken before the row is read, so it is never later than the value
+        # that read comes back with.
+        presence_known_at = monotonic()
         user = await authenticate_ws_token(token, session)
         if user is None:
             logger.warning("Notifications WS: auth failed")
@@ -173,7 +177,10 @@ async def websocket_notifications(websocket: WebSocket):
         chosen_presence = user.presence
 
     await notification_stream.stream.connect(
-        user_id, websocket, chosen_presence=chosen_presence
+        user_id,
+        websocket,
+        chosen_presence=chosen_presence,
+        presence_known_at=presence_known_at,
     )
     try:
         while True:

--- a/backend/app/api/v1/platform_endpoints/notifications.py
+++ b/backend/app/api/v1/platform_endpoints/notifications.py
@@ -24,7 +24,7 @@ from app.schemas.platform.notification import (
     NotificationRead,
 )
 from app.core.messages import NotificationMessages
-from app.services.platform import notification_stream
+from app.services.platform import notification_stream, presence
 from app.services.platform import user_notifications as notifications_service
 from app.services.platform.ws_auth import authenticate_ws_token
 
@@ -34,6 +34,11 @@ logger = logging.getLogger(__name__)
 # Message type for authentication — the same first-frame handshake the guild
 # events, queue, counter and collaboration sockets use.
 MSG_AUTH = 5
+
+# "Somebody just did something in this tab." One byte, no payload: it says only
+# that the person is at their keyboard, which is the whole of what idle needs
+# to know. The client throttles it hard, so this is a frame a minute at most.
+MSG_ACTIVE = 6
 
 # How long an accepted socket may go without sending that frame. Generous
 # against a slow network, short against a socket that will never send one.
@@ -104,7 +109,10 @@ async def websocket_notifications(websocket: WebSocket):
     Protocol: the client sends ``MSG_AUTH`` with ``{"token": "..."}`` as its
     first (binary) frame, exactly as on the guild events socket; web sessions
     may send ``{"token": null}`` and be authenticated from the session cookie.
-    After that the server sends id envelopes and the client sends nothing.
+    After that the server sends id envelopes, and the only thing the client
+    sends back is ``MSG_ACTIVE`` — a sign that its person is at the keyboard,
+    which is what keeps them from reading as idle. It names nobody: the socket
+    already knows whose it is.
 
     Authorization is connect-time only. The stream says "your inbox changed"
     and never what changed, so the decision that matters is made by the refetch
@@ -162,13 +170,21 @@ async def websocket_notifications(websocket: WebSocket):
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
             return
         user_id = user.id
+        chosen_presence = user.presence
 
-    await notification_stream.stream.connect(user_id, websocket)
+    await notification_stream.stream.connect(
+        user_id, websocket, chosen_presence=chosen_presence
+    )
     try:
         while True:
-            # Nothing is expected from the client; awaiting keeps the socket
-            # open and surfaces the disconnect.
-            await websocket.receive_text()
+            # Awaiting keeps the socket open and surfaces the disconnect; the
+            # one frame the client does send is its person's activity.
+            frame = await websocket.receive()
+            if frame.get("type") == "websocket.disconnect":
+                break
+            data = frame.get("bytes")
+            if data and data[0] == MSG_ACTIVE:
+                presence.online.active(user_id)
     except WebSocketDisconnect:
         pass
     except Exception:

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -53,7 +53,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models.platform.guild import GuildRole, GuildMembership
 from app.models.platform.guild_image import GuildImageVariant
 from app.models.tenant.initiative import InitiativeMember
-from app.models.platform.user import User, UserStatus
+from app.models.platform.user import Presence, User, UserStatus
 from app.models.tenant.reaction_digest import ReactionDigestItem
 from app.models.tenant.task_assignment_digest import TaskAssignmentDigestItem
 from app.schemas.platform.guild import (
@@ -417,8 +417,8 @@ async def read_user_profile(
     fixed width, so the two come apart again exactly.
 
     A profile is public and has no guild in it: it carries the handle, the
-    face, the status, the look and whether they are online, and it is the same
-    page whoever opens it. That is why it is not reached through a guild — no
+    face, the status, the look and how they appear, and it is the same page
+    whoever opens it. That is why it is not reached through a guild — no
     part of the answer depends on one.
 
     Read from ``public.user_profiles``, the view that *is* the public
@@ -463,7 +463,7 @@ async def read_user_profile(
         status=row.status,
         custom_status=row.custom_status or {},
         profile_decorations=row.profile_decorations or {},
-        online=presence.online.is_online(row.id),
+        presence=presence.online.presence_of(row.id),
         joined_at=row.created_at,
     )
 
@@ -897,6 +897,10 @@ async def update_users_me(
         # Already held to shape by ``CustomStatus``; ``None`` is the status
         # taken off, which is the empty object rather than a null column.
         current_user.custom_status = update_data["custom_status"] or {}
+    if "presence" in update_data:
+        # The column is the standing preference. The roll is told separately
+        # below, once the write is safely down.
+        current_user.presence = Presence(update_data["presence"])
     if "profile_decorations" in update_data:
         # The payload validated it into ``ProfileDecorations``, so what lands
         # in the column is a known set of keys holding catalog ids and nothing
@@ -929,6 +933,11 @@ async def update_users_me(
     session.add(current_user)
     await session.commit()
     await session.refresh(current_user)
+    if "presence" in update_data:
+        # A change made from an open tab takes effect for readers immediately,
+        # rather than at the next reconnect. Told after the commit, so nothing
+        # is shown on the strength of a write that did not land.
+        presence.online.chose(current_user.id, current_user.presence)
     # Platform path — no initiative_roles enrichment (see read_users_me).
     # The SPA replaces its auth state with this response, so carry the same
     # linked-identity signal /users/me serves.

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -19,7 +19,7 @@ from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
 from app.db.query import MAX_ID_FILTER_VALUES
 from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
-from app.models.platform.user import User, UserStatus
+from app.models.platform.user import Presence, User, UserStatus
 from app.core.profile_decorations import SHIPPED_DECORATIONS
 from app.core.usernames import url_handle
 from app.models.platform.user_decoration import UserDecoration
@@ -1196,7 +1196,7 @@ async def test_profile_carries_the_basics(client: AsyncClient, session: AsyncSes
         "frame": None,
         "badges": ["core.fan"],
     }
-    assert body["online"] is False
+    assert body["presence"] == "offline"
     assert body["joined_at"]
 
 
@@ -1227,7 +1227,7 @@ async def test_profile_never_carries_a_real_name(
         "status",
         "custom_status",
         "profile_decorations",
-        "online",
+        "presence",
         "joined_at",
     }
 
@@ -1273,8 +1273,8 @@ async def test_profile_hides_a_suspended_account(
 async def test_profile_says_when_someone_is_online(
     client: AsyncClient, session: AsyncSession
 ):
-    """Online is a fact about the person, not about a guild — a reader who
-    shares no guild with them still sees it."""
+    """How someone appears is a fact about the person, not about a guild — a
+    reader who shares no guild with them still sees it."""
     guild = await create_guild(session)
     caller = await create_user(session)
     subject = await create_user(session)
@@ -1291,13 +1291,13 @@ async def test_profile_says_when_someone_is_online(
         await realtime_manager.disconnect(socket)  # type: ignore[arg-type]
 
     assert response.status_code == 200
-    assert response.json()["online"] is True
+    assert response.json()["presence"] == "online"
 
     after = await client.get(
         f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
         headers=get_auth_headers(caller),
     )
-    assert after.json()["online"] is False
+    assert after.json()["presence"] == "offline"
 
 
 @pytest.mark.integration
@@ -1322,13 +1322,13 @@ async def test_profile_says_online_with_no_guild_open(
         await notification_stream.stream.disconnect(socket)
 
     assert response.status_code == 200
-    assert response.json()["online"] is True
+    assert response.json()["presence"] == "online"
 
     after = await client.get(
         f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
         headers=get_auth_headers(caller),
     )
-    assert after.json()["online"] is False
+    assert after.json()["presence"] == "offline"
 
 
 @pytest.mark.integration
@@ -1354,7 +1354,133 @@ async def test_profile_stays_online_while_any_socket_is_open(
     finally:
         await notification_stream.stream.disconnect(bell)
 
-    assert response.json()["online"] is True
+    assert response.json()["presence"] == "online"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("chosen", ["idle", "busy"])
+async def test_profile_shows_what_someone_picked(
+    client: AsyncClient, session: AsyncSession, chosen: str
+):
+    """Each is shown as itself, not flattened to online."""
+    caller = await create_user(session)
+    subject = await create_user(session)
+
+    socket = object()
+    await notification_stream.stream.connect(
+        subject.id, socket, chosen_presence=Presence(chosen)
+    )
+    try:
+        response = await client.get(
+            f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+            headers=get_auth_headers(caller),
+        )
+    finally:
+        await notification_stream.stream.disconnect(socket)
+
+    assert response.json()["presence"] == chosen
+
+
+@pytest.mark.integration
+async def test_profile_shows_offline_for_someone_who_picked_it(
+    client: AsyncClient, session: AsyncSession
+):
+    """Appearing offline holds with a tab open — that is the whole point of it."""
+    caller = await create_user(session)
+    subject = await create_user(session)
+
+    socket = object()
+    await notification_stream.stream.connect(
+        subject.id, socket, chosen_presence=Presence.offline
+    )
+    try:
+        response = await client.get(
+            f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+            headers=get_auth_headers(caller),
+        )
+    finally:
+        await notification_stream.stream.disconnect(socket)
+
+    assert response.json()["presence"] == "offline"
+
+
+@pytest.mark.integration
+async def test_presence_change_reaches_readers_without_a_reconnect(
+    client: AsyncClient, session: AsyncSession
+):
+    """The socket carried the old choice; setting a new one is followed live."""
+    caller = await create_user(session)
+    subject = await create_user(session)
+    profile_url = (
+        f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile"
+    )
+
+    socket = object()
+    await notification_stream.stream.connect(subject.id, socket)
+    try:
+        assert (await client.get(profile_url, headers=get_auth_headers(caller))).json()[
+            "presence"
+        ] == "online"
+
+        saved = await client.patch(
+            "/api/v1/users/me",
+            headers=get_auth_headers(subject),
+            json={"presence": "offline"},
+        )
+        assert saved.status_code == 200
+        assert saved.json()["presence"] == "offline"
+
+        assert (await client.get(profile_url, headers=get_auth_headers(caller))).json()[
+            "presence"
+        ] == "offline"
+    finally:
+        await notification_stream.stream.disconnect(socket)
+
+
+@pytest.mark.integration
+async def test_presence_outlives_the_socket_that_set_it(
+    client: AsyncClient, session: AsyncSession
+):
+    """The choice is a column, so a new tab appears the way the last one did."""
+    caller = await create_user(session)
+    subject = await create_user(session)
+
+    saved = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(subject),
+        json={"presence": "busy"},
+    )
+    assert saved.status_code == 200
+
+    await session.refresh(subject)
+    socket = object()
+    await notification_stream.stream.connect(
+        subject.id, socket, chosen_presence=subject.presence
+    )
+    try:
+        response = await client.get(
+            f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/profile",
+            headers=get_auth_headers(caller),
+        )
+    finally:
+        await notification_stream.stream.disconnect(socket)
+
+    assert response.json()["presence"] == "busy"
+
+
+@pytest.mark.integration
+async def test_presence_rejects_a_value_that_is_not_one(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(user),
+        json={"presence": "invisible"},
+    )
+
+    assert response.status_code == 422
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/events.py
+++ b/backend/app/api/v1/tenant_endpoints/events.py
@@ -136,7 +136,13 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
     # non-member. (A member of no initiative joins nothing — correct: they have
     # no content to be notified about. The user is still present in the guild,
     # which the manager tracks separately from the rooms.)
-    await manager.connect(guild_id, initiative_ids, websocket, user_id=user.id)
+    await manager.connect(
+        guild_id,
+        initiative_ids,
+        websocket,
+        user_id=user.id,
+        chosen_presence=user.presence,
+    )
     logger.info(
         f"Events WS: user {user.id} joined {len(initiative_ids)} initiative room(s) in guild {guild_id}"
     )

--- a/backend/app/api/v1/tenant_endpoints/events.py
+++ b/backend/app/api/v1/tenant_endpoints/events.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import logging
+from time import monotonic
 from typing import Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
@@ -111,6 +112,9 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
         # a since-dropped guild role would make every query error) before the auth
         # query — AsyncSessionLocal doesn't run get_session's per-request reset.
         await session.exec(text(CONNECTION_RESET_SQL))
+        # Taken before the row is read, so it is never later than the value
+        # that read comes back with.
+        presence_known_at = monotonic()
         user = await _user_from_token(token, session)
         if user is None:
             logger.warning("Events WebSocket: Auth failed")
@@ -142,6 +146,7 @@ async def websocket_updates(websocket: WebSocket, guild_id: int):
         websocket,
         user_id=user.id,
         chosen_presence=user.presence,
+        presence_known_at=presence_known_at,
     )
     logger.info(
         f"Events WS: user {user.id} joined {len(initiative_ids)} initiative room(s) in guild {guild_id}"

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -55,6 +55,39 @@ class UserStatus(str, Enum):
     anonymized = "anonymized"
 
 
+class Presence(str, Enum):
+    """How a person appears to everyone else.
+
+    Both halves of one idea, which is why it is one enum: what a person picks
+    for themselves, and what a reader of their name is shown. The picked value
+    is a standing preference on the account; the shown value is that preference
+    narrowed by what the process can see — whether they have Initiative open at
+    all, and whether anyone has touched it lately — which is decided in one
+    place (``app.services.platform.presence``).
+
+    ``idle`` is the one a person may either pick or be given: left on
+    ``online``, an account that goes quiet is shown it anyway, and picking it
+    outright is how someone says they would rather look that way regardless.
+
+    Not to be confused with ``UserStatus`` (the account's standing, which is not
+    the account holder's to write) or ``custom_status`` (the line they wrote).
+    """
+
+    #: Follow the connection: shown while a tab is open, and not otherwise.
+    online = "online"
+    #: Open, but with no sign of anyone at the keyboard for a while — the
+    #: state for stepping away, whether or not you said so. The one that is
+    #: inferred as well as picked: it is what ``online`` becomes on its own
+    #: after a long enough quiet, and what someone picks to look that way
+    #: whether or not they are.
+    idle = "idle"
+    #: Here, and would rather not be interrupted.
+    busy = "busy"
+    #: Shown to nobody, whether or not a tab is open. Also what a reader is
+    #: told about anyone who has nothing open.
+    offline = "offline"
+
+
 #: The statuses that may hold a session. A suspended account signs in — that is
 #: how its holder reaches their own account, and how they can be told why —
 #: and is stopped at every guild instead.
@@ -142,6 +175,17 @@ class User(SQLModel, table=True):
     custom_status: dict = Field(
         default_factory=dict,
         sa_column=Column(JSONB, nullable=False, server_default="{}"),
+    )
+    #: How this person wants to appear to everyone else — see ``Presence``.
+    #: A standing preference rather than live state: the live half is which
+    #: sockets are open, which no column could hold.
+    presence: Presence = Field(
+        default=Presence.online,
+        sa_column=Column(
+            SQLEnum(Presence, name="user_presence"),
+            nullable=False,
+            server_default=Presence.online.value,
+        ),
     )
     #: How this person's profile is dressed: a banner, a frame around the
     #: picture, badges beside the name. Each is an id naming a catalog entry

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -21,7 +21,7 @@ from app.core.profile_decorations import (
     validate_decoration_id,
 )
 from app.core.role_context import guild_shows_member_names
-from app.models.platform.user import UserRole, UserStatus
+from app.models.platform.user import Presence, UserRole, UserStatus
 from app.core.config import settings
 
 # ``avatar_url`` is where a user's picture is: either a path this API serves
@@ -342,7 +342,7 @@ class UserProfile(SanitizedBaseModel):
 
     A profile is public. It carries the handle — which is the name in this
     product, unique and never withheld — the face, the line they wrote, the
-    look they picked, whether they are online, and when they joined. It never
+    look they picked, how they appear right now, and when they joined. It never
     carries a real name: ``full_name`` is a guild's business (a guild decides
     whether it renders names at all), and this shape has no guild in it.
 
@@ -362,9 +362,10 @@ class UserProfile(SanitizedBaseModel):
     status: UserStatus = UserStatus.active
     custom_status: CustomStatus = Field(default_factory=CustomStatus)
     profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
-    #: Whether this person has Initiative open right now — the account, not a
-    #: guild. Set by the endpoint from ``realtime.manager.online``.
-    online: bool = False
+    #: How this person appears right now — the account, not a guild. What they
+    #: picked, narrowed by whether they have anything open; set by the endpoint
+    #: from the one roll that decides it.
+    presence: Presence = Presence.offline
     #: When the account was made.
     joined_at: datetime
 
@@ -386,6 +387,9 @@ class UserRead(UserBase):
     updated_at: datetime
     avatar_url: Optional[str] = None
     custom_status: CustomStatus = Field(default_factory=CustomStatus)
+    #: What this account picked, not what a reader would be shown: on your own
+    #: record this is the setting itself, and the control that writes it.
+    presence: Presence = Presence.online
     profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
     week_starts_on: int = 0
     recent_tabs_limit: int = 20
@@ -468,6 +472,7 @@ class UserSelfUpdate(SanitizedBaseModel):
     avatar_url: Optional[str] = None
     # Sending ``null`` takes the status off; leaving it out leaves it alone.
     custom_status: Optional[CustomStatus] = None
+    presence: Optional[Presence] = None
     # The whole set at once rather than one key at a time: a profile wears a
     # look, and a partial write would have no way to say "take the frame off".
     profile_decorations: Optional[ProfileDecorations] = None

--- a/backend/app/schemas/tenant/comment.py
+++ b/backend/app/schemas/tenant/comment.py
@@ -7,6 +7,7 @@ from pydantic import ConfigDict, Field, computed_field, field_validator, model_v
 
 from app.schemas.base import RichTextStr, SanitizedBaseModel
 from app.schemas.tenant.reaction import ReactionGroup
+from app.models.platform.user import Presence
 from app.schemas.platform.user import GuildNameVisibility, ProfileDecorations
 from app.services.platform import presence
 
@@ -19,7 +20,7 @@ class CommentAuthor(GuildNameVisibility):
     names.
 
     It carries what a picture needs to be drawn the way it is drawn everywhere
-    else — the decorations and whether they are around — because a comment is
+    else — the decorations and how they are appearing — because a comment is
     one of the places a person appears at a size where both are legible.
     Neither is private: the same two are on the public profile.
     """
@@ -33,17 +34,18 @@ class CommentAuthor(GuildNameVisibility):
     avatar_url: Optional[str] = None
     profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
 
-    @computed_field(return_type=bool)  # type: ignore[misc]
+    @computed_field(return_type=Presence)  # type: ignore[misc]
     @property
-    def online(self) -> bool:
-        """Whether they have Initiative open, at the moment this was serialized.
+    def presence(self) -> Presence:
+        """How they appear, at the moment this was serialized.
 
         Computed rather than stamped by each endpoint: a comment author is
-        built in nine places, and presence is not a column anything could
-        select. It is a process-local fact, so it is read where the shape is
-        made rather than passed down to it.
+        built in nine places, and what a reader is shown is not a column
+        anything could select — it is what the account picked narrowed by which
+        sockets are open. So it is read where the shape is made rather than
+        passed down to it.
         """
-        return presence.online.is_online(self.id)
+        return presence.online.presence_of(self.id)
 
 
 class CommentBase(SanitizedBaseModel):

--- a/backend/app/services/platform/notification_stream.py
+++ b/backend/app/services/platform/notification_stream.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, Set
 from sqlalchemy import event
 from sqlalchemy.orm import Session as SyncSession
 
+from app.models.platform.user import Presence
 from app.services.platform import presence
 
 logger = logging.getLogger(__name__)
@@ -58,14 +59,22 @@ class NotificationStream:
         self._socket_user: Dict[Any, int] = {}
         self._lock = asyncio.Lock()
 
-    async def connect(self, user_id: int, websocket: Any) -> None:
+    async def connect(
+        self,
+        user_id: int,
+        websocket: Any,
+        *,
+        chosen_presence: Presence = Presence.online,
+    ) -> None:
         """Register an already-accepted socket as this user's."""
         async with self._lock:
             self._sockets.setdefault(user_id, set()).add(websocket)
             self._socket_user[websocket] = user_id
         # This socket is open wherever they are in the app, including outside
-        # any guild, so it is what "has Initiative open" means.
-        presence.online.arrived(user_id)
+        # any guild, so it is what "has Initiative open" means. It carries the
+        # account's own choice of how to appear along with it, because the roll
+        # answers both halves of that question together.
+        presence.online.arrived(user_id, chosen_presence)
 
     async def disconnect(self, websocket: Any) -> None:
         """Drop a socket; the last one drops its user's entry entirely."""

--- a/backend/app/services/platform/notification_stream.py
+++ b/backend/app/services/platform/notification_stream.py
@@ -23,7 +23,7 @@ it any more.
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set
 
 from sqlalchemy import event
 from sqlalchemy.orm import Session as SyncSession
@@ -65,8 +65,13 @@ class NotificationStream:
         websocket: Any,
         *,
         chosen_presence: Presence = Presence.online,
+        presence_known_at: Optional[float] = None,
     ) -> None:
-        """Register an already-accepted socket as this user's."""
+        """Register an already-accepted socket as this user's.
+
+        ``presence_known_at`` is when the caller read ``chosen_presence``, so
+        the roll can tell a value read before a change from one read after it.
+        """
         async with self._lock:
             self._sockets.setdefault(user_id, set()).add(websocket)
             self._socket_user[websocket] = user_id
@@ -74,7 +79,7 @@ class NotificationStream:
         # any guild, so it is what "has Initiative open" means. It carries the
         # account's own choice of how to appear along with it, because the roll
         # answers both halves of that question together.
-        presence.online.arrived(user_id, chosen_presence)
+        presence.online.arrived(user_id, chosen_presence, known_at=presence_known_at)
 
     async def disconnect(self, websocket: Any) -> None:
         """Drop a socket; the last one drops its user's entry entirely."""

--- a/backend/app/services/platform/presence.py
+++ b/backend/app/services/platform/presence.py
@@ -12,13 +12,35 @@ tab sits inside a guild. The notification stream
 is open on every page for as long as someone is signed in, which is what makes
 it the signal that actually answers the question.
 
+It takes three facts to say how someone appears, and the roll holds all three
+so that "how does this person appear" is one lookup with one answer, rather
+than a rule each of the several surfaces that draw a dot would have to apply
+for itself:
+
+* whether anything is open, which only the sockets know;
+* what the person picked — ``users.presence``, which is a column because it
+  outlives every socket, and which a connecting socket brings with it;
+* when they last did something, which is what separates someone at their
+  keyboard from someone who left a tab open. That only ever narrows ``online``
+  — to ``idle`` — because every other value is something a person said, and an
+  inference does not talk over a statement. Picking ``idle`` outright is one of
+  those statements, and holds however busy the keyboard is.
+
 Bounded the way the other in-memory rolls are: these are one process's own
 sockets. Where the API runs as more than one worker each holds a share, so this
-can say "no" about someone another worker is serving. It drives a dot beside a
-name — a hint, not a fact anything depends on.
+can say "offline" about someone another worker is serving — the direction that
+tells a reader less rather than more.
 """
 
+from time import monotonic
 from typing import Dict, Iterable, Set
+
+from app.models.platform.user import Presence
+
+#: How long a person's tabs go without a sign of them before they read as idle.
+#: Long enough to sit through reading a document, short enough that a tab left
+#: open overnight does not claim someone is at it.
+IDLE_AFTER_SECONDS = 10 * 60
 
 
 class OnlineRoll:
@@ -27,9 +49,20 @@ class OnlineRoll:
     def __init__(self) -> None:
         # user_id -> how many of that user's sockets are open on this process.
         self._sockets: Dict[int, int] = {}
+        # user_id -> what they picked, for as long as they have something open.
+        # Dropped with their last socket: a preference nobody can be shown is
+        # the column's to keep, not this roll's.
+        self._chosen: Dict[int, Presence] = {}
+        # user_id -> monotonic time of the last sign of them. Monotonic because
+        # only the gap matters, and a clock that steps must not move it.
+        self._last_active: Dict[int, float] = {}
 
-    def arrived(self, user_id: int) -> None:
+    def arrived(self, user_id: int, chosen: Presence = Presence.online) -> None:
         self._sockets[user_id] = self._sockets.get(user_id, 0) + 1
+        # The newest socket read the column most recently, so it wins.
+        self._chosen[user_id] = chosen
+        # Opening a tab is somebody doing something.
+        self._last_active[user_id] = monotonic()
 
     def left(self, user_id: int) -> None:
         remaining = self._sockets.get(user_id, 0) - 1
@@ -37,13 +70,48 @@ class OnlineRoll:
             self._sockets[user_id] = remaining
         else:
             self._sockets.pop(user_id, None)
+            self._chosen.pop(user_id, None)
+            self._last_active.pop(user_id, None)
+
+    def chose(self, user_id: int, chosen: Presence) -> None:
+        """Follow a change made from an open tab.
+
+        Ignored for someone with nothing open: they appear offline either way,
+        and their next socket brings the column's value with it.
+        """
+        if user_id in self._sockets:
+            self._chosen[user_id] = chosen
+
+    def active(self, user_id: int) -> None:
+        """Note a sign of them, from any one of their tabs.
+
+        Per user rather than per socket: a person reading in one window is at
+        their keyboard whatever the other windows are doing, and the newest
+        sign of them is the one that answers that.
+        """
+        if user_id in self._sockets:
+            self._last_active[user_id] = monotonic()
+
+    def presence_of(self, user_id: int) -> Presence:
+        """How this account appears to anyone reading it right now."""
+        if user_id not in self._sockets:
+            return Presence.offline
+        chosen = self._chosen.get(user_id, Presence.online)
+        if chosen is not Presence.online:
+            return chosen
+        since = monotonic() - self._last_active.get(user_id, 0.0)
+        return Presence.idle if since >= IDLE_AFTER_SECONDS else Presence.online
 
     def is_online(self, user_id: int) -> bool:
-        return user_id in self._sockets
+        """Whether this account appears at all — any of the shown states.
+
+        Idle counts: they are here, they are just not typing.
+        """
+        return self.presence_of(user_id) is not Presence.offline
 
     def online_users(self, user_ids: Iterable[int]) -> Set[int]:
         """Which of these accounts are online, for a page of them at a time."""
-        return {user_id for user_id in user_ids if user_id in self._sockets}
+        return {user_id for user_id in user_ids if self.is_online(user_id)}
 
 
 #: The one roll every channel feeds and every reader asks.

--- a/backend/app/services/platform/presence.py
+++ b/backend/app/services/platform/presence.py
@@ -19,7 +19,10 @@ for itself:
 
 * whether anything is open, which only the sockets know;
 * what the person picked — ``users.presence``, which is a column because it
-  outlives every socket, and which a connecting socket brings with it;
+  outlives every socket. Two things carry it here: a connecting socket, which
+  read the row at some point on its way in, and the endpoint that writes it.
+  Neither is reliably the later one, so each says *when* it learned what it
+  knows and the later knowledge wins;
 * when they last did something, which is what separates someone at their
   keyboard from someone who left a tab open. That only ever narrows ``online``
   — to ``idle`` — because every other value is something a person said, and an
@@ -33,7 +36,7 @@ tells a reader less rather than more.
 """
 
 from time import monotonic
-from typing import Dict, Iterable, Set
+from typing import Dict, Iterable, Optional, Set
 
 from app.models.platform.user import Presence
 
@@ -49,18 +52,47 @@ class OnlineRoll:
     def __init__(self) -> None:
         # user_id -> how many of that user's sockets are open on this process.
         self._sockets: Dict[int, int] = {}
-        # user_id -> what they picked, for as long as they have something open.
-        # Dropped with their last socket: a preference nobody can be shown is
-        # the column's to keep, not this roll's.
-        self._chosen: Dict[int, Presence] = {}
+        # user_id -> (what they picked, when this roll learned it). The second
+        # half is what settles a disagreement between the two things that say
+        # so — see ``_learned``.
+        #
+        # Kept past the last socket, deliberately: a choice made with nothing
+        # open is exactly the one a connect already in flight must not undo.
+        # It is one small entry per account this process has seen.
+        self._chosen: Dict[int, tuple[Presence, float]] = {}
         # user_id -> monotonic time of the last sign of them. Monotonic because
         # only the gap matters, and a clock that steps must not move it.
         self._last_active: Dict[int, float] = {}
 
-    def arrived(self, user_id: int, chosen: Presence = Presence.online) -> None:
+    def _learned(self, user_id: int, chosen: Presence, known_at: float) -> None:
+        """Record a choice, unless this roll already knows a later one.
+
+        The two callers learn it at different points: a socket reads the column
+        somewhere on its way in, and a write knows it at the commit. Either can
+        reach the roll second, so what is compared is when each *learned* its
+        value rather than when it got here — otherwise a connect that started
+        before a change could land after it and put the old value back.
+        """
+        known = self._chosen.get(user_id)
+        if known is not None and known[1] > known_at:
+            return
+        self._chosen[user_id] = (chosen, known_at)
+
+    def arrived(
+        self,
+        user_id: int,
+        chosen: Presence = Presence.online,
+        *,
+        known_at: Optional[float] = None,
+    ) -> None:
+        """Register a socket, and the column value it read on the way in.
+
+        ``known_at`` is a ``monotonic()`` reading taken *before* that read, so
+        it is never later than the state the socket is carrying. Left out, the
+        value is treated as read now.
+        """
         self._sockets[user_id] = self._sockets.get(user_id, 0) + 1
-        # The newest socket read the column most recently, so it wins.
-        self._chosen[user_id] = chosen
+        self._learned(user_id, chosen, monotonic() if known_at is None else known_at)
         # Opening a tab is somebody doing something.
         self._last_active[user_id] = monotonic()
 
@@ -70,17 +102,16 @@ class OnlineRoll:
             self._sockets[user_id] = remaining
         else:
             self._sockets.pop(user_id, None)
-            self._chosen.pop(user_id, None)
             self._last_active.pop(user_id, None)
 
     def chose(self, user_id: int, chosen: Presence) -> None:
-        """Follow a change made from an open tab.
+        """Follow a change to the column, as the endpoint that wrote it commits.
 
-        Ignored for someone with nothing open: they appear offline either way,
-        and their next socket brings the column's value with it.
+        Recorded whether or not anything is open. Someone with no sockets
+        appears offline either way, but the record is what stops a connect
+        already on its way in from arriving with the value it read first.
         """
-        if user_id in self._sockets:
-            self._chosen[user_id] = chosen
+        self._learned(user_id, chosen, monotonic())
 
     def active(self, user_id: int) -> None:
         """Note a sign of them, from any one of their tabs.
@@ -96,7 +127,8 @@ class OnlineRoll:
         """How this account appears to anyone reading it right now."""
         if user_id not in self._sockets:
             return Presence.offline
-        chosen = self._chosen.get(user_id, Presence.online)
+        known = self._chosen.get(user_id)
+        chosen = known[0] if known is not None else Presence.online
         if chosen is not Presence.online:
             return chosen
         since = monotonic() - self._last_active.get(user_id, 0.0)

--- a/backend/app/services/platform/presence_test.py
+++ b/backend/app/services/platform/presence_test.py
@@ -10,7 +10,11 @@ import pytest
 
 from app.models.platform.user import Presence
 from app.services.platform import presence as presence_module
-from app.services.platform.presence import IDLE_AFTER_SECONDS, OnlineRoll
+from app.services.platform.presence import (
+    IDLE_AFTER_SECONDS,
+    OnlineRoll,
+    monotonic,
+)
 
 
 @pytest.fixture
@@ -54,8 +58,46 @@ def test_appearing_offline_holds_with_a_tab_open() -> None:
 
 
 @pytest.mark.unit
-def test_the_last_socket_takes_the_choice_with_it() -> None:
-    """The column keeps the preference; the roll only holds it while it shows."""
+def test_a_connect_that_started_first_cannot_undo_a_later_choice() -> None:
+    """A socket reads the column somewhere on its way in and can arrive after a
+    change that was made while it was still on its way."""
+    roll = OnlineRoll()
+    roll.arrived(7, Presence.online)
+    read_at = monotonic()  # the connecting socket reads the row here
+
+    roll.chose(7, Presence.offline)  # ...and a write lands before it registers
+    roll.arrived(7, Presence.online, known_at=read_at)
+
+    assert roll.presence_of(7) is Presence.offline
+
+
+@pytest.mark.unit
+def test_a_choice_made_with_nothing_open_survives_the_connect_it_raced() -> None:
+    """The same race, with the write landing while the first tab is still
+    opening — so there is no socket for the write to find."""
+    roll = OnlineRoll()
+    read_at = monotonic()
+
+    roll.chose(7, Presence.offline)
+    roll.arrived(7, Presence.online, known_at=read_at)
+
+    assert roll.presence_of(7) is Presence.offline
+
+
+@pytest.mark.unit
+def test_a_socket_that_read_after_the_change_carries_it() -> None:
+    """The rule is which value is later, not which caller is a socket."""
+    roll = OnlineRoll()
+    roll.chose(7, Presence.offline)
+
+    roll.arrived(7, Presence.busy, known_at=monotonic())
+
+    assert roll.presence_of(7) is Presence.busy
+
+
+@pytest.mark.unit
+def test_closing_the_last_tab_puts_someone_offline() -> None:
+    """Whatever they picked, nothing open is nothing to show."""
     roll = OnlineRoll()
     roll.arrived(7, Presence.busy)
     roll.arrived(7, Presence.busy)
@@ -77,8 +119,9 @@ def test_a_change_is_followed_while_connected() -> None:
 
 
 @pytest.mark.unit
-def test_a_change_by_someone_with_nothing_open_is_ignored() -> None:
-    """They appear offline either way, and their next socket brings the column."""
+def test_a_change_by_someone_with_nothing_open_shows_nothing() -> None:
+    """Recorded, so a connect in flight cannot undo it — but nothing open is
+    still nothing to show."""
     roll = OnlineRoll()
 
     roll.chose(7, Presence.busy)
@@ -89,8 +132,7 @@ def test_a_change_by_someone_with_nothing_open_is_ignored() -> None:
 
 
 @pytest.mark.unit
-def test_the_newest_socket_wins() -> None:
-    """It read the column most recently, so it is the freshest answer."""
+def test_the_socket_that_read_most_recently_wins() -> None:
     roll = OnlineRoll()
     roll.arrived(7, Presence.online)
     roll.arrived(7, Presence.busy)

--- a/backend/app/services/platform/presence_test.py
+++ b/backend/app/services/platform/presence_test.py
@@ -1,0 +1,197 @@
+"""The roll that decides how a person appears.
+
+Three facts meet here — which sockets are open, what the account picked, and
+when anyone last touched it — and these pin the rule that combines them,
+because every surface that draws a dot asks this one object rather than
+applying the rule for itself.
+"""
+
+import pytest
+
+from app.models.platform.user import Presence
+from app.services.platform import presence as presence_module
+from app.services.platform.presence import IDLE_AFTER_SECONDS, OnlineRoll
+
+
+@pytest.fixture
+def a_while_later(monkeypatch):
+    """Move the clock the roll reads, without moving anyone's real one."""
+
+    def go(seconds: float) -> None:
+        base = presence_module.monotonic()
+        monkeypatch.setattr(
+            presence_module, "monotonic", lambda: base + seconds, raising=True
+        )
+
+    return go
+
+
+@pytest.mark.unit
+def test_nobody_is_online_until_something_is_open() -> None:
+    roll = OnlineRoll()
+
+    assert roll.presence_of(7) is Presence.offline
+    assert roll.is_online(7) is False
+
+
+@pytest.mark.unit
+def test_an_open_tab_shows_what_it_brought() -> None:
+    roll = OnlineRoll()
+    roll.arrived(7, Presence.busy)
+
+    assert roll.presence_of(7) is Presence.busy
+    assert roll.is_online(7) is True
+
+
+@pytest.mark.unit
+def test_appearing_offline_holds_with_a_tab_open() -> None:
+    roll = OnlineRoll()
+    roll.arrived(7, Presence.offline)
+
+    assert roll.presence_of(7) is Presence.offline
+    assert roll.is_online(7) is False
+    assert roll.online_users([7]) == set()
+
+
+@pytest.mark.unit
+def test_the_last_socket_takes_the_choice_with_it() -> None:
+    """The column keeps the preference; the roll only holds it while it shows."""
+    roll = OnlineRoll()
+    roll.arrived(7, Presence.busy)
+    roll.arrived(7, Presence.busy)
+
+    roll.left(7)
+    assert roll.presence_of(7) is Presence.busy  # a second tab is still open
+
+    roll.left(7)
+    assert roll.presence_of(7) is Presence.offline
+
+
+@pytest.mark.unit
+def test_a_change_is_followed_while_connected() -> None:
+    roll = OnlineRoll()
+    roll.arrived(7)
+
+    roll.chose(7, Presence.busy)
+    assert roll.presence_of(7) is Presence.busy
+
+
+@pytest.mark.unit
+def test_a_change_by_someone_with_nothing_open_is_ignored() -> None:
+    """They appear offline either way, and their next socket brings the column."""
+    roll = OnlineRoll()
+
+    roll.chose(7, Presence.busy)
+
+    assert roll.presence_of(7) is Presence.offline
+    roll.arrived(7, Presence.busy)
+    assert roll.presence_of(7) is Presence.busy
+
+
+@pytest.mark.unit
+def test_the_newest_socket_wins() -> None:
+    """It read the column most recently, so it is the freshest answer."""
+    roll = OnlineRoll()
+    roll.arrived(7, Presence.online)
+    roll.arrived(7, Presence.busy)
+
+    assert roll.presence_of(7) is Presence.busy
+
+
+@pytest.mark.unit
+def test_online_users_narrows_a_page_of_accounts() -> None:
+    roll = OnlineRoll()
+    roll.arrived(7)
+    roll.arrived(8, Presence.busy)
+    roll.arrived(9, Presence.offline)
+
+    assert roll.online_users([7, 8, 9, 10]) == {7, 8}
+
+
+@pytest.mark.unit
+def test_an_open_tab_goes_idle_when_nobody_touches_it(a_while_later) -> None:
+    """Nobody says they are away from their keyboard; the quiet says it."""
+    roll = OnlineRoll()
+    roll.arrived(7)
+
+    a_while_later(IDLE_AFTER_SECONDS + 1)
+
+    assert roll.presence_of(7) is Presence.idle
+    # Idle is still here — they are just not typing.
+    assert roll.is_online(7) is True
+
+
+@pytest.mark.unit
+def test_a_sign_of_them_brings_them_back(a_while_later) -> None:
+    roll = OnlineRoll()
+    roll.arrived(7)
+    a_while_later(IDLE_AFTER_SECONDS + 1)
+    assert roll.presence_of(7) is Presence.idle
+
+    roll.active(7)
+
+    assert roll.presence_of(7) is Presence.online
+
+
+@pytest.mark.unit
+def test_one_tab_being_used_keeps_the_person_here(a_while_later) -> None:
+    """A person reading in one window is at their keyboard whatever the other
+    windows are doing."""
+    roll = OnlineRoll()
+    roll.arrived(7)
+    roll.arrived(7)
+    a_while_later(IDLE_AFTER_SECONDS + 1)
+
+    roll.active(7)
+
+    assert roll.presence_of(7) is Presence.online
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("chosen", [Presence.idle, Presence.busy, Presence.offline])
+def test_a_guess_never_talks_over_what_someone_said(
+    a_while_later, chosen: Presence
+) -> None:
+    """Everything but ``online`` is a statement, and going quiet is not an
+    argument against one."""
+    roll = OnlineRoll()
+    roll.arrived(7, chosen)
+
+    a_while_later(IDLE_AFTER_SECONDS + 1)
+
+    assert roll.presence_of(7) is chosen
+
+
+@pytest.mark.unit
+def test_picking_idle_holds_while_someone_is_typing() -> None:
+    """Picked and inferred are the same state: someone who would rather look
+    idle looks idle, whatever their keyboard says."""
+    roll = OnlineRoll()
+    roll.arrived(7, Presence.idle)
+
+    roll.active(7)
+
+    assert roll.presence_of(7) is Presence.idle
+    assert roll.is_online(7) is True
+
+
+@pytest.mark.unit
+def test_a_sign_of_someone_with_nothing_open_is_ignored() -> None:
+    roll = OnlineRoll()
+
+    roll.active(7)
+
+    assert roll.presence_of(7) is Presence.offline
+
+
+@pytest.mark.unit
+def test_reconnecting_starts_the_clock_again(a_while_later) -> None:
+    """Opening a tab is somebody doing something."""
+    roll = OnlineRoll()
+    roll.arrived(7)
+    a_while_later(IDLE_AFTER_SECONDS + 1)
+    roll.left(7)
+
+    roll.arrived(7)
+
+    assert roll.presence_of(7) is Presence.online

--- a/backend/app/services/realtime.py
+++ b/backend/app/services/realtime.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, Set, Tuple
+from typing import Any, Dict, Iterable, Optional, Set, Tuple
 
 from fastapi import WebSocket
 
@@ -67,9 +67,14 @@ class ConnectionManager:
         *,
         user_id: int,
         chosen_presence: Presence = Presence.online,
+        presence_known_at: Optional[float] = None,
     ) -> None:
         """Register an already-accepted socket under each of its initiative rooms,
-        namespaced to ``guild_id``, and mark its user present in that guild."""
+        namespaced to ``guild_id``, and mark its user present in that guild.
+
+        ``presence_known_at`` is when the caller read ``chosen_presence``, so
+        the roll can tell a value read before a change from one read after it.
+        """
         async with self._lock:
             joined = self._socket_rooms.setdefault(websocket, set())
             for initiative_id in initiative_ids:
@@ -79,7 +84,9 @@ class ConnectionManager:
             self._socket_identity[websocket] = (guild_id, user_id)
             present = self._present.setdefault(guild_id, {})
             present[user_id] = present.get(user_id, 0) + 1
-            presence.online.arrived(user_id, chosen_presence)
+            presence.online.arrived(
+                user_id, chosen_presence, known_at=presence_known_at
+            )
 
     async def disconnect(self, websocket: WebSocket) -> None:
         """Remove a socket from every room it joined, and from its guild's roll."""

--- a/backend/app/services/realtime.py
+++ b/backend/app/services/realtime.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Iterable, Set, Tuple
 
 from fastapi import WebSocket
 
+from app.models.platform.user import Presence
 from app.services.platform import presence
 
 # A room is identified by (guild_id, initiative_id). The guild_id is REQUIRED in
@@ -65,6 +66,7 @@ class ConnectionManager:
         websocket: WebSocket,
         *,
         user_id: int,
+        chosen_presence: Presence = Presence.online,
     ) -> None:
         """Register an already-accepted socket under each of its initiative rooms,
         namespaced to ``guild_id``, and mark its user present in that guild."""
@@ -77,7 +79,7 @@ class ConnectionManager:
             self._socket_identity[websocket] = (guild_id, user_id)
             present = self._present.setdefault(guild_id, {})
             present[user_id] = present.get(user_id, 0) + 1
-            presence.online.arrived(user_id)
+            presence.online.arrived(user_id, chosen_presence)
 
     async def disconnect(self, websocket: WebSocket) -> None:
         """Remove a socket from every room it joined, and from its guild's roll."""
@@ -122,7 +124,11 @@ class ConnectionManager:
         return len(self._rooms.get((guild_id, initiative_id), set()))
 
     def present_count(self, guild_id: int) -> int:
-        """How many distinct users have this guild open on this process."""
+        """How many distinct users have this guild open on this process.
+
+        A count of open tabs, not of dots: how a person chooses to appear is
+        about the person, and this figure is about the guild.
+        """
         return len(self._present.get(guild_id, {}))
 
     def present_counts(self, guild_ids: Iterable[int]) -> Dict[int, int]:

--- a/backend/app/services/realtime_test.py
+++ b/backend/app/services/realtime_test.py
@@ -25,6 +25,7 @@ from app.api.deps import establish_guild_access
 from app.api.v1.tenant_endpoints.events import _accessible_initiative_ids
 from app.models.platform.access_grant import AccessGrant, AccessGrantStatus, AccessLevel
 from app.models.platform.guild import GuildRole
+from app.models.platform.user import Presence
 from app.services import realtime
 from app.services.realtime import ConnectionManager, broadcast_event, manager
 from app.testing import (
@@ -120,6 +121,22 @@ async def test_presence_includes_a_member_of_no_initiative() -> None:
 
     await cm.disconnect(socket)
     assert cm.present_count(1) == 0
+
+
+@pytest.mark.unit
+async def test_the_guild_count_is_open_tabs_not_dots() -> None:
+    """How a person chooses to appear is about the person; this figure is about
+    the guild, so someone appearing offline still has it open."""
+    cm = ConnectionManager()
+    hidden, seen = FakeWebSocket(), FakeWebSocket()
+    await cm.connect(1, [5], hidden, user_id=7, chosen_presence=Presence.offline)
+    await cm.connect(1, [5], seen, user_id=8)
+
+    try:
+        assert cm.present_count(1) == 2
+    finally:
+        await cm.disconnect(hidden)
+        await cm.disconnect(seen)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -464,6 +464,23 @@ def _reset_app_registration_cache():
 
 
 @pytest.fixture(autouse=True)
+def _reset_presence_roll():
+    """Start and end every test with nobody online.
+
+    How a person appears is answered from a process-global roll fed by the
+    sockets this process holds (see ``app.services.platform.presence``). Test
+    databases RESTART IDENTITY per test, so user ids repeat — and a test that
+    leaves a socket registered would hand its user id to whoever gets that id
+    next, which reads as a stranger being online.
+    """
+    from app.services.platform import presence
+
+    presence.online = presence.OnlineRoll()
+    yield
+    presence.online = presence.OnlineRoll()
+
+
+@pytest.fixture(autouse=True)
 def _disable_hibp_check(monkeypatch):
     """Disable the HaveIBeenPwned breach lookup for all tests by default.
 

--- a/frontend/public/locales/de/profiles.json
+++ b/frontend/public/locales/de/profiles.json
@@ -6,8 +6,19 @@
   },
   "presence": {
     "label": "Präsenz",
+    "edit": "Wie du erscheinst",
+    "change": "Präsenz: {{state}}. Ändern, wie du erscheinst.",
+    "failed": "Das konnte nicht gespeichert werden.",
     "online": "Online",
-    "offline": "Offline"
+    "idle": "Inaktiv",
+    "busy": "Beschäftigt",
+    "offline": "Offline",
+    "help": {
+      "online": "Wird angezeigt, solange du Initiative offen hast.",
+      "idle": "Wird von selbst gesetzt, wenn eine Weile nichts passiert ist – oder wähle es, um zu sagen, dass du kurz weg bist.",
+      "busy": "Du bist da und möchtest nicht gestört werden.",
+      "offline": "Niemand sieht dich als anwesend, auch bei geöffnetem Tab."
+    }
   },
   "joined": {
     "label": "Dabei seit"

--- a/frontend/public/locales/en/profiles.json
+++ b/frontend/public/locales/en/profiles.json
@@ -6,8 +6,19 @@
   },
   "presence": {
     "label": "Presence",
+    "edit": "How you appear",
+    "change": "Presence: {{state}}. Change how you appear.",
+    "failed": "That could not be saved.",
     "online": "Online",
-    "offline": "Offline"
+    "idle": "Idle",
+    "busy": "Busy",
+    "offline": "Offline",
+    "help": {
+      "online": "Shown while you have Initiative open.",
+      "idle": "Set on its own once nothing's been touched for a while — or pick it to say you've stepped away.",
+      "busy": "You're around, and would rather not be interrupted.",
+      "offline": "Nobody sees you as here, even with a tab open."
+    }
   },
   "joined": {
     "label": "Joined"

--- a/frontend/public/locales/es/profiles.json
+++ b/frontend/public/locales/es/profiles.json
@@ -6,8 +6,19 @@
   },
   "presence": {
     "label": "Presencia",
+    "edit": "Cómo apareces",
+    "change": "Presencia: {{state}}. Cambia cómo apareces.",
+    "failed": "No se pudo guardar.",
     "online": "En línea",
-    "offline": "Desconectado"
+    "idle": "Inactivo",
+    "busy": "Ocupado",
+    "offline": "Desconectado",
+    "help": {
+      "online": "Se muestra mientras tengas Initiative abierto.",
+      "idle": "Se pone solo cuando llevas un rato sin tocar nada, o elígelo para decir que te has apartado.",
+      "busy": "Estás por aquí y prefieres que no te interrumpan.",
+      "offline": "Nadie te ve presente, aunque tengas una pestaña abierta."
+    }
   },
   "joined": {
     "label": "Se unió"

--- a/frontend/public/locales/fr/profiles.json
+++ b/frontend/public/locales/fr/profiles.json
@@ -6,8 +6,19 @@
   },
   "presence": {
     "label": "Présence",
+    "edit": "Comment vous apparaissez",
+    "change": "Présence : {{state}}. Changer comment vous apparaissez.",
+    "failed": "Impossible d'enregistrer.",
     "online": "En ligne",
-    "offline": "Hors ligne"
+    "idle": "Inactif",
+    "busy": "Occupé",
+    "offline": "Hors ligne",
+    "help": {
+      "online": "Affiché tant que vous avez Initiative ouvert.",
+      "idle": "Se met tout seul quand rien n'a bougé depuis un moment — ou choisissez-le pour dire que vous vous êtes éclipsé.",
+      "busy": "Vous êtes là et préférez ne pas être dérangé.",
+      "offline": "Personne ne vous voit présent, même avec un onglet ouvert."
+    }
   },
   "joined": {
     "label": "A rejoint"

--- a/frontend/src/__tests__/factories/user.factory.ts
+++ b/frontend/src/__tests__/factories/user.factory.ts
@@ -150,7 +150,7 @@ export function buildUserProfile(overrides: Partial<UserProfile> = {}): UserProf
     status: "active",
     custom_status: { emoji: null, text: null },
     profile_decorations: { banner: null, frame: null, badges: [] },
-    online: false,
+    presence: "offline",
     joined_at: "2026-01-15T00:00:00.000Z",
     ...overrides,
   };

--- a/frontend/src/__tests__/userProfileRoute.test.tsx
+++ b/frontend/src/__tests__/userProfileRoute.test.tsx
@@ -91,10 +91,24 @@ describe("a member's profile", () => {
   });
 
   it("says when someone has Initiative open", async () => {
-    answerWith(buildUserProfile({ online: true }));
+    answerWith(buildUserProfile({ presence: "online" }));
     await renderProfile();
 
     expect(await screen.findByText("Online")).toBeInTheDocument();
+  });
+
+  it("says which state someone is in, not just that they are here", async () => {
+    answerWith(buildUserProfile({ presence: "busy" }));
+    await renderProfile();
+
+    expect(await screen.findByText("Busy")).toBeInTheDocument();
+  });
+
+  it("shows someone who stepped away from the keyboard as idle", async () => {
+    answerWith(buildUserProfile({ presence: "idle" }));
+    await renderProfile();
+
+    expect(await screen.findByText("Idle")).toBeInTheDocument();
   });
 
   it("wears the decorations it can draw, and ignores the ones it cannot", async () => {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1496,6 +1496,32 @@ export interface ProfileDecorationsOutput {
 }
 
 /**
+ * How a person appears to everyone else.
+ *
+ * Both halves of one idea, which is why it is one enum: what a person picks
+ * for themselves, and what a reader of their name is shown. The picked value
+ * is a standing preference on the account; the shown value is that preference
+ * narrowed by what the process can see — whether they have Initiative open at
+ * all, and whether anyone has touched it lately — which is decided in one
+ * place (``app.services.platform.presence``).
+ *
+ * ``idle`` is the one a person may either pick or be given: left on
+ * ``online``, an account that goes quiet is shown it anyway, and picking it
+ * outright is how someone says they would rather look that way regardless.
+ *
+ * Not to be confused with ``UserStatus`` (the account's standing, which is not
+ * the account holder's to write) or ``custom_status`` (the line they wrote).
+ */
+export type Presence = (typeof Presence)[keyof typeof Presence];
+
+export const Presence = {
+  online: "online",
+  idle: "idle",
+  busy: "busy",
+  offline: "offline",
+} as const;
+
+/**
  * Who wrote a comment.
  *
  * An address never reaches a guild, so there is none here; the handle names
@@ -1503,7 +1529,7 @@ export interface ProfileDecorationsOutput {
  * names.
  *
  * It carries what a picture needs to be drawn the way it is drawn everywhere
- * else — the decorations and whether they are around — because a comment is
+ * else — the decorations and how they are appearing — because a comment is
  * one of the places a person appears at a size where both are legible.
  * Neither is private: the same two are on the public profile.
  */
@@ -1515,14 +1541,15 @@ export interface CommentAuthor {
   avatar_url?: string | null;
   profile_decorations?: ProfileDecorationsOutput;
   /**
-   * Whether they have Initiative open, at the moment this was serialized.
+   * How they appear, at the moment this was serialized.
    *
    * Computed rather than stamped by each endpoint: a comment author is
-   * built in nine places, and presence is not a column anything could
-   * select. It is a process-local fact, so it is read where the shape is
-   * made rather than passed down to it.
+   * built in nine places, and what a reader is shown is not a column
+   * anything could select — it is what the account picked narrowed by which
+   * sockets are open. So it is read where the shape is made rather than
+   * passed down to it.
    */
-  readonly online: boolean;
+  readonly presence: Presence;
 }
 
 export interface CommentCreate {
@@ -5106,7 +5133,7 @@ export interface UserGuildMember {
  *
  * A profile is public. It carries the handle — which is the name in this
  * product, unique and never withheld — the face, the line they wrote, the
- * look they picked, whether they are online, and when they joined. It never
+ * look they picked, how they appear right now, and when they joined. It never
  * carries a real name: ``full_name`` is a guild's business (a guild decides
  * whether it renders names at all), and this shape has no guild in it.
  *
@@ -5122,7 +5149,7 @@ export interface UserProfile {
   status: UserStatus;
   custom_status: CustomStatusOutput;
   profile_decorations: ProfileDecorationsOutput;
-  online: boolean;
+  presence: Presence;
   joined_at: string;
 }
 
@@ -5140,6 +5167,7 @@ export interface UserRead {
   updated_at: string;
   avatar_url: string | null;
   custom_status: CustomStatusOutput;
+  presence: Presence;
   profile_decorations: ProfileDecorationsOutput;
   week_starts_on: number;
   recent_tabs_limit: number;
@@ -5187,6 +5215,7 @@ export interface UserSelfUpdate {
   current_password?: string | null;
   avatar_url?: string | null;
   custom_status?: CustomStatusInput | null;
+  presence?: Presence | null;
   profile_decorations?: ProfileDecorationsInput | null;
   week_starts_on?: number | null;
   recent_tabs_limit?: number | null;

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -765,8 +765,8 @@ export const useRemoveDecorationPackApiV1UsersMeDecorationPacksUidDelete = <
  * fixed width, so the two come apart again exactly.
  *
  * A profile is public and has no guild in it: it carries the handle, the
- * face, the status, the look and whether they are online, and it is the same
- * page whoever opens it. That is why it is not reached through a guild — no
+ * face, the status, the look and how they appear, and it is the same page
+ * whoever opens it. That is why it is not reached through a guild — no
  * part of the answer depends on one.
  *
  * Read from ``public.user_profiles``, the view that *is* the public

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -122,7 +122,7 @@ export const CommentThread = ({
           <ProfileAvatar
             user={anonymizedAuthor ? { id: null } : (comment.author ?? { id: comment.created_by })}
             decorations={anonymizedAuthor ? null : comment.author?.profile_decorations}
-            online={!anonymizedAuthor && comment.author?.online}
+            presence={anonymizedAuthor ? undefined : comment.author?.presence}
             className="size-9"
           />
           <div className="min-w-0 flex-1">

--- a/frontend/src/components/sidebar/SidebarUserFooter.tsx
+++ b/frontend/src/components/sidebar/SidebarUserFooter.tsx
@@ -25,10 +25,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SidebarFooter } from "@/components/ui/sidebar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { PresenceDot } from "@/components/user/PresenceDot";
+import { PresenceMenu } from "@/components/user/PresenceMenu";
 import { ProfileAvatar } from "@/components/user/ProfileAvatar";
 import { ProfileStatus } from "@/components/user/ProfileStatus";
 import { VersionDialog } from "@/components/VersionDialog";
 import { guildPath } from "@/lib/guildUrl";
+import { presenceLabelKey } from "@/lib/presence";
 import { getUrlHandle, getUserDisplayName } from "@/lib/userDisplay";
 
 export interface SidebarUserFooterProps {
@@ -43,7 +46,7 @@ export interface SidebarUserFooterProps {
   hasUpdate: boolean;
   isLoadingVersion: boolean;
   onLogout: () => void;
-  /** Re-read the account after the status is set from here. */
+  /** Re-read the account after the status or the presence is set from here. */
   refreshUser: () => Promise<void>;
 }
 
@@ -60,7 +63,7 @@ export const SidebarUserFooter = ({
   onLogout,
   refreshUser,
 }: SidebarUserFooterProps) => {
-  const { t } = useTranslation(["nav"]);
+  const { t } = useTranslation(["nav", "profiles"]);
   const gp = (path: string) => (activeGuildId ? guildPath(activeGuildId, path) : path);
   const displayName = getUserDisplayName(user);
   const handle = getUrlHandle(user);
@@ -84,7 +87,6 @@ export const SidebarUserFooter = ({
                 <ProfileAvatar
                   user={user}
                   decorations={user?.profile_decorations}
-                  online={Boolean(user)}
                   className="size-8 text-xs"
                 />
                 <div className="flex min-w-0 flex-1 flex-col items-start overflow-hidden text-left">
@@ -148,18 +150,38 @@ export const SidebarUserFooter = ({
             <ModeToggle />
           </div>
         </div>
-        {/* Set where it is read, the same as on the profile: a status is the
-            thing you change most often, and the sidebar is where you already
-            are when it changes. */}
+        {/* Both set where they are read, the same as on the profile: a status
+            and a presence are the two things you change most often, and the
+            sidebar is where you already are when they change.
+
+            The bubble keeps the left, under the face it is a thought of, and
+            gives up the width it does not need; the dot takes the room that
+            frees on the right, where the bell and the theme toggle already are.
+
+            The dot is here rather than on the picture above, because two of
+            them would be two places saying one thing — and the one you can
+            click is the one worth keeping. */}
         {user ? (
-          <div className="px-2 pb-2">
+          <div className="flex items-start justify-between gap-2 px-2 pb-2">
             <ProfileStatus
               status={user.custom_status}
               editable
               tail="up"
               onSaved={refreshUser}
-              className="block w-full text-xs"
+              className="min-w-0 text-xs"
             />
+            <PresenceMenu presence={user.presence} align="end" onChanged={refreshUser}>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="mt-2.5 size-7 shrink-0"
+                aria-label={t("profiles:presence.change", {
+                  state: t(`profiles:${presenceLabelKey(user.presence)}`),
+                })}
+              >
+                <PresenceDot presence={user.presence} className="size-3" />
+              </Button>
+            </PresenceMenu>
           </div>
         ) : null}
         <div className="border-t">

--- a/frontend/src/components/user/PresenceDot.tsx
+++ b/frontend/src/components/user/PresenceDot.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "react-i18next";
+
+import type { Presence } from "@/api/generated/initiativeAPI.schemas";
+import { PRESENCE_COLOR, presenceLabelKey } from "@/lib/presence";
+import { cn } from "@/lib/utils";
+
+interface PresenceDotProps {
+  presence: Presence;
+  /**
+   * Say the state in words for a reader who cannot see the colour. Left off
+   * where something around the dot already says it — a label beside it, or a
+   * button holding it — so it is not read twice.
+   */
+  labelled?: boolean;
+  className?: string;
+}
+
+/**
+ * The coloured circle that says how someone is appearing.
+ *
+ * Sized by whatever contains it, so the same component is the quarter-sized
+ * badge on an avatar and the small mark in a line of text.
+ */
+export const PresenceDot = ({ presence, labelled, className }: PresenceDotProps) => {
+  const { t } = useTranslation("profiles");
+  const label = t(presenceLabelKey(presence));
+
+  return (
+    <span
+      role="img"
+      className={cn("block rounded-full", PRESENCE_COLOR[presence], className)}
+      aria-label={label}
+      aria-hidden={labelled ? undefined : "true"}
+      title={labelled ? label : undefined}
+    />
+  );
+};

--- a/frontend/src/components/user/PresenceMenu.tsx
+++ b/frontend/src/components/user/PresenceMenu.tsx
@@ -1,0 +1,86 @@
+import { Check } from "lucide-react";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { Presence, UserSelfUpdate } from "@/api/generated/initiativeAPI.schemas";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PresenceDot } from "@/components/user/PresenceDot";
+import { useUpdateCurrentUser } from "@/hooks/useUsers";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { PRESENCE_ORDER, presenceHelpKey, presenceLabelKey } from "@/lib/presence";
+
+interface PresenceMenuProps {
+  /** What the account is set to — the choice, not what a reader is shown. */
+  presence: Presence;
+  /** The control this hangs off: the dot on your avatar, or a chip beside it. */
+  children: ReactNode;
+  align?: "start" | "center" | "end";
+  side?: "top" | "right" | "bottom" | "left";
+  /** Re-read the account once the new choice is saved. */
+  onChanged?: () => Promise<void> | void;
+}
+
+/**
+ * Picking how you appear.
+ *
+ * The same menu wherever it is opened from, because there is one setting: the
+ * sidebar is where you already are when it changes, and the profile card is
+ * where you are looking at the dot when you decide it is wrong.
+ *
+ * Idle is offered even though it is also worked out on its own — a person who
+ * would rather look like they stepped away can say so, and saying it means it
+ * holds however busy their keyboard is.
+ */
+export const PresenceMenu = ({
+  presence,
+  children,
+  align = "start",
+  side,
+  onChanged,
+}: PresenceMenuProps) => {
+  const { t } = useTranslation("profiles");
+
+  const save = useUpdateCurrentUser({
+    onSuccess: async () => {
+      await onChanged?.();
+    },
+    onError: (error: unknown) => toast.error(getErrorMessage(error, "profiles:presence.failed")),
+  });
+
+  return (
+    // modal={false}: a modal dropdown nested in the non-modal mobile sidebar
+    // drawer dismisses the drawer on open.
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuContent align={align} side={side} className="w-60">
+        <DropdownMenuLabel>{t("presence.edit")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {PRESENCE_ORDER.map((option) => (
+          <DropdownMenuItem
+            key={option}
+            className="items-start gap-2.5"
+            disabled={save.isPending}
+            onSelect={() => save.mutate({ presence: option } as UserSelfUpdate)}
+          >
+            <PresenceDot presence={option} className="mt-1 size-2.5 shrink-0" />
+            <span className="flex min-w-0 flex-1 flex-col">
+              <span className="font-medium">{t(presenceLabelKey(option))}</span>
+              <span className="text-muted-foreground text-xs">{t(presenceHelpKey(option))}</span>
+            </span>
+            {option === presence ? (
+              <Check className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            ) : null}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/frontend/src/components/user/ProfileAvatar.tsx
+++ b/frontend/src/components/user/ProfileAvatar.tsx
@@ -1,5 +1,6 @@
-import type { ProfileDecorationsOutput } from "@/api/generated/initiativeAPI.schemas";
+import type { Presence, ProfileDecorationsOutput } from "@/api/generated/initiativeAPI.schemas";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { PresenceDot } from "@/components/user/PresenceDot";
 import { FRAME_INSET, FRAME_SIZE, resolveDecoration } from "@/lib/profileDecorations";
 import {
   type AvatarSourceUser,
@@ -13,8 +14,13 @@ import { cn } from "@/lib/utils";
 interface ProfileAvatarProps {
   user: (DisplayableUser & AvatarSourceUser) | null | undefined;
   decorations?: ProfileDecorationsOutput | null;
-  /** Show the "has the app open" dot. Left off where presence isn't known. */
-  online?: boolean;
+  /**
+   * How they are appearing. Left off where presence isn't known, and `offline`
+   * draws nothing: absence is what an empty corner already says.
+   */
+  presence?: Presence;
+  /** Suppress the dot so a caller can put its own control in that corner. */
+  hidePresence?: boolean;
   /**
    * Separate the picture from artwork behind it with a ring in the card's own
    * colour — for an avatar that overlaps a banner. Ignored when a frame is
@@ -32,13 +38,14 @@ interface ProfileAvatarProps {
  * The frame is artwork with a hole in it and the picture fills the hole. Every
  * frame is drawn to the same aperture, so one inset seats all of them and a
  * frame published later needs no code here. It carries no information, so it is
- * hidden from assistive technology; the presence dot is not, and says so in
- * words wherever it appears.
+ * hidden from assistive technology; the presence dot is not, and says which
+ * state it means in words rather than in colour alone.
  */
 export const ProfileAvatar = ({
   user,
   decorations,
-  online,
+  presence,
+  hidePresence,
   ring,
   className,
 }: ProfileAvatarProps) => {
@@ -65,8 +72,12 @@ export const ProfileAvatar = ({
           style={{ width: FRAME_SIZE, height: FRAME_SIZE, left: FRAME_INSET, top: FRAME_INSET }}
         />
       ) : null}
-      {online ? (
-        <span className="absolute right-0 bottom-0 block size-1/4 rounded-full bg-emerald-500 ring-2 ring-background" />
+      {presence && presence !== "offline" && !hidePresence ? (
+        <PresenceDot
+          presence={presence}
+          labelled
+          className="absolute right-0 bottom-0 size-1/4 ring-2 ring-background"
+        />
       ) : null}
     </div>
   );

--- a/frontend/src/components/user/ProfileMeta.tsx
+++ b/frontend/src/components/user/ProfileMeta.tsx
@@ -1,12 +1,15 @@
 import { useTranslation } from "react-i18next";
 
+import type { Presence } from "@/api/generated/initiativeAPI.schemas";
+import { PresenceDot } from "@/components/user/PresenceDot";
 import { formatDate } from "@/lib/formatDate";
+import { presenceLabelKey } from "@/lib/presence";
 
 /**
  * The two facts a profile states about an account rather than about a person:
- * whether they have Initiative open, and when they joined.
+ * how they are appearing, and when they joined.
  */
-export const ProfileMeta = ({ online, joinedAt }: { online: boolean; joinedAt: string }) => {
+export const ProfileMeta = ({ presence, joinedAt }: { presence: Presence; joinedAt: string }) => {
   const { t } = useTranslation("profiles");
   return (
     <dl className="flex flex-wrap gap-x-8 gap-y-2 border-t pt-4 text-sm">
@@ -15,11 +18,8 @@ export const ProfileMeta = ({ online, joinedAt }: { online: boolean; joinedAt: s
             gets the list read out rather than shown. */}
         <dt className="sr-only">{t("presence.label")}</dt>
         <dd className="flex items-center gap-1.5 font-medium">
-          <span
-            className={`size-2 rounded-full ${online ? "bg-emerald-500" : "bg-muted-foreground/40"}`}
-            aria-hidden="true"
-          />
-          {online ? t("presence.online") : t("presence.offline")}
+          <PresenceDot presence={presence} className="size-2" />
+          {t(presenceLabelKey(presence))}
         </dd>
       </div>
       <div className="flex items-center gap-2">

--- a/frontend/src/components/user/ProfilePicture.tsx
+++ b/frontend/src/components/user/ProfilePicture.tsx
@@ -3,6 +3,7 @@ import { type ChangeEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type {
+  Presence,
   ProfileDecorationsOutput,
   UserSelfUpdate,
 } from "@/api/generated/initiativeAPI.schemas";
@@ -33,7 +34,9 @@ const linked = (url: string | null | undefined): boolean => Boolean(url) && !upl
 interface ProfilePictureProps {
   user: DisplayableUser & AvatarSourceUser;
   decorations: ProfileDecorationsOutput;
-  online?: boolean;
+  presence?: Presence;
+  /** Leave the corner empty for a caller putting its own control there. */
+  hidePresence?: boolean;
   className?: string;
   /** Whether this is your own picture, and clicking it opens the editor. */
   editable?: boolean;
@@ -52,7 +55,8 @@ interface ProfilePictureProps {
 export const ProfilePicture = ({
   user,
   decorations,
-  online,
+  presence,
+  hidePresence,
   className,
   editable = false,
   onChanged,
@@ -113,7 +117,8 @@ export const ProfilePicture = ({
     <ProfileAvatar
       user={user}
       decorations={decorations}
-      online={online}
+      presence={presence}
+      hidePresence={hidePresence}
       ring
       className={className}
     />

--- a/frontend/src/components/user/ProfilePreview.tsx
+++ b/frontend/src/components/user/ProfilePreview.tsx
@@ -1,13 +1,19 @@
+import { useTranslation } from "react-i18next";
+
 import type {
   CustomStatusOutput,
+  Presence,
   ProfileDecorationsOutput,
 } from "@/api/generated/initiativeAPI.schemas";
 import { UserHandle } from "@/components/UserHandle";
 import { Card, CardContent } from "@/components/ui/card";
+import { PresenceDot } from "@/components/user/PresenceDot";
+import { PresenceMenu } from "@/components/user/PresenceMenu";
 import { ProfileBadges } from "@/components/user/ProfileBadges";
 import { ProfileMeta } from "@/components/user/ProfileMeta";
 import { ProfilePicture } from "@/components/user/ProfilePicture";
 import { ProfileStatus } from "@/components/user/ProfileStatus";
+import { presenceLabelKey } from "@/lib/presence";
 import { resolveDecoration } from "@/lib/profileDecorations";
 import type { AvatarSourceUser, DisplayableUser } from "@/lib/userDisplay";
 
@@ -15,9 +21,11 @@ interface ProfilePreviewProps {
   user: DisplayableUser & AvatarSourceUser;
   decorations: ProfileDecorationsOutput;
   status: CustomStatusOutput;
+  /** What the account is set to appear as. */
+  presence: Presence;
   /** ISO date the account was created. */
   joinedAt: string;
-  /** Re-read the account after the status or the picture is changed here. */
+  /** Re-read the account after anything set from the card is changed. */
   onChanged?: () => Promise<void> | void;
 }
 
@@ -30,18 +38,22 @@ interface ProfilePreviewProps {
  * avatar, badges, status and footer the page draws, so what you see here
  * cannot say something the page does not.
  *
- * The card is also the controls: the picture and the status are both set by
- * clicking them here, because the thing you are looking at is the thing you
- * want to change and a section further down would be a second place to keep
- * in agreement with this one.
+ * The card is also the controls: the picture, the status and the presence dot
+ * are all set by clicking them here, because the thing you are looking at is
+ * the thing you want to change and a section further down would be a second
+ * place to keep in agreement with this one. The dot is the one control that
+ * has to sit outside the picture rather than on it — the picture is a button,
+ * and a button inside a button belongs to neither.
  */
 export const ProfilePreview = ({
   user,
   decorations,
   status,
+  presence,
   joinedAt,
   onChanged,
 }: ProfilePreviewProps) => {
+  const { t } = useTranslation("profiles");
   const banner = resolveDecoration(decorations.banner, "banner");
 
   return (
@@ -58,14 +70,25 @@ export const ProfilePreview = ({
         <div className="-mt-20 space-y-1">
           <ProfileStatus status={status} editable onSaved={onChanged} />
           <div className="flex flex-wrap items-end gap-4">
-            <ProfilePicture
-              user={user}
-              decorations={decorations}
-              online
-              editable
-              onChanged={onChanged}
-              className="size-24 sm:size-28"
-            />
+            <div className="relative">
+              <ProfilePicture
+                user={user}
+                decorations={decorations}
+                hidePresence
+                editable
+                onChanged={onChanged}
+                className="size-24 sm:size-28"
+              />
+              <PresenceMenu presence={presence} onChanged={onChanged}>
+                <button
+                  type="button"
+                  className="absolute right-0 bottom-0 rounded-full ring-2 ring-card transition-transform hover:scale-110 focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-2"
+                  aria-label={t("presence.change", { state: t(presenceLabelKey(presence)) })}
+                >
+                  <PresenceDot presence={presence} className="size-6 sm:size-7" />
+                </button>
+              </PresenceMenu>
+            </div>
             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1 pb-1">
               <UserHandle user={user} className="font-semibold text-2xl" />
               <ProfileBadges decorations={decorations} />
@@ -73,7 +96,7 @@ export const ProfilePreview = ({
           </div>
         </div>
 
-        <ProfileMeta online joinedAt={joinedAt} />
+        <ProfileMeta presence={presence} joinedAt={joinedAt} />
       </CardContent>
     </Card>
   );

--- a/frontend/src/hooks/useNotificationStream.ts
+++ b/frontend/src/hooks/useNotificationStream.ts
@@ -6,6 +6,18 @@ import { buildApiWsUrl } from "@/lib/wsUrl";
 
 // Message type for authentication (must match the backend's MSG_AUTH).
 const MSG_AUTH = 5;
+// "Somebody just did something here" (the backend's MSG_ACTIVE). One byte, no
+// payload: the socket already knows whose it is.
+const MSG_ACTIVE = 6;
+
+// How often that byte may go out, however busy the keyboard is. The server
+// only needs to know the person was around within its idle window, so once a
+// minute answers that with a frame nobody would notice.
+const ACTIVITY_INTERVAL_MS = 60_000;
+
+// What counts as a sign of someone. Pointer, key and scroll cover being at the
+// machine; a tab coming back to the front covers returning to it.
+const ACTIVITY_EVENTS = ["pointerdown", "keydown", "wheel", "touchstart"] as const;
 
 const RECONNECT_DELAY_MS = 2000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
@@ -53,6 +65,13 @@ export const useNotificationStreamConnected = (): boolean =>
     () => false
   );
 
+const sendActivityMessage = (websocket: WebSocket) => {
+  if (websocket.readyState !== WebSocket.OPEN) {
+    return;
+  }
+  websocket.send(new Uint8Array([MSG_ACTIVE]));
+};
+
 const sendAuthMessage = (websocket: WebSocket, token: string | null) => {
   const payload = JSON.stringify({ token });
   const payloadBytes = new TextEncoder().encode(payload);
@@ -73,6 +92,11 @@ const sendAuthMessage = (websocket: WebSocket, token: string | null) => {
  * Every frame is a content-free "your inbox changed"; the response is to
  * invalidate the notification queries and let React Query refetch through the
  * normal REST path, which is the authorization gate.
+ *
+ * It carries one thing the other way: a throttled byte saying its person is at
+ * the keyboard. That is what keeps them from reading as idle — and going quiet
+ * is the whole signal, so a tab left open needs to send nothing for the server
+ * to work out that nobody is at it.
  *
  * Mount once, at the authenticated app shell.
  */
@@ -163,8 +187,37 @@ export const useNotificationStream = () => {
 
     connect();
 
+    // Throttled at the source rather than on a timer: no frame goes out for a
+    // tab nobody is touching, which is exactly the state being reported.
+    let lastReported = 0;
+    const reportActivity = () => {
+      const now = Date.now();
+      if (now - lastReported < ACTIVITY_INTERVAL_MS) {
+        return;
+      }
+      lastReported = now;
+      if (websocketRef.current) {
+        sendActivityMessage(websocketRef.current);
+      }
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        // Coming back to the tab is being back, whenever the last click was.
+        lastReported = 0;
+        reportActivity();
+      }
+    };
+    for (const name of ACTIVITY_EVENTS) {
+      window.addEventListener(name, reportActivity, { passive: true });
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
     return () => {
       isActive = false;
+      for (const name of ACTIVITY_EVENTS) {
+        window.removeEventListener(name, reportActivity);
+      }
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       setConnected(false);
       if (reconnectTimerRef.current) {
         window.clearTimeout(reconnectTimerRef.current);

--- a/frontend/src/lib/presence.ts
+++ b/frontend/src/lib/presence.ts
@@ -1,0 +1,37 @@
+import { Presence } from "@/api/generated/initiativeAPI.schemas";
+
+/**
+ * How someone appears, and how that is drawn.
+ *
+ * One list, in the order the menu offers them, so a state added to the API
+ * enum has exactly one place to be described rather than a colour in one file
+ * and a label in another.
+ *
+ * `idle` sits in it twice over: it is what `online` becomes on its own once a
+ * person's tabs go quiet, and it is also a thing they may pick outright.
+ */
+export const PRESENCE_ORDER = [
+  Presence.online,
+  Presence.idle,
+  Presence.busy,
+  Presence.offline,
+] as const;
+
+/**
+ * The dot's colour, per state.
+ *
+ * The word goes with it wherever it is drawn, because a colour on its own is
+ * not something everyone can read.
+ */
+export const PRESENCE_COLOR: Record<Presence, string> = {
+  [Presence.online]: "bg-emerald-500",
+  [Presence.idle]: "bg-amber-400",
+  [Presence.busy]: "bg-rose-500",
+  [Presence.offline]: "bg-muted-foreground/40",
+};
+
+/** The `profiles:presence.*` key naming a state. */
+export const presenceLabelKey = (presence: Presence) => `presence.${presence}` as const;
+
+/** The `profiles:presence.help.*` key saying what picking it does. */
+export const presenceHelpKey = (presence: Presence) => `presence.help.${presence}` as const;

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -24,8 +24,8 @@ import { profileBanner } from "@/lib/profileBanner";
  *
  * Public, and the same page whoever opens it: the handle is the name in this
  * product, so nothing here depends on a community deciding whether it renders
- * real names, and "online" is a fact about the person rather than about a
- * place they happen to share with the reader.
+ * real names, and how they appear is a fact about the person rather than about
+ * a place they happen to share with the reader.
  *
  * Your own status is editable in place; nothing else on it is. The rest is
  * written on Settings → Profile, so there is one place a person edits
@@ -85,7 +85,7 @@ export const UserProfilePage = () => {
           <ProfileAvatar
             user={profile}
             decorations={profile.profile_decorations}
-            online={profile.online}
+            presence={profile.presence}
             ring
             className="size-24 sm:size-28"
           />
@@ -98,7 +98,7 @@ export const UserProfilePage = () => {
         </div>
       </div>
 
-      <ProfileMeta online={profile.online} joinedAt={profile.joined_at} />
+      <ProfileMeta presence={profile.presence} joinedAt={profile.joined_at} />
 
       <ProfileCommunities handle={handle} />
     </div>

--- a/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsProfilePage.tsx
@@ -25,10 +25,10 @@ interface UserSettingsProfilePageProps {
  * Your profile: the face other people see, and everything that makes it.
  *
  * The card at the top is that face, kept live against the pickers below it —
- * and it is the controls too. Your picture and your status are both set by
- * clicking them on the card, because that is where you are looking when you
- * decide to change them, and a form further down would be a second place to
- * keep in agreement with the first.
+ * and it is the controls too. Your picture, your status and the dot saying how
+ * you appear are all set by clicking them on the card, because that is where
+ * you are looking when you decide to change them, and a form further down
+ * would be a second place to keep in agreement with the first.
  *
  * Your packs sit under your look rather than over it: what you are wearing is
  * why you came, and what you own is where you go to change it.
@@ -76,6 +76,7 @@ export const UserSettingsProfilePage = ({ user, refreshUser }: UserSettingsProfi
         user={user}
         decorations={{ banner, frame, badges }}
         status={user.custom_status}
+        presence={user.presence}
         joinedAt={user.created_at}
         onChanged={refreshUser}
       />


### PR DESCRIPTION
## Problem

The dot beside a name only ever said "has a tab open". There was no way to say
you would rather not be interrupted, no way to appear offline while you work,
and nothing that noticed a tab left open on an empty desk.

## Changes

Four states, one enum — `online`, `idle`, `busy`, `offline`.

**The choice is a column; how a reader sees it is the process's answer.** A
preference outlives every socket, so it is stored; what a reader is shown takes
knowing what is open, so it is not. One roll answers "how does this person
appear" ([presence.py](backend/app/services/platform/presence.py)) rather than
each surface that draws a dot applying the rule for itself.

**Idle is both picked and inferred.** Left on `online`, an account reads as idle
once its tabs have gone quiet for ten minutes; picked outright, it holds however
busy the keyboard is. Tabs report a throttled byte (`MSG_ACTIVE`, at most one a
minute) on the notification socket, so going quiet is the whole signal — a tab
nobody is touching sends nothing.

- [presence.py](backend/app/services/platform/presence.py) — the roll now holds
  what was picked and when someone was last seen, alongside which sockets are open
- [user.py](backend/app/models/platform/user.py),
  [20260903_0216](backend/alembic/versions/20260903_0216_user_presence.py) — the
  `users.presence` column and its type. The request path holds its UPDATE on
  `users` per column (0144), so the new one is named in that grant
- [user.py](backend/app/schemas/platform/user.py),
  [comment.py](backend/app/schemas/tenant/comment.py) — `online: bool` becomes
  `presence` on the public shapes
- [notifications.py](backend/app/api/v1/platform_endpoints/notifications.py) — the
  activity frame; [useNotificationStream.ts](frontend/src/hooks/useNotificationStream.ts)
  sends it
- [PresenceMenu.tsx](frontend/src/components/user/PresenceMenu.tsx),
  [PresenceDot.tsx](frontend/src/components/user/PresenceDot.tsx),
  [presence.ts](frontend/src/lib/presence.ts) — one menu, opened from the sidebar
  and from the profile card in Settings › Profile
- [SidebarUserFooter.tsx](frontend/src/components/sidebar/SidebarUserFooter.tsx) —
  the status bubble gives up the width it was not using and the dot takes the space
  that frees. The picture above no longer carries a dot of its own: two would be
  two places saying one thing, and the one you can click is the one worth keeping
- [conftest.py](backend/conftest.py) — the roll is process-global and user ids
  repeat between tests, so each test starts and ends with nobody on it

A guild's online figure is deliberately **not** one of the surfaces that reads
the choice — it counts open tabs, because it is about the guild rather than
about a person.

New keys are in all four locales.

## Testing

- `cd backend && pytest -n 0 app/services/platform/presence_test.py app/services/realtime_test.py app/api/v1/platform_endpoints/users_test.py` — 101 passed
- `cd backend && ruff check app alembic && ty check app` — clean
- `cd backend && alembic upgrade head` — applied, single head
- `cd frontend && npx vitest run src/__tests__ src/components/user src/components/comments src/components/sidebar src/pages/user` — 474 passed
- `cd frontend && npx tsc --noEmit && pnpm lint` — clean