### PR TITLE
Give # back to the reference picker

### DIFF
--- a/frontend/src/components/documents/editor/document-extension.test.tsx
+++ b/frontend/src/components/documents/editor/document-extension.test.tsx
@@ -1,0 +1,61 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { LexicalExtensionComposer } from "@lexical/react/LexicalExtensionComposer";
+import { render } from "@testing-library/react";
+import { $createParagraphNode, $createTextNode, $getRoot, type LexicalEditor } from "lexical";
+import { describe, expect, it } from "vitest";
+
+import { documentExtension } from "./document-extension";
+
+function Grab({ take }: { take: (editor: LexicalEditor) => void }): null {
+  const [editor] = useLexicalComposerContext();
+  take(editor);
+  return null;
+}
+
+/** The types of the nodes a line of text turns into, in a real document. */
+function typedIntoADocument(line: string): string[] {
+  let editor!: LexicalEditor;
+  render(
+    <LexicalExtensionComposer
+      extension={documentExtension({ collaborative: false, editable: true })}
+      contentEditable={null}
+    >
+      <Grab
+        take={(found) => {
+          editor = found;
+        }}
+      />
+    </LexicalExtensionComposer>
+  );
+
+  editor.update(
+    () => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode(line));
+      $getRoot().clear().append(paragraph);
+    },
+    { discrete: true }
+  );
+
+  const types: string[] = [];
+  editor.getEditorState().read(() => {
+    for (const node of $getRoot()
+      .getFirstChildOrThrow<ReturnType<typeof $createParagraphNode>>()
+      .getChildren()) {
+      types.push(node.getType());
+    }
+  });
+  return types;
+}
+
+describe("what the document editor makes of what is typed", () => {
+  it("leaves a word after # as plain text", () => {
+    // The picker reads what is being typed out of ordinary text, so anything
+    // that claims `#` for itself takes the trigger away from references.
+    expect(typedIntoADocument("see #launch")).toEqual(["text"]);
+  });
+
+  it("still leaves prose alone", () => {
+    expect(typedIntoADocument("see the launch")).toEqual(["text"]);
+  });
+});

