### PR TITLE
Select a run of cards with shift-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Shift-click picks a run of cards.** Selecting projects, documents, queues, counter groups or dashboards no longer means one click per card: click the first, hold shift and click the last, and everything between them comes with it. Shift-clicking away from a card you just unticked clears that run the same way.
+
 - **Nine sports packs.** Soccer, basketball, gridiron, hockey, baseball, volleyball, tennis, martial arts and fencing, each with the ground it is played on for a banner, a frame made of the equipment, and the object itself for a badge — a match ball's panels, a football's lacing, a face-off circle, a baseball's seam, a net, a string bed, a belt tied at the bottom, and a blade bent round to its own guard.
 
 - **A profile says which communities someone is in.** Only the ones that opted into the community directory — a community that never listed itself does not appear on anybody's profile, for anyone.

--- a/frontend/src/components/access/SelectableGridItem.test.tsx
+++ b/frontend/src/components/access/SelectableGridItem.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SelectableGridItem } from "./SelectableGridItem";
+
+describe("SelectableGridItem", () => {
+  it("renders children untouched outside selection mode", () => {
+    const onToggle = vi.fn();
+    render(
+      <SelectableGridItem active={false} selected={false} onToggle={onToggle} label="Card">
+        <a href="/somewhere">Open</a>
+      </SelectableGridItem>
+    );
+
+    expect(screen.getByRole("link", { name: "Open" })).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("reports whether shift was held so the list can extend a range", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <SelectableGridItem active selected={false} onToggle={onToggle} label="Card">
+        <span>Card</span>
+      </SelectableGridItem>
+    );
+
+    const overlay = screen.getByRole("button", { name: "Card" });
+
+    await user.click(overlay);
+    expect(onToggle).toHaveBeenLastCalledWith({ extend: false });
+
+    await user.keyboard("{Shift>}");
+    await user.click(overlay);
+    await user.keyboard("{/Shift}");
+    expect(onToggle).toHaveBeenLastCalledWith({ extend: true });
+  });
+});

--- a/frontend/src/components/access/SelectableGridItem.test.tsx
+++ b/frontend/src/components/access/SelectableGridItem.test.tsx
@@ -36,4 +36,25 @@ describe("SelectableGridItem", () => {
     await user.keyboard("{/Shift}");
     expect(onToggle).toHaveBeenLastCalledWith({ extend: true });
   });
+
+  it("extends from the keyboard too, where the overlay is the only stop", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <SelectableGridItem active selected={false} onToggle={onToggle} label="Card">
+        <span>Card</span>
+      </SelectableGridItem>
+    );
+
+    screen.getByRole("button", { name: "Card" }).focus();
+
+    await user.keyboard("{Enter}");
+    expect(onToggle).toHaveBeenLastCalledWith({ extend: false });
+
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+    expect(onToggle).toHaveBeenLastCalledWith({ extend: true });
+
+    await user.keyboard("{Shift>} {/Shift}");
+    expect(onToggle).toHaveBeenLastCalledWith({ extend: true });
+  });
 });

--- a/frontend/src/components/access/SelectableGridItem.tsx
+++ b/frontend/src/components/access/SelectableGridItem.tsx
@@ -1,13 +1,15 @@
 import { Check } from "lucide-react";
 import type { ReactNode } from "react";
 
+import type { GridToggleOptions } from "@/hooks/useGridSelection";
 import { cn } from "@/lib/utils";
 
 interface SelectableGridItemProps {
   /** Whether the list is in selection mode. When false, children render as-is. */
   active: boolean;
   selected: boolean;
-  onToggle: () => void;
+  /** Called with `extend` when the click held shift, asking for a range. */
+  onToggle: (options: GridToggleOptions) => void;
   children: ReactNode;
   label?: string;
 }