--- a/frontend/src/components/documents/editor/document-extension.ts
+++ b/frontend/src/components/documents/editor/document-extension.ts
@@ -1,0 +1,121 @@
+import { CodeExtension } from "@lexical/code";
+import { CodePrismExtension } from "@lexical/code-prism";
+import {
+  AutoFocusExtension,
+  ClearEditorExtension,
+  DecoratorTextExtension,
+  HorizontalRuleExtension,
+  SelectionAlwaysOnDisplayExtension,
+} from "@lexical/extension";
+import { HistoryExtension } from "@lexical/history";
+import {
+  AutoLinkExtension,
+  ClickableLinkExtension,
+  createLinkMatcherWithRegExp,
+  LinkExtension,
+} from "@lexical/link";
+import { CheckListExtension, ListExtension } from "@lexical/list";
+import { OverflowNode } from "@lexical/overflow";
+import { RichTextExtension } from "@lexical/rich-text";
+import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
+import { configExtension, defineExtension, type InitialEditorStateType } from "lexical";
+
+import { EmojisExtension } from "@/components/ui/editor/extensions/emojis-extension";
+import { HeadingAnchorExtension } from "@/components/ui/editor/extensions/heading-anchor-extension";
+import { ImagesExtension } from "@/components/ui/editor/extensions/images-extension";
+import { KeywordsExtension } from "@/components/ui/editor/extensions/keywords-extension";
+import { LayoutExtension } from "@/components/ui/editor/extensions/layout-extension";
+import { ListMaxIndentLevelExtension } from "@/components/ui/editor/extensions/list-max-indent-level-extension";
+import { MarkdownShortcutsExtension } from "@/components/ui/editor/extensions/markdown-shortcuts-extension";
+import { BadgeNode } from "@/components/ui/editor/nodes/badge-node";
+import { TweetNode } from "@/components/ui/editor/nodes/embeds/tweet-node";
+import { YouTubeNode } from "@/components/ui/editor/nodes/embeds/youtube-node";
+import { EntityMentionNode } from "@/components/ui/editor/nodes/entity-mention-node";
+import { LEGACY_NODES } from "@/components/ui/editor/nodes/legacy-nodes";
+import { MentionNode } from "@/components/ui/editor/nodes/mention-node";
+import { editorTheme } from "@/components/ui/editor/themes/editor-theme";
+import { validateUrl } from "@/components/ui/editor/utils/url";
+
+const URL_REGEX =
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)(?<![-.+():%])/;
+
+const EMAIL_REGEX =
+  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
+
+const AUTO_LINK_MATCHERS = [
+  createLinkMatcherWithRegExp(URL_REGEX, (text) =>
+    text.startsWith("http") ? text : `https://${text}`
+  ),
+  createLinkMatcherWithRegExp(EMAIL_REGEX, (text) => `mailto:${text}`),
+];
+
+export interface DocumentExtensionOptions {
+  /** Yjs owns history and the initial content when a document is shared. */
+  collaborative: boolean;
+  editable: boolean;
+  /** What the document opens with, or `null` for an empty one. */
+  initialEditorState?: InitialEditorStateType;
+}
+
+/**
+ * Everything the document editor is made of: its nodes, and the behaviours
+ * registered on top of them.
+ *
+ * A module of its own because what is in this list decides what typing does —
+ * an extension that claims a character claims it from the pickers as well.
+ */
+export function documentExtension({
+  collaborative,
+  editable,
+  initialEditorState = null,
+}: DocumentExtensionOptions) {
+  return defineExtension({
+    name: "@initiative/document-editor",
+    namespace: "Editor",
+    nodes: [
+      OverflowNode,
+      TableNode,
+      TableCellNode,
+      TableRowNode,
+      MentionNode,
+      TweetNode,
+      YouTubeNode,
+      EntityMentionNode,
+      BadgeNode,
+      ...LEGACY_NODES,
+    ],
+    theme: editorTheme,
+    editable,
+    onError: (error) => console.error(error),
+    // In collaborative mode, leave the initial state empty.
+    // CollaborationPlugin owns the initial state via its initialEditorState prop.
+    $initialEditorState: collaborative ? null : initialEditorState,
+    dependencies: [
+      RichTextExtension,
+      AutoFocusExtension,
+      SelectionAlwaysOnDisplayExtension,
+      // History is owned by Yjs in collaborative mode; only register HistoryExtension otherwise.
+      ...(collaborative ? [] : [HistoryExtension]),
+      configExtension(LinkExtension, {
+        validateUrl,
+        attributes: { rel: "noopener noreferrer", target: "_blank" },
+      }),
+      configExtension(AutoLinkExtension, { matchers: AUTO_LINK_MATCHERS }),
+      ClickableLinkExtension,
+      ListExtension,
+      CheckListExtension,
+      HorizontalRuleExtension,
+      ClearEditorExtension,
+      DecoratorTextExtension,
+      CodeExtension,
+      CodePrismExtension,
+      EmojisExtension,
+      ImagesExtension,
+      KeywordsExtension,
+      LayoutExtension,
+      HeadingAnchorExtension,
+      ListMaxIndentLevelExtension,
+      MarkdownShortcutsExtension,
+    ],
+  });
+}

--- a/frontend/src/components/documents/editor/editor.tsx
+++ b/frontend/src/components/documents/editor/editor.tsx
@@ -1,60 +1,15 @@
 "use client";
 
-import { CodeExtension } from "@lexical/code";
-import { CodePrismExtension } from "@lexical/code-prism";
-import {
-  AutoFocusExtension,
-  ClearEditorExtension,
-  DecoratorTextExtension,
-  HorizontalRuleExtension,
-  SelectionAlwaysOnDisplayExtension,
-} from "@lexical/extension";
-import { HashtagExtension } from "@lexical/hashtag";
-import { HistoryExtension } from "@lexical/history";
-import {
-  AutoLinkExtension,
-  ClickableLinkExtension,
-  createLinkMatcherWithRegExp,
-  LinkExtension,
-} from "@lexical/link";
-import { CheckListExtension, ListExtension } from "@lexical/list";
-import { OverflowNode } from "@lexical/overflow";
 import { LexicalCollaboration } from "@lexical/react/LexicalCollaborationContext";
 import { CollaborationPlugin } from "@lexical/react/LexicalCollaborationPlugin";
 import { LexicalExtensionComposer } from "@lexical/react/LexicalExtensionComposer";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
-import { RichTextExtension } from "@lexical/rich-text";
-import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
-import {
-  $createTextNode,
-  configExtension,
-  defineExtension,
-  type EditorState,
-  type SerializedEditorState,
-} from "lexical";
+import type { EditorState, SerializedEditorState } from "lexical";
 import { Loader2 } from "lucide-react";
 import { useMemo, useRef } from "react";
 import type * as Y from "yjs";
 
-import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
-import { EmojisExtension } from "@/components/ui/editor/extensions/emojis-extension";
-import { HeadingAnchorExtension } from "@/components/ui/editor/extensions/heading-anchor-extension";
-import { ImagesExtension } from "@/components/ui/editor/extensions/images-extension";
-import { KeywordsExtension } from "@/components/ui/editor/extensions/keywords-extension";
-import { LayoutExtension } from "@/components/ui/editor/extensions/layout-extension";
-import { ListMaxIndentLevelExtension } from "@/components/ui/editor/extensions/list-max-indent-level-extension";
-import { MarkdownShortcutsExtension } from "@/components/ui/editor/extensions/markdown-shortcuts-extension";
-import { BadgeNode } from "@/components/ui/editor/nodes/badge-node";
-import { TweetNode } from "@/components/ui/editor/nodes/embeds/tweet-node";
-import { YouTubeNode } from "@/components/ui/editor/nodes/embeds/youtube-node";
-import {
-  $createEntityMentionNode,
-  EntityMentionNode,
-} from "@/components/ui/editor/nodes/entity-mention-node";
-import { MentionNode } from "@/components/ui/editor/nodes/mention-node";
-import { WikilinkNode } from "@/components/ui/editor/nodes/wikilink-node";
-import { editorTheme } from "@/components/ui/editor/themes/editor-theme";
-import { validateUrl } from "@/components/ui/editor/utils/url";
+import type { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAuth } from "@/hooks/useAuth";
 import { getUserColorHsl } from "@/lib/userColor";
@@ -62,20 +17,8 @@ import { getUserDisplayName } from "@/lib/userDisplay";
 import { cn } from "@/lib/utils";
 import type { CollaborationProvider } from "@/lib/yjs/CollaborationProvider";
 
+import { documentExtension } from "./document-extension";
 import { Plugins } from "./plugins";