@@ -16,6 +18,9 @@ interface SelectableGridItemProps {
  * Wraps a grid card so it can be multi-selected without touching the card
  * component. In selection mode the card underneath is made non-interactive (its
  * link won't navigate) and a full-card toggle button + checkbox overlay is shown.
+ * Holding shift asks the list for a range from the last card clicked to this one
+ * — keyboard activation counts too, since Shift+Enter/Space fires a click with
+ * the modifier set.
  */
 export function SelectableGridItem({
   active,
@@ -35,11 +40,11 @@ export function SelectableGridItem({
       </div>
       <button
         type="button"
-        onClick={onToggle}
+        onClick={(event) => onToggle({ extend: event.shiftKey })}
         aria-pressed={selected}
         aria-label={label}
         className={cn(
-          "absolute inset-0 z-10 rounded-2xl ring-inset transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "absolute inset-0 z-10 select-none rounded-2xl ring-inset transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           selected ? "bg-primary/5 ring-2 ring-primary" : "hover:bg-muted/20"
         )}
       >

--- a/frontend/src/components/documents/DocumentsTagsView.tsx
+++ b/frontend/src/components/documents/DocumentsTagsView.tsx
@@ -8,6 +8,7 @@ import { PaginationBar } from "@/components/documents/PaginationBar";
 import { TagTreeView } from "@/components/tags/TagTreeView";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import type { GridToggleOptions } from "@/hooks/useGridSelection";
 
 export interface DocumentsTagsViewProps {
   documents: DocumentSummary[];
@@ -27,7 +28,7 @@ export interface DocumentsTagsViewProps {
    * cards become checkboxes while active. */
   selectionActive?: boolean;
   selectedDocumentIds?: Set<number>;
-  onToggleDocument?: (document: DocumentSummary) => void;
+  onToggleDocument?: (document: DocumentSummary, options?: GridToggleOptions) => void;
 }
 
 export const DocumentsTagsView = ({
@@ -102,7 +103,7 @@ export const DocumentsTagsView = ({
                   key={document.id}
                   active={selectionActive}
                   selected={selectedDocumentIds?.has(document.id) ?? false}
-                  onToggle={() => onToggleDocument?.(document)}
+                  onToggle={(options) => onToggleDocument?.(document, options)}
                   label={document.name}
                 >
                   <DocumentCard document={document} />

--- a/frontend/src/components/projects/ProjectListPanel.tsx
+++ b/frontend/src/components/projects/ProjectListPanel.tsx
@@ -113,7 +113,9 @@ export const ProjectListPanel = ({
     { value: "list", label: t("view.list"), icon: List },
   ];
 
-  const selection = useGridSelection<ProjectRead>();
+  // Ranges run along the order the cards render in — in selection mode
+  // that's `sortedProjects` (the pinned section is hidden while selecting).
+  const selection = useGridSelection<ProjectRead>(sortedProjects);
   // An archived project refuses sharing changes server-side, so the bulk
   // action is disabled up front rather than failing when the dialog submits.
   // Export is unaffected — it only reads.
@@ -168,7 +170,7 @@ export const ProjectListPanel = ({
           key={project.id}
           active
           selected={selection.selectedIds.has(project.id)}
-          onToggle={() => selection.toggle(project)}
+          onToggle={(options) => selection.toggle(project, options)}
           label={project.name}
         >
           <ProjectItem

--- a/frontend/src/hooks/useGridSelection.test.ts
+++ b/frontend/src/hooks/useGridSelection.test.ts
@@ -40,4 +40,49 @@ describe("useGridSelection", () => {
     expect(result.current.selectedItems.map((i) => i.id).sort()).toEqual([1, 9]);
     expect(result.current.selectedItems.find((i) => i.id === 1)?.name).toBe("page1");
   });
+
+  it("shift-click selects the run between the anchor and the clicked card", () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+    const { result } = renderHook(() => useGridSelection(items));
+
+    act(() => result.current.enter());
+    act(() => result.current.toggle({ id: 1 }));
+    act(() => result.current.toggle({ id: 4 }, { extend: true }));
+
+    expect([...result.current.selectedIds].sort()).toEqual([1, 2, 3, 4]);
+  });
+
+  it("shift-click clears the run when the anchor was just deselected", () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+    const { result } = renderHook(() => useGridSelection(items));
+
+    act(() => result.current.toggle({ id: 1 }));
+    act(() => result.current.toggle({ id: 4 }, { extend: true }));
+    // Deselect 3, then sweep back up to 1 — the anchor's state paints the run.
+    act(() => result.current.toggle({ id: 3 }));
+    act(() => result.current.toggle({ id: 1 }, { extend: true }));
+
+    expect([...result.current.selectedIds]).toEqual([4]);
+  });
+
+  it("shift-click is a plain toggle before anything has been clicked", () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const { result } = renderHook(() => useGridSelection(items));
+
+    act(() => result.current.toggle({ id: 3 }, { extend: true }));
+
+    expect([...result.current.selectedIds]).toEqual([3]);
+  });
+
+  it("forgets the anchor on exit, so the next list starts fresh", () => {
+    const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const { result } = renderHook(() => useGridSelection(items));
+
+    act(() => result.current.toggle({ id: 1 }));
+    act(() => result.current.exit());
+    act(() => result.current.enter());
+    act(() => result.current.toggle({ id: 3 }, { extend: true }));
+
+    expect([...result.current.selectedIds]).toEqual([3]);
+  });
 });

--- a/frontend/src/hooks/useGridSelection.ts
+++ b/frontend/src/hooks/useGridSelection.ts
@@ -1,4 +1,14 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { resolveCardClick } from "@/lib/selectionRange";
+
+/** Options a single card click carries. */
+export interface GridToggleOptions {
+  /** Shift was held — extend the selection from the last clicked card. */
+  extend?: boolean;
+}
+
+const NO_ITEMS: readonly never[] = [];
 
 /**
  * Multi-select state for a card/grid list (projects, queues, counter groups, …).
@@ -8,27 +18,52 @@ import { useCallback, useMemo, useState } from "react";
  * Selected items are stored **by value**, not derived from the current page, so a
  * selection survives pagination/filtering: pick items on page 1, page to page 2,
  * pick more, and all of them are acted on together.
+ *
+ * Pass the cards in the order they render to enable shift-click range selection;
+ * the range runs along that order.
  */
-export function useGridSelection<T extends { id: number }>() {
+export function useGridSelection<T extends { id: number }>(items: readonly T[] = NO_ITEMS) {
   const [active, setActive] = useState(false);
   const [selectedMap, setSelectedMap] = useState<Map<number, T>>(new Map());
+
+  // Only ever read from a click handler, so the latest render's list is the
+  // right one — a range is measured against what the user is looking at.
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const anchorRef = useRef<number | null>(null);
 
   const selectedItems = useMemo(() => [...selectedMap.values()], [selectedMap]);
   const selectedIds = useMemo(() => new Set(selectedMap.keys()), [selectedMap]);
 
-  const toggle = useCallback((item: T) => {
+  const toggle = useCallback((item: T, options?: GridToggleOptions) => {
+    // Read the anchor and the list *now*: React runs the updater below at render
+    // time, by which point the refs already describe the next click.
+    const anchorId = anchorRef.current;
+    const items = itemsRef.current;
+    anchorRef.current = item.id;
+
     setSelectedMap((prev) => {
+      const { add, remove } = resolveCardClick(item, {
+        items,
+        anchorId,
+        isSelected: (id) => prev.has(id),
+        extend: options?.extend,
+      });
       const next = new Map(prev);
-      if (next.has(item.id)) next.delete(item.id);
-      else next.set(item.id, item);
+      for (const id of remove) next.delete(id);
+      for (const added of add) next.set(added.id, added);
       return next;
     });
   }, []);
 
-  const clear = useCallback(() => setSelectedMap(new Map()), []);
+  const clear = useCallback(() => {
+    anchorRef.current = null;
+    setSelectedMap(new Map());
+  }, []);
 
   const enter = useCallback(() => setActive(true), []);
   const exit = useCallback(() => {
+    anchorRef.current = null;
     setActive(false);
     setSelectedMap(new Map());
   }, []);

--- a/frontend/src/lib/selectionRange.test.ts
+++ b/frontend/src/lib/selectionRange.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { itemsInRange, resolveCardClick } from "./selectionRange";
+
+const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }];
+
+describe("itemsInRange", () => {
+  it("returns the inclusive slice in either direction", () => {
+    expect(itemsInRange(items, 2, 4).map((i) => i.id)).toEqual([2, 3, 4]);
+    expect(itemsInRange(items, 4, 2).map((i) => i.id)).toEqual([2, 3, 4]);
+    expect(itemsInRange(items, 3, 3).map((i) => i.id)).toEqual([3]);
+  });
+
+  it("returns nothing when either end is missing from the list", () => {
+    expect(itemsInRange(items, 2, 99)).toEqual([]);
+    expect(itemsInRange(items, 99, 2)).toEqual([]);
+  });
+});
+
+describe("resolveCardClick", () => {
+  const click = (id: number, selected: number[], anchorId: number | null, extend?: boolean) =>
+    resolveCardClick(
+      { id },
+      { items, anchorId, isSelected: (candidate) => selected.includes(candidate), extend }
+    );
+
+  it("toggles a single card when shift is not held", () => {
+    expect(click(3, [], null)).toEqual({ add: [{ id: 3 }], remove: [] });
+    expect(click(3, [3], 3)).toEqual({ add: [], remove: [3] });
+  });
+
+  it("selects the whole run when shift-clicking from a selected anchor", () => {
+    const { add, remove } = click(4, [2], 2, true);
+    expect(add.map((i) => i.id)).toEqual([2, 3, 4]);
+    expect(remove).toEqual([]);
+  });
+
+  it("clears the run when shift-clicking from an unselected anchor", () => {
+    const { add, remove } = click(1, [1, 2], 3, true);
+    expect(add).toEqual([]);
+    expect(remove).toEqual([1, 2, 3]);
+  });
+
+  it("falls back to a plain toggle without a usable anchor", () => {
+    // Nothing clicked yet…
+    expect(click(2, [], null, true)).toEqual({ add: [{ id: 2 }], remove: [] });
+    // …the anchor is the card itself…
+    expect(click(2, [2], 2, true)).toEqual({ add: [], remove: [2] });
+    // …or the anchor was left behind on another page.
+    expect(click(2, [], 99, true)).toEqual({ add: [{ id: 2 }], remove: [] });
+  });
+});

--- a/frontend/src/lib/selectionRange.ts
+++ b/frontend/src/lib/selectionRange.ts
@@ -1,0 +1,70 @@
+/**
+ * Range selection for card grids — the shift-click gesture shared by every list
+ * that turns its cards into checkboxes (projects, documents, queues, counter
+ * groups, dashboards).
+ *
+ * The rules are the ones people already know from file managers and mail
+ * clients: a plain click flips one card and becomes the *anchor*; a shift-click
+ * paints every card between that anchor and the clicked one.
+ */
+
+/** Items between two ids in the visible order, inclusive of both ends. */
+export function itemsInRange<T extends { id: number }>(
+  items: readonly T[],
+  fromId: number,
+  toId: number
+): T[] {
+  const from = items.findIndex((item) => item.id === fromId);
+  const to = items.findIndex((item) => item.id === toId);
+  if (from === -1 || to === -1) {
+    return [];
+  }
+  return from <= to ? items.slice(from, to + 1) : items.slice(to, from + 1);
+}
+
+export interface CardClickOptions<T> {
+  /** The cards in the order they are rendered — the axis a range runs along. */
+  items: readonly T[];
+  /** The last card clicked, or null when nothing has been clicked yet. */
+  anchorId: number | null;
+  isSelected: (id: number) => boolean;
+  /** Shift was held. */
+  extend?: boolean;
+}
+
+/** The items a click adds to the selection and the ids it takes out. */
+export interface SelectionChange<T> {
+  add: T[];
+  remove: number[];
+}
+
+/**
+ * Resolve one click on a selectable card into the selection change it makes.
+ *
+ * A shift-click paints the run from the anchor to the clicked card with the
+ * *anchor's* state, so the same gesture both selects a run and clears one:
+ * shift-clicking from a selected anchor selects everything it reaches, and
+ * shift-clicking from one you just deselected clears them instead. Without a
+ * usable anchor — nothing clicked yet, or a range that spans two lists (e.g.
+ * the anchor was left behind on another page) — it falls back to a plain toggle.
+ */
+export function resolveCardClick<T extends { id: number }>(
+  item: T,
+  { items, anchorId, isSelected, extend }: CardClickOptions<T>
+): SelectionChange<T> {
+  const plainToggle = (): SelectionChange<T> =>
+    isSelected(item.id) ? { add: [], remove: [item.id] } : { add: [item], remove: [] };
+
+  if (!extend || anchorId === null || anchorId === item.id) {
+    return plainToggle();
+  }
+
+  const range = itemsInRange(items, anchorId, item.id);
+  if (range.length === 0) {
+    return plainToggle();
+  }
+
+  return isSelected(anchorId)
+    ? { add: range, remove: [] }
+    : { add: [], remove: range.map((ranged) => ranged.id) };
+}

--- a/frontend/src/pages/DocumentsPage.tsx
+++ b/frontend/src/pages/DocumentsPage.tsx
@@ -50,6 +50,7 @@ import {
   useDocumentsList,
   usePrefetchDocumentsList,
 } from "@/hooks/useDocuments";
+import type { GridToggleOptions } from "@/hooks/useGridSelection";
 import { useInitiativeAccess, useToolCreateAccess } from "@/hooks/useInitiativeAccess";
 import { useInitiatives } from "@/hooks/useInitiatives";
 import { usePersistedTableState } from "@/hooks/usePersistedTableState";
@@ -57,6 +58,7 @@ import { useTags } from "@/hooks/useTags";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { useGuildPath } from "@/lib/guildUrl";
 import { hasWriteAccess } from "@/lib/permissions";
+import { resolveCardClick } from "@/lib/selectionRange";
 import { buildTagTree, collectDescendantTagIds, findNodeByPath } from "@/lib/tagTree";
 import { toolDetailRoute } from "@/lib/tools";
 
@@ -446,14 +448,36 @@ export const DocumentsView = ({
     () => new Set(selectedDocuments.map((doc) => doc.id)),
     [selectedDocuments]
   );
-  const toggleDocumentSelection = useCallback((document: DocumentSummary) => {
-    setSelectedDocuments((prev) =>
-      prev.some((doc) => doc.id === document.id)
-        ? prev.filter((doc) => doc.id !== document.id)
-        : [...prev, document]
-    );
-  }, []);
+  // Shift-click extends from the last card clicked; the range runs along the
+  // order the cards render in, which the grid and tags views share. Both refs
+  // are read only from a click handler, so they describe what the user sees.
+  const selectionAnchorRef = useRef<number | null>(null);
+  const visibleDocumentsRef = useRef<DocumentSummary[]>([]);
+  const toggleDocumentSelection = useCallback(
+    (document: DocumentSummary, options?: GridToggleOptions) => {
+      // Read the anchor and the list *now*: React runs the updater below at
+      // render time, by which point the refs already describe the next click.
+      const anchorId = selectionAnchorRef.current;
+      const items = visibleDocumentsRef.current;
+      selectionAnchorRef.current = document.id;
+
+      setSelectedDocuments((prev) => {
+        const selectedIds = new Set(prev.map((doc) => doc.id));
+        const { add, remove } = resolveCardClick(document, {
+          items,
+          anchorId,
+          isSelected: (id) => selectedIds.has(id),
+          extend: options?.extend,
+        });
+        const removed = new Set(remove);
+        const kept = prev.filter((doc) => !removed.has(doc.id));
+        return [...kept, ...add.filter((doc) => !selectedIds.has(doc.id))];
+      });
+    },
+    []
+  );
   const exitCardSelection = useCallback(() => {
+    selectionAnchorRef.current = null;
     setCardSelectionActive(false);
     setSelectedDocuments([]);
   }, []);
@@ -461,6 +485,7 @@ export const DocumentsView = ({
   // hidden selection behind another view's bulk actions — every change starts
   // unselected.
   useEffect(() => {
+    selectionAnchorRef.current = null;
     setCardSelectionActive(false);
     setSelectedDocuments([]);
   }, [viewMode, status]);
@@ -596,6 +621,7 @@ export const DocumentsView = ({
 
   // Server handles untagged filtering via ?untagged=true param
   const displayDocuments = documents;
+  visibleDocumentsRef.current = displayDocuments;
 
   return (
     <div className="space-y-6">
@@ -761,7 +787,7 @@ export const DocumentsView = ({
                   key={document.id}
                   active={cardSelectionActive}
                   selected={selectedDocumentIds.has(document.id)}
-                  onToggle={() => toggleDocumentSelection(document)}
+                  onToggle={(options) => toggleDocumentSelection(document, options)}
                   label={document.name}
                 >
                   <DocumentCard document={document} />

--- a/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
+++ b/frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx
@@ -80,7 +80,7 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
     });
   };
 
-  const selection = useGridSelection<(typeof groups)[number]>();
+  const selection = useGridSelection<(typeof groups)[number]>(groups);
 
   const groupImport = useToolImportAction({
     tool: Tool.counter_group,
@@ -138,7 +138,7 @@ export const CounterGroupsView = ({ fixedInitiativeId, canCreate }: CountersView
                 key={group.id}
                 active={selection.active}
                 selected={selection.selectedIds.has(group.id)}
-                onToggle={() => selection.toggle(group)}
+                onToggle={(options) => selection.toggle(group, options)}
                 label={group.name}
               >
                 <CounterGroupCard group={group} />

--- a/frontend/src/pages/initiativeTools/dashboards/DashboardsPage.tsx
+++ b/frontend/src/pages/initiativeTools/dashboards/DashboardsPage.tsx
@@ -78,7 +78,7 @@ export const DashboardsView = ({ fixedInitiativeId, canCreate }: DashboardsViewP
     });
   };
 
-  const selection = useGridSelection<(typeof dashboards)[number]>();
+  const selection = useGridSelection<(typeof dashboards)[number]>(dashboards);
 
   return (
     <div className="space-y-6">
@@ -129,7 +129,7 @@ export const DashboardsView = ({ fixedInitiativeId, canCreate }: DashboardsViewP
                 key={dashboard.id}
                 active={selection.active}
                 selected={selection.selectedIds.has(dashboard.id)}
-                onToggle={() => selection.toggle(dashboard)}
+                onToggle={(options) => selection.toggle(dashboard, options)}
                 label={dashboard.name}
               >
                 <DashboardCard dashboard={dashboard} />

--- a/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
+++ b/frontend/src/pages/initiativeTools/queues/QueuesPage.tsx
@@ -119,7 +119,7 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
     });
   }, [queuesQuery.data, searchQuery, statusFilter]);
 
-  const selection = useGridSelection<(typeof queues)[number]>();
+  const selection = useGridSelection<(typeof queues)[number]>(queues);
 
   const queueImport = useToolImportAction({
     tool: Tool.queue,
@@ -192,7 +192,7 @@ export const QueuesView = ({ fixedInitiativeId, canCreate }: QueuesViewProps) =>
                 key={queue.id}
                 active={selection.active}
                 selected={selection.selectedIds.has(queue.id)}
-                onToggle={() => selection.toggle(queue)}
+                onToggle={(options) => selection.toggle(queue, options)}
                 label={queue.name}
               >
                 <QueueCard queue={queue} />


### PR DESCRIPTION
## Problem

Selection mode turns cards into checkboxes across six lists (projects, documents in both grid and tags views, queues, counter groups, dashboards), but picking a dozen of them meant a dozen individual clicks. The shared overlay in `SelectableGridItem` called `onToggle()` with no arguments, so the click's modifier keys never reached the list underneath.

Task: https://initiative.morels.me/g/3/i/5/projects/1/tasks/2739

## Changes

- New [selectionRange.ts](frontend/src/lib/selectionRange.ts) — the range logic as pure functions (`itemsInRange`, `resolveCardClick`), so the two selection stores share one behaviour instead of growing two copies.
- [useGridSelection.ts](frontend/src/hooks/useGridSelection.ts) takes the cards in render order and `toggle(item, { extend })`, tracks an anchor (the last card clicked), and forgets it on `exit`/`clear`.
- [SelectableGridItem.tsx](frontend/src/components/access/SelectableGridItem.tsx) passes `{ extend: event.shiftKey }`. Keyboard activation is covered too — Shift+Enter/Space fires a click with the modifier set.
- Wired at every call site: [ProjectListPanel](frontend/src/components/projects/ProjectListPanel.tsx), [QueuesPage](frontend/src/pages/initiativeTools/queues/QueuesPage.tsx), [CounterGroupsPage](frontend/src/pages/initiativeTools/counters/CounterGroupsPage.tsx), [DashboardsPage](frontend/src/pages/initiativeTools/dashboards/DashboardsPage.tsx), and [DocumentsPage](frontend/src/pages/DocumentsPage.tsx) + [DocumentsTagsView](frontend/src/components/documents/DocumentsTagsView.tsx) (documents keep their own selection state, shared with the table view).

**Behaviour.** A shift-click paints the run from the anchor to the clicked card with the *anchor's* state — so it selects a run, and shift-clicking from a card you just unticked clears one. With no usable anchor (nothing clicked yet, or the anchor left behind on another page) it falls back to a plain toggle, so the existing "a selection survives pagination" property still holds. The anchor moves to the last card clicked, GitHub-style, rather than staying pinned.

**Scope.** Cards only. The documents *table* view has its own TanStack row checkboxes and is untouched.

One subtlety worth flagging for review: React runs a `setState` updater at render time, so reading the anchor ref *inside* the updater sees the value the current click already overwrote. Both call sites snapshot the anchor and the list before calling `setState`.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check src` — clean
- `cd frontend && ./scripts/test-changed.sh` — 210 files, 2304 tests passed

New tests: [selectionRange.test.ts](frontend/src/lib/selectionRange.test.ts) (both range directions, missing ends, the four click outcomes), 4 cases added to [useGridSelection.test.ts](frontend/src/hooks/useGridSelection.test.ts) (select a run, clear a run, no-anchor fallback, anchor forgotten on exit), and a new [SelectableGridItem.test.tsx](frontend/src/components/access/SelectableGridItem.test.tsx) proving the `shiftKey` plumbing and that children render untouched outside selection mode.