-
-const URL_REGEX =
-  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)(?<![-.+():%])/;
-
-const EMAIL_REGEX =
-  /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
-
-const AUTO_LINK_MATCHERS = [
-  createLinkMatcherWithRegExp(URL_REGEX, (text) =>
-    text.startsWith("http") ? text : `https://${text}`
-  ),
-  createLinkMatcherWithRegExp(EMAIL_REGEX, (text) => `mailto:${text}`),
-];
 
 export interface EditorProps {
   editorState?: EditorState;
@@ -141,87 +84,19 @@ export function Editor({
   const initialEditorStateRef = useRef(editorState);
   const initialEditorSerializedStateRef = useRef(editorSerializedState);
 
-  const appExtension = useMemo(() => {
-    const wasCollaborative = initialCollabRef.current;
-    const initState = initialEditorStateRef.current;
-    const initSerialized = initialEditorSerializedStateRef.current;
-
-    return defineExtension({
-      name: "@initiative/document-editor",
-      namespace: "Editor",
-      nodes: [
-        OverflowNode,
-        TableNode,
-        TableCellNode,
-        TableRowNode,
-        MentionNode,
-        TweetNode,
-        YouTubeNode,
-        EntityMentionNode,
-        BadgeNode,
-        // `[[ ]]` wrote its own node before references were one thing. Stored
-        // documents still hold them, so every one is read as the reference it
-        // always was — rendering live like the rest, and written back as a
-        // reference the next time the document is saved.
-        {
-          replace: WikilinkNode,
-          with: (node: WikilinkNode) => {
-            const documentId = node.getDocumentId();
-            // One that never resolved points at nothing, so there is nothing to
-            // migrate but the words. Keeping its id would write a reference to
-            // document 0 — a link that can never come good.
-            return documentId
-              ? $createEntityMentionNode(
-                  SearchEntityType.document,
-                  documentId,
-                  node.getDocumentTitle()
-                )
-              : $createTextNode(node.getDocumentTitle());
-          },
-        },
-      ],
-      theme: editorTheme,
-      editable: !initialReadOnlyRef.current,
-      onError: (error) => console.error(error),
-      // In collaborative mode, leave the initial state empty.
-      // CollaborationPlugin owns the initial state via its initialEditorState prop.
-      $initialEditorState: wasCollaborative
-        ? null
-        : initState
-          ? initState
-          : initSerialized
-            ? JSON.stringify(initSerialized)
-            : null,
-      dependencies: [
-        RichTextExtension,
-        AutoFocusExtension,
-        SelectionAlwaysOnDisplayExtension,
-        // History is owned by Yjs in collaborative mode; only register HistoryExtension otherwise.
-        ...(wasCollaborative ? [] : [HistoryExtension]),
-        configExtension(LinkExtension, {
-          validateUrl,
-          attributes: { rel: "noopener noreferrer", target: "_blank" },
-        }),
-        configExtension(AutoLinkExtension, { matchers: AUTO_LINK_MATCHERS }),
-        ClickableLinkExtension,
-        ListExtension,
-        CheckListExtension,
-        HorizontalRuleExtension,
-        ClearEditorExtension,
-        DecoratorTextExtension,
-        HashtagExtension,
-        CodeExtension,
-        CodePrismExtension,
-        EmojisExtension,
-        ImagesExtension,
-        KeywordsExtension,
-        LayoutExtension,
-        HeadingAnchorExtension,
-        ListMaxIndentLevelExtension,
-        MarkdownShortcutsExtension,
-      ],
-    });
-  }, []);
+  const appExtension = useMemo(
+    () =>
+      documentExtension({
+        collaborative: initialCollabRef.current,
+        editable: !initialReadOnlyRef.current,
+        initialEditorState:
+          initialEditorStateRef.current ??
+          (initialEditorSerializedStateRef.current
+            ? JSON.stringify(initialEditorSerializedStateRef.current)
+            : null),
+      }),
+    []
+  );
 
   return (
     <div

--- a/frontend/src/components/documents/editor/plugins.tsx
+++ b/frontend/src/components/documents/editor/plugins.tsx
@@ -28,6 +28,7 @@ import { EmojiPickerPlugin } from "@/components/ui/editor/plugins/emoji-picker-p
 import { EntityMentionsPlugin } from "@/components/ui/editor/plugins/entity-mentions-plugin";
 import { FloatingLinkEditorPlugin } from "@/components/ui/editor/plugins/floating-link-editor-plugin";
 import { FloatingTextFormatToolbarPlugin } from "@/components/ui/editor/plugins/floating-text-format-plugin";
+import { LegacyNodesPlugin } from "@/components/ui/editor/plugins/legacy-nodes-plugin";
 import { LinkSanitizePlugin } from "@/components/ui/editor/plugins/link-sanitize-plugin";
 import { MentionsPlugin } from "@/components/ui/editor/plugins/mentions-plugin";
 import { AlignmentPickerPlugin } from "@/components/ui/editor/plugins/picker/alignment-picker-plugin";
@@ -214,6 +215,7 @@ export function Plugins({
         <TableActionMenuPlugin anchorElem={floatingAnchorElem} readOnly={readOnly} />
         <TabIndentationPlugin />
 
+        <LegacyNodesPlugin />
         <MentionsPlugin initiativeId={initiativeId ?? undefined} />
         {supportsEntityMentions && <DocumentBadgesPlugin />}
         {supportsEntityMentions && <EntityMentionsPlugin initiativeId={initiativeId} />}

--- a/frontend/src/components/ui/editor/nodes/legacy-nodes.test.ts
+++ b/frontend/src/components/ui/editor/nodes/legacy-nodes.test.ts
@@ -1,0 +1,96 @@
+import { createEditor } from "lexical";
+import { describe, expect, it } from "vitest";
+
+import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
+import {
+  $isEntityMentionNode,
+  EntityMentionNode,
+} from "@/components/ui/editor/nodes/entity-mention-node";
+import { LEGACY_NODES, registerLegacyNodes } from "@/components/ui/editor/nodes/legacy-nodes";
+
+const text = (extra: Record<string, unknown>) => ({
+  detail: 0,
+  format: 0,
+  mode: "normal",
+  style: "",
+  version: 1,
+  ...extra,
+});
+
+/** What one node of a stored document is, once today's editor has opened it. */
+type Opened = { type: string; text: string; entityType?: string; entityId?: number };
+
+function opened(children: Record<string, unknown>[]): Opened[] {
+  const editor = createEditor({
+    nodes: [EntityMentionNode, ...LEGACY_NODES],
+    onError: (error) => {
+      throw error;
+    },
+  });
+  editor.setEditorState(
+    editor.parseEditorState(
+      JSON.stringify({
+        root: {
+          children: [
+            { children, direction: null, format: "", indent: 0, type: "paragraph", version: 1 },
+          ],
+          direction: null,
+          format: "",
+          indent: 0,
+          type: "root",
+          version: 1,
+        },
+      })
+    )
+  );
+  registerLegacyNodes(editor);
+
+  const found: Opened[] = [];
+  editor.getEditorState().read(() => {
+    for (const node of editor.getEditorState()._nodeMap.values()) {
+      if (node.getType() === "root" || node.getType() === "paragraph") continue;
+      found.push({
+        type: node.getType(),
+        text: node.getTextContent(),
+        ...($isEntityMentionNode(node)
+          ? { entityType: node.getEntityType(), entityId: node.getEntityId() }
+          : {}),
+      });
+    }
+  });
+  return found;
+}
+
+describe("a document written before references were one thing", () => {
+  it("reads a stored hashtag as the word it looks like", () => {
+    // `#` is the reference trigger now, and the picker reads what is being
+    // typed out of ordinary text — a hashtag of its own is not that.
+    expect(opened([text({ type: "hashtag", text: "#launch" })])).toEqual([
+      { type: "text", text: "#launch" },
+    ]);
+  });
+
+  it("reads a resolved wikilink as the reference it always was", () => {
+    expect(
+      opened([
+        text({ type: "wikilink", text: "Roadmap", documentId: 12, documentTitle: "Roadmap" }),
+      ])
+    ).toEqual([
+      {
+        type: "entity-mention",
+        text: "Roadmap",
+        entityType: SearchEntityType.document,
+        entityId: 12,
+      },
+    ]);
+  });
+
+  it("keeps the words of a wikilink that never resolved", () => {
+    // It names nothing, so there is nothing to carry over but what it says.
+    expect(
+      opened([
+        text({ type: "wikilink", text: "Nowhere", documentId: null, documentTitle: "Nowhere" }),
+      ])
+    ).toEqual([{ type: "text", text: "Nowhere" }]);
+  });
+});

--- a/frontend/src/components/ui/editor/nodes/legacy-nodes.ts
+++ b/frontend/src/components/ui/editor/nodes/legacy-nodes.ts
@@ -1,0 +1,63 @@
+import { HashtagNode } from "@lexical/hashtag";
+import { mergeRegister } from "@lexical/utils";
+import {
+  $createTextNode,
+  $nodesOfType,
+  type Klass,
+  type LexicalEditor,
+  type LexicalNode,
+} from "lexical";
+
+import { $convertLegacyWikilink } from "@/components/ui/editor/nodes/entity-mention-node";
+import { WikilinkNode } from "@/components/ui/editor/nodes/wikilink-node";
+
+/**
+ * Node types documents still hold that nothing writes any more.
+ *
+ * They stay registered so a stored document opens at all — Lexical refuses a
+ * type it does not know — and each one is rewritten as current content on the
+ * way in.
+ */
+export const LEGACY_NODES: Klass<LexicalNode>[] = [WikilinkNode, HashtagNode];
+
+/** What a legacy node is in today's document. */
+function $modernize(node: LexicalNode): void {
+  if (node instanceof WikilinkNode) {
+    // `[[ ]]` wrote its own node before references were one thing. One that
+    // resolved to a document is that reference, and renders live like the rest;
+    // one that never resolved names nothing, so only its words remain.
+    node.replace(
+      $convertLegacyWikilink({
+        documentId: node.getDocumentId(),
+        documentTitle: node.getDocumentTitle(),
+      }) ?? $createTextNode(node.getDocumentTitle())
+    );
+  } else if (node instanceof HashtagNode) {
+    // `#` opens the reference picker now, so the word after it names a thing
+    // rather than styling itself. What was stored reads back as the plain word
+    // it already looked like.
+    node.replace($createTextNode(node.getTextContent()));
+  }
+}
+
+/**
+ * Rewrites the legacy nodes a document opens with, and any that arrive later.
+ *
+ * The sweep covers the document as loaded; the transforms cover what a paste or
+ * a collaborator's update brings in afterwards. Either way the rewrite reaches
+ * storage the next time the document is saved, and a document nobody opens
+ * again is left as it is.
+ */
+export function registerLegacyNodes(editor: LexicalEditor): () => void {
+  editor.update(
+    () => {
+      for (const klass of LEGACY_NODES) {
+        for (const node of $nodesOfType(klass)) $modernize(node);
+      }
+    },
+    { discrete: true }
+  );
+  return mergeRegister(
+    ...LEGACY_NODES.map((klass) => editor.registerNodeTransform(klass, $modernize))
+  );
+}

--- a/frontend/src/components/ui/editor/plugins/document-badges-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/document-badges-plugin.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { BadgeState } from "@/api/generated/initiativeAPI.schemas";
 import { BadgeStatesContext, useDocumentBadges } from "@/hooks/useDocumentBadges";
-import { collectReferences } from "@/lib/documentReferences";
+import { documentReferences } from "@/lib/documentReferences";
 
 /**
  * Reads everything the page refers to, once.
@@ -20,12 +20,10 @@ export function DocumentBadgesPlugin({ children }: { children?: ReactNode }): JS
 
   useEffect(() => {
     const collect = () => {
-      editor.getEditorState().read(() => {
-        // Compared as a string so an edit that moves a reference without
-        // changing the set does not start a new request.
-        const next = collectReferences(Object.values(editor.getEditorState()._nodeMap));
-        setRefs((current) => (current.join() === next.join() ? current : next));
-      });
+      // Compared as a string so an edit that moves a reference without
+      // changing the set does not start a new request.
+      const next = documentReferences(editor.getEditorState());
+      setRefs((current) => (current.join() === next.join() ? current : next));
     };
     collect();
     return editor.registerUpdateListener(collect);

--- a/frontend/src/components/ui/editor/plugins/legacy-nodes-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/legacy-nodes-plugin.tsx
@@ -1,0 +1,15 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useEffect } from "react";
+
+import { registerLegacyNodes } from "@/components/ui/editor/nodes/legacy-nodes";
+
+/**
+ * Reads what older versions of the editor wrote as what it means today.
+ *
+ * See `legacy-nodes` for which node types those are and what each becomes.
+ */
+export function LegacyNodesPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => registerLegacyNodes(editor), [editor]);
+  return null;
+}

--- a/frontend/src/lib/documentReferences.test.ts
+++ b/frontend/src/lib/documentReferences.test.ts
@@ -1,4 +1,10 @@
-import { createEditor, type LexicalEditor } from "lexical";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+  type LexicalEditor,
+} from "lexical";
 import { describe, expect, it } from "vitest";
 
 import { BadgeKind, SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
@@ -7,7 +13,7 @@ import {
   $createEntityMentionNode,
   EntityMentionNode,
 } from "@/components/ui/editor/nodes/entity-mention-node";
-import { collectReferences, nodeReference } from "@/lib/documentReferences";
+import { collectReferences, documentReferences, nodeReference } from "@/lib/documentReferences";
 
 function inEditor<T>(fn: () => T): T {
   const editor: LexicalEditor = createEditor({
@@ -73,5 +79,32 @@ describe("what a page asks about", () => {
 
   it("ignores ordinary prose", () => {
     expect(inEditor(() => collectReferences([]))).toEqual([]);
+  });
+});
+
+describe("what a page asks about, read off the page", () => {
+  it("finds the references written into a document", () => {
+    // The plugin asks the editor, not a list handed to it — a walk that comes
+    // back empty leaves every chip and every name showing what it was typed as.
+    const editor: LexicalEditor = createEditor({
+      nodes: [BadgeNode, EntityMentionNode],
+      onError: (error) => {
+        throw error;
+      },
+    });
+    editor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        paragraph.append(
+          $createTextNode("see "),
+          $createEntityMentionNode(SearchEntityType.task, 12, "Ship it"),
+          $createBadgeNode(BadgeKind["task:status"], 12, "Ship it")
+        );
+        $getRoot().append(paragraph);
+      },
+      { discrete: true }
+    );
+
+    expect(documentReferences(editor.getEditorState())).toEqual(["task:12", "task:12:status"]);
   });
 });

--- a/frontend/src/lib/documentReferences.ts
+++ b/frontend/src/lib/documentReferences.ts
@@ -3,10 +3,10 @@
  *
  * Chips and links are both references, and the page reads them together: a chip
  * asks `task:12:status`, a link asks `task:12`, and one request answers both.
- * Pulled out of the plugin so the walk can be tested without an editor.
+ * Pulled out of the plugin so the walk over a document can be tested.
  */
 
-import type { LexicalNode } from "lexical";
+import type { EditorState, LexicalNode } from "lexical";
 
 import { $isBadgeNode } from "@/components/ui/editor/nodes/badge-node";
 import { $isEntityMentionNode } from "@/components/ui/editor/nodes/entity-mention-node";
@@ -31,3 +31,7 @@ export const collectReferences = (nodes: Iterable<LexicalNode>): string[] => {
   }
   return [...found].sort();
 };
+
+/** Every reference a document holds, wherever in it they sit. */
+export const documentReferences = (state: EditorState): string[] =>
+  state.read(() => collectReferences(state._nodeMap.values()));


### PR DESCRIPTION
## Problem

`#` did nothing in a document. The editor registered `@lexical/hashtag`, whose text-entity transform rewrites `#word` into a hashtag node as soon as the first letter lands. Lexical's typeahead reads the caret's text only when the node is *simple* text, so the reference picker opened on the bare `#` and closed on the next keystroke. Nothing ever connected those hashtag nodes to the tag system — they were blue text — and `#` names things now.

Two more in the same area, both found while testing this one:

- **No badge or reference ever asked for its state.** `DocumentBadgesPlugin` collected with `Object.values(editorState._nodeMap)`. `_nodeMap` is a `Map`, so that is always `[]` — every chip and every reference showed the words it was typed with and nothing else. `collectReferences` was tested; the walk that feeds it was not.
- **A document holding an old `[[link]]` threw on open.** The wikilink migration used a node replacement returning an `EntityMentionNode`, and Lexical requires a replacement to be a subclass of what it replaces (`$applyNodeReplacement`, invariant 202 — in prod too).

## Changes

- Drop `HashtagExtension`. `HashtagNode` stays registered so stored documents still parse.
- `legacy-nodes.ts` owns the node types nothing writes any more and what each becomes: a resolved wikilink is the reference it always was, an unresolved one is its words, a hashtag is the plain word it looked like. A sweep on open plus a transform for what a paste or a collaborator brings in later.
- `document-extension.ts` — the editor's node and extension list, out of the component so what typing does can be tested.
- `documentReferences(state)` walks the document next to the collector that reads it; the plugin calls that.

## Testing

- `document-extension.test.tsx` — `see #launch` typed into the real extension set stays one text node. Verified it reports `['text', 'hashtag']` with the extension put back.
- `documentReferences.test.ts` — references written into a document are found. Verified it returns `[]` with the old `Object.values` walk.
- `legacy-nodes.test.ts` — the three stored shapes, opened.
- `pnpm test:run`: 208 files, 2290 tests, all passing. `tsc` and `biome` clean.

No changelog entry: all three are fixes to features still under `[Unreleased]`.