### PR TITLE
Scope an admin's initiatives to what they joined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A community admin sees the initiatives they're in**, not every initiative in the community. That holds in the sidebar and on the community's front page alike: an admin reads the front page the way anyone else does — the initiatives they joined, then the ones on offer. Their authority over the community is unchanged; it simply no longer decides what they navigate. They put an initiative in front of themselves by joining it from the front page — an admin walks straight in rather than asking, whatever the initiative's joining setting — or by taking the project manager role in Settings › Initiatives, which still lists every initiative in the community.
 
+- **Promoting someone to community admin lifts the initiative roles they already hold.** A promotion changed their standing in the community and left every initiative membership they had on the role they joined with, so the app went on treating them as an ordinary member there — they were not told when somebody asked to join, and the waiting-requests count on the community front page read zero. Those rows now move to project manager with the promotion, and one that was left behind by an earlier promotion can be put right from the initiative's Members tab.
+
 - **Project managers can invite community admins into an initiative.** The invite used to be refused, because an admin can only hold the project manager role there. It now simply gives them that role, so a manager can add an admin without first working out who is one — and the member picker offers them like anybody else.
 
 - **"Browse the marketplace" sits next to the create button** on the dashboards list rather than behind the overflow menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **One emoji picker everywhere**, searchable and in your language.
 
-- **A community admin's sidebar lists the initiatives they're in**, not every initiative in the community.
+- **A community admin sees the initiatives they're in**, not every initiative in the community. That holds in the sidebar and on the community's front page alike: an admin reads the front page the way anyone else does — the initiatives they joined, then the ones on offer. Their authority over the community is unchanged; it simply no longer decides what they navigate. They put an initiative in front of themselves by joining it from the front page — an admin walks straight in rather than asking, whatever the initiative's joining setting — or by taking the project manager role in Settings › Initiatives, which still lists every initiative in the community.
+
+- **Project managers can invite community admins into an initiative.** The invite used to be refused, because an admin can only hold the project manager role there. It now simply gives them that role, so a manager can add an admin without first working out who is one — and the member picker offers them like anybody else.
 
 - **"Browse the marketplace" sits next to the create button** on the dashboards list rather than behind the overflow menu.
 

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -951,6 +951,11 @@ async def admin_update_guild_member_role(
 
     target_membership.role = payload.role
     session.add(target_membership)
+    # A promotion changes the guild role underneath initiative rows that already
+    # exist; bring them up to the manager role an admin's row carries.
+    await guilds_service.align_admin_initiative_roles(
+        session, guild_id=guild_id, user_id=user_id, role=payload.role
+    )
     await session.commit()
     # Guild role change (e.g. admin → member) may reduce content access — re-check
     # this user's live content streams immediately (matches the other paths).

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -1288,6 +1288,11 @@ async def update_guild_membership(
 
     target_membership.role = payload.role
     session.add(target_membership)
+    # A promotion changes the guild role underneath initiative rows that already
+    # exist; bring them up to the manager role an admin's row carries.
+    await guilds_service.align_admin_initiative_roles(
+        session, guild_id=guild_id, user_id=user_id, role=payload.role
+    )
     await session.commit()
     # Guild-level access change (e.g. admin → member loses the guild-admin
     # bypass): re-check this user's live content streams now so the change takes

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -31,7 +31,7 @@ from app.models.tenant.initiative import (
     JoinRequestStatus,
     PermissionKey,
 )
-from app.models.platform.guild import GuildMembership, GuildRole
+from app.models.platform.guild import GuildRole
 from app.models.tenant.task import Task, TaskAssignee
 from app.models.platform.user import User
 from app.schemas.tenant.initiative import (
@@ -154,23 +154,23 @@ async def _guard_guild_admin_role(
     guild_id: int,
     target_user_id: int,
     role: InitiativeRoleModel | None,
-    guild_membership: GuildMembership | None = None,
 ) -> None:
     """Restrict which initiative roles a guild admin may be assigned.
 
     A guild admin already has complete access to every initiative in their
-    guild (see ``role_context.is_request_guild_admin``), so they are implicit
-    full-access members. They may *additionally* hold a manager role — purely
-    for manager-style features like notifications — but must never be assigned a
-    standard member or custom role. This keeps the admin's standing access
-    distinct from per-initiative DAC and is enforced server-side for safety.
+    guild (see ``role_context.is_request_guild_admin``), so their membership
+    row carries a manager role — purely for manager-style features like
+    notifications — and never a standard member or custom one. Every route that
+    *creates* a row settles that itself
+    (:func:`initiatives_service.resolve_membership_role`); this is the backstop
+    for the one route that only ever changes an existing role, where silently
+    substituting would answer a question nobody asked.
     """
     if role is not None and role.is_manager:
         return  # manager role is the one allowed elevation for an admin
-    membership = guild_membership or await guilds_service.get_membership(
+    if await initiatives_service.is_guild_admin_member(
         session, guild_id=guild_id, user_id=target_user_id
-    )
-    if membership and membership.role == GuildRole.admin:
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=InitiativeMessages.GUILD_ADMIN_ROLE_RESTRICTED,
@@ -267,8 +267,10 @@ async def list_initiative_directory(
     Open to every guild member — it lists only what each initiative published
     about itself (name, description, colour, roster size), never its content.
     Initiatives whose policy is ``private`` are listed only to their own
-    members — and to guild admins, whose standing already reaches every
-    initiative in the guild.
+    members, guild admins included: an admin's authority over the guild is
+    unchanged, but the front page shows what they are in and what is on offer,
+    read the same way for everyone. ``/initiatives/?scope=guild`` is the
+    whole-guild listing, and guild settings is where it is managed.
 
     Declared before ``/{initiative_id}`` so the literal path wins the match.
     """
@@ -276,7 +278,6 @@ async def list_initiative_directory(
         session,
         guild_id=guild_context.guild_id,
         user_id=current_user.id,
-        include_unlisted=rls_service.is_guild_admin(guild_context.role),
     )
 
 
@@ -292,6 +293,11 @@ async def join_initiative(
     Idempotent: already being a member is a success, not a conflict. Any other
     join policy answers 403 — the same answer for ``private`` and ``request``,
     so it says only "not by this route".
+
+    A guild admin walks in whatever the policy says, and on the manager role:
+    the queue exists to exercise an authority they already hold, and staffing
+    themselves onto an initiative is how they bring it into their own
+    navigation. It is the same act as ticking themselves in guild settings.
     """
     # A scoped grantee reaches this guild for a window; the membership row this
     # would create has no end date, so joining is for real guild members.
@@ -304,7 +310,9 @@ async def join_initiative(
     initiative = await _get_initiative_or_404(
         initiative_id, session, guild_context.guild_id
     )
-    if not initiatives_service.is_self_joinable(initiative):
+    if not initiatives_service.is_self_joinable(
+        initiative
+    ) and not rls_service.is_guild_admin(guild_context.role):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=InitiativeMessages.NOT_JOINABLE,
@@ -400,16 +408,6 @@ async def _resolve_join_request(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=AuthMessages.USER_NOT_FOUND
         )
-    if approved:
-        # A guild admin is an implicit full-access member and must never hold a
-        # standard member role; if the requester was promoted while the request
-        # sat in the queue, say so rather than writing the row.
-        await _guard_guild_admin_role(
-            session,
-            guild_id=initiative.guild_id,
-            target_user_id=request.user_id,
-            role=None,
-        )
     try:
         await initiatives_service.resolve_join_request(
             session, request=request, resolver_id=current_user.id, approved=approved
@@ -479,9 +477,9 @@ async def create_join_request(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=InitiativeMessages.NOT_REQUESTABLE,
         )
-    # A guild admin already reaches every initiative in their guild, so there is
-    # nothing here to ask for — and the membership row an approval would write
-    # is one they must never hold (see ``_guard_guild_admin_role``).
+    # A guild admin holds the authority this queue exercises, so they walk in
+    # (``POST /join``, which takes them whatever the policy says) rather than
+    # knocking and waiting for a member to answer.
     if rls_service.is_guild_admin(guild_context.role):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -1332,7 +1330,12 @@ async def add_initiative_member(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
 ) -> InitiativeRead:
-    """Add a member to an initiative or update their role."""
+    """Add a member to an initiative or update their role.
+
+    Any project manager may bring in any member of the guild, guild admins
+    included — an admin simply lands on the manager role their standing already
+    implies, whatever role the invite named.
+    """
     initiative = await _get_initiative_or_404(
         initiative_id, session, guild_context.guild_id
     )
@@ -1360,38 +1363,34 @@ async def add_initiative_member(
             detail=InitiativeMessages.USER_NOT_IN_GUILD,
         )
 
-    # Get the role to assign (default to member role if not specified)
-    role_id = payload.role_id
-    if role_id is None:
-        resolved_role = await initiatives_service.get_member_role(
-            session, initiative_id=initiative_id
-        )
-        if not resolved_role:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=InitiativeMessages.MEMBER_ROLE_NOT_FOUND,
-            )
-        role_id = resolved_role.id
-    else:
+    requested_role = None
+    if payload.role_id is not None:
         # Verify role exists and belongs to this initiative
-        resolved_role = await initiatives_service.get_role_by_id(
-            session, role_id=role_id, initiative_id=initiative_id
+        requested_role = await initiatives_service.get_role_by_id(
+            session, role_id=payload.role_id, initiative_id=initiative_id
         )
-        if not resolved_role:
+        if not requested_role:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=InitiativeMessages.ROLE_NOT_FOUND,
             )
 
-    # Guild admins are implicit full-access members; they may only be elevated
-    # to a manager role, never assigned a standard member or custom role.
-    await _guard_guild_admin_role(
+    # The role the row actually takes: what was asked for, the built-in member
+    # role when nothing was, or the manager role for a guild admin — whose
+    # standing already reaches the initiative. Settling it here is what lets a
+    # project manager invite an admin without knowing they are one.
+    resolved_role = await initiatives_service.resolve_membership_role(
         session,
-        guild_id=initiative.guild_id,
-        target_user_id=payload.user_id,
-        role=resolved_role,
-        guild_membership=guild_membership,
+        initiative=initiative,
+        user_id=payload.user_id,
+        requested=requested_role,
     )
+    if not resolved_role:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=InitiativeMessages.MEMBER_ROLE_NOT_FOUND,
+        )
+    role_id = resolved_role.id
 
     stmt = select(InitiativeMember).where(
         InitiativeMember.initiative_id == initiative_id,

--- a/backend/app/api/v1/tenant_endpoints/initiatives.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives.py
@@ -278,6 +278,7 @@ async def list_initiative_directory(
         session,
         guild_id=guild_context.guild_id,
         user_id=current_user.id,
+        is_guild_admin=rls_service.is_guild_admin(guild_context.role),
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -910,12 +910,16 @@ async def test_member_roster_reports_a_custom_role_as_itself(
 
 
 @pytest.mark.integration
-async def test_guild_admin_cannot_be_assigned_member_role(
+async def test_inviting_a_guild_admin_lands_them_on_the_manager_role(
     client: AsyncClient, session: AsyncSession, acting_user
 ):
-    """A guild admin is an implicit full-access member; assigning them a
-    standard member (or custom) role is rejected — they may only be elevated to
-    a manager role."""
+    """An invite naming a standard role for a guild admin still succeeds.
+
+    A guild admin's standing already reaches every initiative, so their row
+    carries the manager role — the invite settles that rather than refusing,
+    which is what lets a project manager add an admin without first checking
+    who is one.
+    """
     from app.models.tenant.initiative import InitiativeRoleModel
     from sqlmodel import select
 
@@ -939,8 +943,36 @@ async def test_guild_admin_cannot_be_assigned_member_role(
         json={"user_id": target_admin.user.id, "role_id": member_role.id},
     )
 
-    assert response.status_code == 400
-    assert response.json()["detail"] == "INITIATIVE_GUILD_ADMIN_ROLE_RESTRICTED"
+    assert response.status_code == 200
+    member_roles = {m["user"]["id"]: m["role_name"] for m in response.json()["members"]}
+    assert member_roles[target_admin.user.id] == "project_manager"
+
+
+@pytest.mark.integration
+async def test_a_project_manager_can_invite_a_guild_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The invite is the project manager's to make, on their own initiative."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    manager = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="project_manager",
+    )
+    target_admin = await acting_user(
+        guild_role=GuildRole.admin, guild=admin.guild, email="admin3@example.com"
+    )
+
+    response = await client.post(
+        manager.g(f"/initiatives/{admin.initiative.id}/members"),
+        headers=manager.headers,
+        json={"user_id": target_admin.user.id},
+    )
+
+    assert response.status_code == 200
+    member_roles = {m["user"]["id"]: m["role_name"] for m in response.json()["members"]}
+    assert member_roles[target_admin.user.id] == "project_manager"
 
 
 @pytest.mark.integration
@@ -1179,18 +1211,22 @@ async def test_directory_lists_private_initiatives_to_their_members(
 
 
 @pytest.mark.integration
-async def test_directory_lists_everything_to_a_guild_admin(
+async def test_directory_reads_the_same_way_for_a_guild_admin(
     client: AsyncClient, session: AsyncSession, acting_user
 ):
-    """A guild admin's directory is the whole guild.
+    """A guild admin's directory is theirs plus what is on offer.
 
-    Their standing already reaches every initiative (the `current_guild_role=
-    'admin'` RLS leg), and the deprecated initiatives page showed them all —
-    so the directory does too, membership still ordered first.
+    Their authority over the guild is unchanged; the front page just stops
+    standing in for it. A private initiative they are not in is not listed to
+    them any more than to anyone else — ``scope=guild`` is where the whole
+    guild is, and guild settings is where it is staffed.
     """
     owner = await acting_user(guild_role=GuildRole.admin)
     await create_initiative(
         session, owner.guild, owner.user, name="Hidden", join_policy="private"
+    )
+    await create_initiative(
+        session, owner.guild, owner.user, name="Askable", join_policy="open"
     )
 
     other_admin = await acting_user(guild_role=GuildRole.admin, guild=owner.guild)
@@ -1199,9 +1235,9 @@ async def test_directory_lists_everything_to_a_guild_admin(
     )
 
     assert response.status_code == 200
-    listed = {entry["name"]: entry for entry in response.json()}
-    assert "Hidden" in listed
-    assert listed["Hidden"]["is_member"] is False
+    listed = {entry["name"] for entry in response.json()}
+    assert "Hidden" not in listed
+    assert "Askable" in listed
 
 
 @pytest.mark.integration
@@ -1352,6 +1388,35 @@ async def test_self_join_rejected_for_non_open_policy(
 
     assert response.status_code == 403
     assert response.json()["detail"] == "INITIATIVE_NOT_JOINABLE"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("policy", ["private", "request"])
+async def test_a_guild_admin_walks_into_a_closed_initiative_as_manager(
+    client: AsyncClient, session: AsyncSession, acting_user, policy: str
+):
+    """A guild admin joins whatever the policy says, on the manager role.
+
+    Their sidebar is their memberships now, so this is how they put an
+    initiative in it — the same act as ticking themselves in guild settings,
+    and the reason they never have to knock at a queue they could answer.
+    """
+    owner = await acting_user(guild_role=GuildRole.admin)
+    initiative = await create_initiative(
+        session, owner.guild, owner.user, name=f"Closed {policy}", join_policy=policy
+    )
+    admin = await acting_user(guild_role=GuildRole.admin, guild=owner.guild)
+
+    response = await client.post(
+        admin.g(f"/initiatives/{initiative.id}/join"), headers=admin.headers
+    )
+
+    assert response.status_code == 200
+    entry = next(
+        m for m in response.json()["members"] if m["user"]["id"] == admin.user.id
+    )
+    assert entry["role_name"] == "project_manager"
+    assert entry["is_manager"] is True
 
 
 @pytest.mark.integration
@@ -2518,12 +2583,14 @@ async def test_directory_badges_the_queue_for_managers_only(
     assert entry["pending_join_request_count"] == 0
     assert entry["has_pending_request"] is True
 
+    # A guild admin outside the initiative is a bystander here like anyone
+    # else: they staff themselves onto it to take the queue.
     admin = await acting_user(guild_role=GuildRole.admin, guild=manager.guild)
     as_admin = await client.get(
         admin.g("/initiatives/directory"), headers=admin.headers
     )
     entry = next(e for e in as_admin.json() if e["id"] == initiative.id)
-    assert entry["pending_join_request_count"] == 1
+    assert entry["pending_join_request_count"] == 0
 
 
 def _capture_join_request_emails(monkeypatch) -> list[dict]:

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -949,6 +949,81 @@ async def test_inviting_a_guild_admin_lands_them_on_the_manager_role(
 
 
 @pytest.mark.integration
+async def test_promotion_to_guild_admin_lifts_existing_initiative_roles(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A promotion reaches the rows the person already held.
+
+    Their guild role changes underneath initiative memberships that already
+    exist, and only this path can bring them up to the manager role an admin's
+    row carries — everything that writes a row settles it for itself.
+    """
+    from app.testing.schema_harness import route_session_to_guild
+
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    joiner = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+
+    response = await client.patch(
+        f"/api/v1/guilds/{admin.guild.id}/members/{joiner.user.id}",
+        headers=admin.headers,
+        json={"role": "admin"},
+    )
+    assert response.status_code == 204, response.text
+
+    await route_session_to_guild(session, admin.guild.id)
+    membership = (
+        await session.exec(
+            select(InitiativeMember).where(
+                InitiativeMember.initiative_id == admin.initiative.id,
+                InitiativeMember.user_id == joiner.user.id,
+            )
+        )
+    ).one()
+    role = await initiatives_service.get_role_by_id(session, role_id=membership.role_id)
+    assert role is not None and role.is_manager
+
+
+@pytest.mark.integration
+async def test_the_queue_badge_survives_a_role_a_promotion_left_behind(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """A guild admin inside an initiative reads its queue whatever their row says.
+
+    Answering a request is authority they hold as admin, so the badge follows
+    the standing rather than the role their membership row happens to carry.
+    """
+    manager = await acting_user(guild_role=GuildRole.member)
+    initiative = await _requestable(session, manager, name="Knockable")
+    admin = await acting_user(
+        guild_role=GuildRole.admin,
+        guild=manager.guild,
+        initiative=initiative,
+        initiative_role="member",
+    )
+    created = await client.post(
+        manager.g(f"/initiatives/{initiative.id}/join-requests"),
+        headers=(
+            await acting_user(guild_role=GuildRole.member, guild=manager.guild)
+        ).headers,
+        json={},
+    )
+    assert created.status_code == 201, created.text
+
+    response = await client.get(
+        admin.g("/initiatives/directory"), headers=admin.headers
+    )
+
+    assert response.status_code == 200
+    entry = next(e for e in response.json() if e["id"] == initiative.id)
+    assert entry["pending_join_request_count"] == 1
+
+
+@pytest.mark.integration
 async def test_a_project_manager_can_invite_a_guild_admin(
     client: AsyncClient, session: AsyncSession, acting_user
 ):

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -286,6 +286,54 @@ async def enroll_new_member_in_auto_join_initiatives(
         )
 
 
+async def align_admin_initiative_roles(
+    session: AsyncSession,
+    *,
+    guild_id: int,
+    user_id: int,
+    role: GuildRole,
+) -> None:
+    """Bring a freshly promoted guild admin's initiative rows up to their standing.
+
+    A guild admin's membership row carries a manager role, which every write
+    path settles for itself. A promotion changes the guild role and nothing
+    else, so the rows the person already held are reconciled here — the one
+    moment their standing changes underneath rows that already exist.
+
+    Only a promotion to admin does anything; a demotion leaves the manager role
+    in place, which is an ordinary initiative role for an ordinary member to
+    hold, and taking it away would be a second decision nobody asked for.
+
+    The initiatives live in the guild's schema and this runs on the system
+    engine with ``search_path = public``, so the work is done through a routed
+    excursion that hands the session back as it found it. The whole excursion
+    sits inside a savepoint: the role change is the thing being asked for, and
+    reconciling rows underneath it must never be what makes it fail. Flush-only;
+    the caller owns the transaction.
+    """
+    if role != GuildRole.admin:
+        return
+    from app.db.session import guild_schema_context
+    from app.services.tenant import initiatives as initiatives_service
+
+    try:
+        async with session.begin_nested():
+            async with guild_schema_context(session, guild_id=guild_id):
+                # A second savepoint so a failure unwinds before the excursion
+                # restores the caller's context, rather than during it.
+                async with session.begin_nested():
+                    await initiatives_service.align_guild_admin_membership_roles(
+                        session, guild_id=guild_id, user_id=user_id
+                    )
+    except Exception:
+        logger.exception(
+            "admin promotion: user %s became an admin of guild %s but their "
+            "existing initiative roles were not reconciled",
+            user_id,
+            guild_id,
+        )
+
+
 # Advisory-lock namespace for per-guild membership-cap admission. A fixed ASCII
 # tag ("USER") so the two-int key (namespace, guild_id) can't collide with the
 # storage-quota ("STOR") or (user_id, guild_id) advisory locks used elsewhere.

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -252,11 +252,10 @@ async def enroll_new_member_in_auto_join_initiatives(
     onboarding hook rather than a sweep: someone who was already in the guild
     is returned earlier and is never re-enrolled.
 
-    A guild admin is skipped. They already reach every initiative in their guild
-    by standing, and the built-in ``member`` role is one they must never hold
-    (see ``_guard_guild_admin_role``) — so for them there is nothing to grant and
-    a row to avoid. This also covers guild creation, where the admin membership
-    is written before the guild's schema exists at all.
+    A guild admin is skipped. Their membership row is written before the guild's
+    schema exists at all — guild creation is the case — and their standing
+    already reaches every initiative, so nothing here is theirs to be handed.
+    They pick which initiatives they navigate by joining them.
 
     The initiatives live in the guild's schema and the join paths that reach here
     run on the system engine with ``search_path = public``, so the work is done

--- a/backend/app/services/tenant/initiatives.py
+++ b/backend/app/services/tenant/initiatives.py
@@ -121,6 +121,53 @@ async def resolve_membership_role(
     return await get_member_role(session, initiative_id=initiative.id)
 
 
+async def align_guild_admin_membership_roles(
+    session: AsyncSession,
+    *,
+    guild_id: int,
+    user_id: int,
+) -> list[int]:
+    """Move ``user_id``'s existing initiative rows onto a manager role.
+
+    A guild admin's membership row carries a manager role.
+    :func:`resolve_membership_role` settles that for every row written from
+    here on; this settles the rows that were already there when they were
+    promoted, so everything that reads ``is_manager`` — the join-request queue
+    and the notifications that follow it, the directory's queue badge — agrees
+    with the standing they now hold.
+
+    Rows already on a manager role are left alone, as is an initiative with no
+    project manager role to move them to. Returns the initiative ids changed.
+
+    The session must already be routed into the guild's schema; flush-only, the
+    caller owns the transaction.
+    """
+    rows = (
+        await session.exec(
+            select(InitiativeMember)
+            .options(selectinload(InitiativeMember.role_ref))
+            .where(
+                InitiativeMember.guild_id == guild_id,
+                InitiativeMember.user_id == user_id,
+            )
+        )
+    ).all()
+
+    changed: list[int] = []
+    for membership in rows:
+        if membership.role_ref is not None and membership.role_ref.is_manager:
+            continue
+        pm_role = await get_pm_role(session, initiative_id=membership.initiative_id)
+        if pm_role is None:
+            continue
+        membership.role_id = pm_role.id
+        session.add(membership)
+        changed.append(membership.initiative_id)
+    if changed:
+        await session.flush()
+    return changed
+
+
 async def create_builtin_roles(
     session: AsyncSession,
     *,
@@ -630,6 +677,7 @@ async def list_directory_entries(
     *,
     guild_id: int,
     user_id: int,
+    is_guild_admin: bool = False,
 ) -> list[InitiativeDirectoryEntry]:
     """The guild's initiative directory, as seen by one caller.
 
@@ -646,7 +694,10 @@ async def list_directory_entries(
     ``scope=guild`` on the initiatives endpoint, which backs guild settings.
 
     Managers additionally get the size of their own join-request queue, so the
-    guild home needs no second call to badge it.
+    guild home needs no second call to badge it. A guild admin gets it for the
+    initiatives they are in, whatever role their own row happens to carry —
+    answering a request is authority they hold as admin. It stays off the
+    initiatives they are not in, which are not theirs to read into.
     """
     member_count = (
         select(func.count())
@@ -671,9 +722,10 @@ async def list_directory_entries(
         )
         .exists()
     )
-    # The queue badge, and only for a manager of that initiative. Everyone else
-    # reads a flat zero instead of a headcount of their peers' knocking, and
-    # the CASE means the count is not computed for them at all.
+    # The queue badge, and only for whoever may answer the queue: a manager of
+    # that initiative, or a guild admin who is in it. Everyone else reads a flat
+    # zero instead of a headcount of their peers' knocking, and the CASE means
+    # the count is not computed for them at all.
     manages = (
         select(InitiativeMember.user_id)
         .join(InitiativeRoleModel, InitiativeRoleModel.id == InitiativeMember.role_id)
@@ -693,7 +745,8 @@ async def list_directory_entries(
         )
         .scalar_subquery()
     )
-    pending_queue_size = case((manages, pending_count), else_=0)
+    may_answer = or_(manages, is_member) if is_guild_admin else manages
+    pending_queue_size = case((may_answer, pending_count), else_=0)
 
     statement = (
         select(

--- a/backend/app/services/tenant/initiatives.py
+++ b/backend/app/services/tenant/initiatives.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import logging
 from typing import Iterable
 
-from sqlalchemy import case, desc, func, or_, true
+from sqlalchemy import case, desc, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import aliased, selectinload
 from sqlmodel import select, delete, update
@@ -23,6 +23,7 @@ from app.models.tenant.initiative import (
     JoinRequestStatus,
     PermissionKey,
 )
+from app.models.platform.guild import GuildMembership, GuildRole
 from app.models.platform.user import User
 from app.schemas.platform.user import UserInitiativeRole, UserSummary
 from app.schemas.tenant.initiative import (
@@ -72,6 +73,52 @@ async def get_member_role(
     return await get_role_by_name(
         session, initiative_id=initiative_id, role_name="member"
     )
+
+
+async def is_guild_admin_member(
+    session: AsyncSession,
+    *,
+    guild_id: int,
+    user_id: int,
+) -> bool:
+    """Whether ``user_id`` holds the admin role in ``guild_id``."""
+    result = await session.exec(
+        select(GuildMembership.role).where(
+            GuildMembership.guild_id == guild_id,
+            GuildMembership.user_id == user_id,
+        )
+    )
+    return result.one_or_none() == GuildRole.admin
+
+
+async def resolve_membership_role(
+    session: AsyncSession,
+    *,
+    initiative: Initiative,
+    user_id: int,
+    requested: InitiativeRoleModel | None = None,
+) -> InitiativeRoleModel | None:
+    """The role a membership row takes for ``user_id`` — the one rule every
+    route into an initiative resolves its role through.
+
+    A guild admin's standing already reaches every initiative in their guild,
+    so their row carries a manager role: the built-in project manager unless a
+    manager role was named. That is settled here rather than refused, so a
+    project manager can bring an admin into their initiative like anyone else.
+
+    Everyone else takes ``requested``, or the built-in ``member`` role when the
+    caller names none. ``None`` means the initiative has no role to give, which
+    is the caller's error to report.
+    """
+    if await is_guild_admin_member(
+        session, guild_id=initiative.guild_id, user_id=user_id
+    ):
+        if requested is not None and requested.is_manager:
+            return requested
+        return await get_pm_role(session, initiative_id=initiative.id)
+    if requested is not None:
+        return requested
+    return await get_member_role(session, initiative_id=initiative.id)
 
 
 async def create_builtin_roles(
@@ -583,7 +630,6 @@ async def list_directory_entries(
     *,
     guild_id: int,
     user_id: int,
-    include_unlisted: bool = False,
 ) -> list[InitiativeDirectoryEntry]:
     """The guild's initiative directory, as seen by one caller.
 
@@ -592,8 +638,12 @@ async def list_directory_entries(
     the guild's complete initiative list. Each entry carries its roster size
     and the caller's own state (in it / knocked / free to join) so the client
     renders one call to action per card. A private initiative the caller is
-    *not* in stays unlisted, exactly as before — unless ``include_unlisted``
-    says the caller's standing already reaches everything (a guild admin).
+    *not* in stays unlisted.
+
+    One reading for everyone, guild admin included: their authority still
+    reaches every initiative, but the front page lists the ones they are in and
+    the ones on offer, the same as anyone else. The whole-guild listing is
+    ``scope=guild`` on the initiatives endpoint, which backs guild settings.
 
     Managers additionally get the size of their own join-request queue, so the
     guild home needs no second call to badge it.
@@ -621,8 +671,7 @@ async def list_directory_entries(
         )
         .exists()
     )
-    # The queue badge, and only for whoever may open the queue: a manager of
-    # that initiative, or a guild admin (``include_unlisted``). Everyone else
+    # The queue badge, and only for a manager of that initiative. Everyone else
     # reads a flat zero instead of a headcount of their peers' knocking, and
     # the CASE means the count is not computed for them at all.
     manages = (
@@ -644,9 +693,7 @@ async def list_directory_entries(
         )
         .scalar_subquery()
     )
-    pending_queue_size = case(
-        (true() if include_unlisted else manages, pending_count), else_=0
-    )
+    pending_queue_size = case((manages, pending_count), else_=0)
 
     statement = (
         select(
@@ -658,9 +705,7 @@ async def list_directory_entries(
         )
         .where(
             Initiative.guild_id == guild_id,
-            true()
-            if include_unlisted
-            else or_(Initiative.join_policy.in_(LISTED_JOIN_POLICIES), is_member),
+            or_(Initiative.join_policy.in_(LISTED_JOIN_POLICIES), is_member),
             Initiative.is_archived.is_(False),
             Initiative.deleted_at.is_(None),
         )
@@ -701,13 +746,17 @@ async def self_join(
     initiative: Initiative,
     user_id: int,
 ) -> InitiativeMember:
-    """Add ``user_id`` to ``initiative`` with the built-in ``member`` role.
+    """Add ``user_id`` to ``initiative`` with the role their standing earns.
 
     The floor, not the ceiling: ``member`` is view-only on the core tools and
     creates nothing, and per-resource sharing still decides what is reachable
     inside. The row is ordinary — ``oidc_managed`` false, so group sync neither
     reaps it nor fights it — which is the whole point: every join path ends at
     the same membership row RLS already reads.
+
+    The role comes from :func:`resolve_membership_role`, so a guild admin
+    arriving by any of these routes lands on the manager role their standing
+    already implies.
 
     Idempotent — an existing membership is returned untouched. Flush-only; the
     caller owns the transaction. The policy check is the caller's
@@ -719,14 +768,16 @@ async def self_join(
     if existing is not None:
         return existing
 
-    member_role = await get_member_role(session, initiative_id=initiative.id)
-    if member_role is None:
+    role = await resolve_membership_role(
+        session, initiative=initiative, user_id=user_id
+    )
+    if role is None:
         raise ValueError(InitiativeMessages.MEMBER_ROLE_NOT_FOUND)
 
     membership = InitiativeMember(
         initiative_id=initiative.id,
         user_id=user_id,
-        role_id=member_role.id,
+        role_id=role.id,
         guild_id=initiative.guild_id,
         oidc_managed=False,
     )
@@ -784,8 +835,8 @@ async def enroll_in_auto_join_initiatives(
     """Enrol a brand-new guild member in the guild's auto-join initiatives.
 
     Each enrolment routes through :func:`self_join`, so an arrival lands on the
-    same membership row every other join path writes — built-in ``member`` role,
-    ``oidc_managed`` false, so group sync neither reaps nor fights it.
+    same membership row every other join path writes — ``oidc_managed`` false,
+    so group sync neither reaps nor fights it.
 
     Best effort, per initiative: one initiative that cannot take a member (its
     built-in ``member`` role is missing, say) is logged and skipped inside its
@@ -926,9 +977,9 @@ async def resolve_join_request(
     """Settle a pending request, creating the membership row on approval.
 
     Approval routes through :func:`self_join`, so an approved requester lands on
-    exactly the row every other join path produces — built-in ``member`` role,
-    ``oidc_managed`` false — and someone who became a member by another route
-    while the request sat in the queue is absorbed rather than colliding.
+    exactly the row every other join path produces — ``oidc_managed`` false —
+    and someone who became a member by another route while the request sat in
+    the queue is absorbed rather than colliding.
 
     The row is claimed before anything is granted: one UPDATE that fires only
     while the status is still ``pending``, so two managers answering at once

--- a/frontend/src/api/generated/initiatives/initiatives.ts
+++ b/frontend/src/api/generated/initiatives/initiatives.ts
@@ -340,8 +340,10 @@ export const useCreateInitiativeApiV1GGuildIdInitiativesPost = <
  * Open to every guild member — it lists only what each initiative published
  * about itself (name, description, colour, roster size), never its content.
  * Initiatives whose policy is ``private`` are listed only to their own
- * members — and to guild admins, whose standing already reaches every
- * initiative in the guild.
+ * members, guild admins included: an admin's authority over the guild is
+ * unchanged, but the front page shows what they are in and what is on offer,
+ * read the same way for everyone. ``/initiatives/?scope=guild`` is the
+ * whole-guild listing, and guild settings is where it is managed.
  *
  * Declared before ``/{initiative_id}`` so the literal path wins the match.
  * @summary List Initiative Directory
@@ -514,6 +516,11 @@ export function useListInitiativeDirectoryApiV1GGuildIdInitiativesDirectoryGet<
  * Idempotent: already being a member is a success, not a conflict. Any other
  * join policy answers 403 — the same answer for ``private`` and ``request``,
  * so it says only "not by this route".
+ *
+ * A guild admin walks in whatever the policy says, and on the manager role:
+ * the queue exists to exercise an authority they already hold, and staffing
+ * themselves onto an initiative is how they bring it into their own
+ * navigation. It is the same act as ticking themselves in guild settings.
  * @summary Join Initiative
  */
 export const joinInitiativeApiV1GGuildIdInitiativesInitiativeIdJoinPost = (
@@ -2871,6 +2878,10 @@ export function useGetInitiativeMembersApiV1GGuildIdInitiativesInitiativeIdMembe
 
 /**
  * Add a member to an initiative or update their role.
+ *
+ * Any project manager may bring in any member of the guild, guild admins
+ * included — an admin simply lands on the manager role their standing already
+ * implies, whatever role the invite named.
  * @summary Add Initiative Member
  */
 export const addInitiativeMemberApiV1GGuildIdInitiativesInitiativeIdMembersPost = (

--- a/frontend/src/components/guildHome/InitiativeDirectory.test.tsx
+++ b/frontend/src/components/guildHome/InitiativeDirectory.test.tsx
@@ -131,15 +131,15 @@ describe("InitiativeDirectory", () => {
     expect(screen.queryByRole("button", { name: "Join" })).not.toBeInTheDocument();
   });
 
-  it("hands a guild admin the whole guild, entered by standing", async () => {
+  it("does not file an initiative an admin has not joined as theirs", async () => {
     renderPage(
       () => (
         <InitiativeDirectory
           entries={[
             buildInitiativeDirectoryEntry({
               id: 11,
-              name: "Hidden",
-              join_policy: "private",
+              name: "Knockable",
+              join_policy: "request",
               is_member: false,
             }),
           ]}
@@ -148,13 +148,14 @@ describe("InitiativeDirectory", () => {
       { guilds: { activeGuildId: 1, activeGuild: buildGuild({ id: 1, role: "admin" }) } }
     );
 
-    // A private initiative the admin is not in is theirs to reach, not on
-    // offer: it sits in their own group, badged with why, title as the way in.
-    expect(await screen.findByRole("heading", { name: "Your initiatives" })).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Open to join" })).not.toBeInTheDocument();
-    expect(screen.getByText("Admin")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Hidden" })).toHaveAttribute("href", "/c/1/i/11");
-    expect(screen.queryByRole("button", { name: "Join" })).not.toBeInTheDocument();
+    // Their authority over the guild is unchanged; this page just stops
+    // standing in for it. The card is on offer, and an admin walks in rather
+    // than knocking, so it carries Join and not Request to join.
+    expect(await screen.findByRole("heading", { name: "Open to join" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Your initiatives" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Join" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request to join" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Knockable" })).not.toBeInTheDocument();
   });
 
   it("still offers an admin an open initiative they are not in", async () => {

--- a/frontend/src/components/guildHome/InitiativeDirectory.tsx
+++ b/frontend/src/components/guildHome/InitiativeDirectory.tsx
@@ -15,6 +15,11 @@
  *    once you've knocked. Nothing about what you can see moves until a manager
  *    answers, so the card says only that you asked.
  *
+ * A guild admin reads this page the same way anyone else does — their
+ * authority over the guild is unchanged, it just no longer decides what is
+ * listed here. They walk in rather than knock, so a card they are not in
+ * offers Join whatever its policy says.
+ *
  * A manager also sees how many people are waiting at their own door: the count
  * reads zero for everyone who couldn't act on it anyway.
  *
@@ -84,19 +89,22 @@ export const InitiativeDirectory = ({ entries, onCreate }: InitiativeDirectoryPr
   const { isGuildAdmin, permissionsFor } = useInitiativeAccess();
   const guildId = useActiveGuildId();
 
-  // A guild admin's standing reaches every initiative without a membership row,
-  // and the backend sends them the unlisted (private) ones too. Those land in
-  // the "yours" group — they are not on offer, and the admin badge says why the
-  // reader is there. One an admin could still genuinely join stays on offer, so
-  // the group a card is in is exactly the answer to "am I in there already":
-  // the title leads in from one group, the Join button from the other, and no
-  // card carries both.
-  const mine = entries.filter(
-    (entry) => entry.is_member || (isGuildAdmin && entry.join_policy !== InitiativeJoinPolicy.open)
-  );
-  const canEnter = (entry: InitiativeDirectoryEntry) => mine.includes(entry);
-  const joinable = entries.filter((entry) => !canEnter(entry));
+  // One reading for everyone, guild admin included: a card is yours when you
+  // are in it, and on offer when you are not. An admin's authority still
+  // reaches the whole guild — it just no longer decides what this page lists,
+  // so the group a card is in is exactly the answer to "am I in there
+  // already": the title leads in from one group, the Join button from the
+  // other, and no card carries both.
+  const mine = entries.filter((entry) => entry.is_member);
+  const canEnter = (entry: InitiativeDirectoryEntry) => entry.is_member;
+  const joinable = entries.filter((entry) => !entry.is_member);
   const hasEnterable = mine.length > 0;
+
+  // A guild admin walks in rather than knocking: they hold the authority the
+  // request queue exercises, so a card they are not in offers the same one
+  // button whatever its policy.
+  const walksIn = (entry: InitiativeDirectoryEntry) =>
+    isGuildAdmin || entry.join_policy === InitiativeJoinPolicy.open;
 
   // Only a card the reader can enter shows counts and a role — for the rest
   // RLS would answer zero anyway — so nothing is fetched for a directory of
@@ -137,8 +145,7 @@ export const InitiativeDirectory = ({ entries, onCreate }: InitiativeDirectoryPr
   }
 
   /**
-   * What the reader is here: their role in the initiative, or the guild-admin
-   * standing that reaches it without a membership row. A member whose row
+   * What the reader is here: their role in the initiative. A member whose row
    * carries no role still gets the plain "you're in" mark.
    */
   const renderMembershipBadge = (entry: InitiativeDirectoryEntry) => {
@@ -151,13 +158,6 @@ export const InitiativeDirectory = ({ entries, onCreate }: InitiativeDirectoryPr
         <Badge variant="secondary" className="shrink-0 gap-1">
           <Check className="h-3 w-3" aria-hidden="true" />
           {roleLabel}
-        </Badge>
-      );
-    }
-    if (isGuildAdmin) {
-      return (
-        <Badge variant="outline" className="shrink-0">
-          {t("initiatives:settings.guildAdminRole")}
         </Badge>
       );
     }
@@ -277,8 +277,8 @@ export const InitiativeDirectory = ({ entries, onCreate }: InitiativeDirectoryPr
           {canEnter(entry) ? renderToolStats(entry) : null}
         </div>
         {/* Nothing to offer a card you're already in — its title leads there.
-            Otherwise the policy decides: walk in, or ask. */}
-        {canEnter(entry) ? null : entry.join_policy === InitiativeJoinPolicy.open ? (
+            Otherwise: walk in where you may, ask where you must. */}
+        {canEnter(entry) ? null : walksIn(entry) ? (
           <Button
             size="sm"
             disabled={joinInitiative.isPending}

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
@@ -71,15 +71,32 @@ export const InitiativeSettingsMembersTab = ({
       return [];
     }
     const existingIds = new Set(members.map((member) => member.user.id));
-    // Guild admins take the project manager role from the guild settings
-    // initiative table, which is the only initiative role they may hold.
     return usersQuery.data.filter(
-      (candidate) =>
-        !existingIds.has(candidate.id) &&
-        candidate.status !== "anonymized" &&
-        candidate.guild_role !== "admin"
+      (candidate) => !existingIds.has(candidate.id) && candidate.status !== "anonymized"
     );
   }, [usersQuery.data, members]);
+
+  // A guild admin's standing already reaches every initiative, so the only
+  // initiative role their row can hold is the manager one — the server settles
+  // that on the way in. The picker says so up front rather than offering a
+  // choice that would be rewritten.
+  const adminIds = useMemo(
+    () =>
+      new Set(
+        (usersQuery.data ?? [])
+          .filter((candidate) => candidate.guild_role === "admin")
+          .map((candidate) => candidate.id)
+      ),
+    [usersQuery.data]
+  );
+  const managerRole = useMemo(
+    () =>
+      roles?.find((role) => role.is_manager) ??
+      roles?.find((role) => role.name === "project_manager"),
+    [roles]
+  );
+  const addingAdmin = adminIds.has(Number(selectedUserId));
+  const effectiveRoleId = addingAdmin && managerRole ? String(managerRole.id) : selectedRoleId;
 
   const addMember = useAddInitiativeMember({
     onSuccess: () => {
@@ -112,11 +129,11 @@ export const InitiativeSettingsMembersTab = ({
   });
 
   const handleAddMember = () => {
-    if (!selectedUserId || !selectedRoleId) {
+    if (!selectedUserId || !effectiveRoleId) {
       return;
     }
     const userId = Number(selectedUserId);
-    const roleId = Number(selectedRoleId);
+    const roleId = Number(effectiveRoleId);
     if (!Number.isFinite(userId) || !Number.isFinite(roleId)) {
       return;
     }
@@ -166,7 +183,7 @@ export const InitiativeSettingsMembersTab = ({
         header: t("settings.roleColumn"),
         cell: ({ row }) => {
           const member = row.original;
-          if (!canManageMembers || !roles) {
+          if (!canManageMembers || !roles || adminIds.has(member.user.id)) {
             return <Badge variant="outline">{getRoleDisplayName(member)}</Badge>;
           }
           return (
@@ -232,6 +249,7 @@ export const InitiativeSettingsMembersTab = ({
     ];
   }, [
     t,
+    adminIds,
     canManageMembers,
     roles,
     showsNames,
@@ -281,7 +299,11 @@ export const InitiativeSettingsMembersTab = ({
                   disabled={usersQuery.isLoading || availableUsers.length === 0}
                 />
                 {roles && (
-                  <Select value={selectedRoleId} onValueChange={setSelectedRoleId}>
+                  <Select
+                    value={effectiveRoleId}
+                    onValueChange={setSelectedRoleId}
+                    disabled={addingAdmin}
+                  >
                     <SelectTrigger className="w-44">
                       <SelectValue placeholder={t("settings.selectRole")} />
                     </SelectTrigger>
@@ -300,7 +322,7 @@ export const InitiativeSettingsMembersTab = ({
                   onClick={handleAddMember}
                   disabled={
                     !selectedUserId ||
-                    !selectedRoleId ||
+                    !effectiveRoleId ||
                     addMember.isPending ||
                     usersQuery.isLoading ||
                     availableUsers.length === 0

--- a/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
+++ b/frontend/src/components/initiatives/settings/InitiativeSettingsMembersTab.tsx
@@ -183,9 +183,19 @@ export const InitiativeSettingsMembersTab = ({
         header: t("settings.roleColumn"),
         cell: ({ row }) => {
           const member = row.original;
-          if (!canManageMembers || !roles || adminIds.has(member.user.id)) {
+          if (!canManageMembers || !roles) {
             return <Badge variant="outline">{getRoleDisplayName(member)}</Badge>;
           }
+          // A community admin already on a manager role has nothing to choose:
+          // it is the only role their row can hold. One that is not — promoted
+          // to admin after joining, so their row kept the role they joined
+          // with — keeps the picker, narrowed to the manager roles, because
+          // this is where that row gets put right.
+          const isAdmin = adminIds.has(member.user.id);
+          if (isAdmin && member.is_manager) {
+            return <Badge variant="outline">{getRoleDisplayName(member)}</Badge>;
+          }
+          const options = isAdmin ? roles.filter((role) => role.is_manager) : roles;
           return (
             <Select
               value={String(member.role_id || "")}
@@ -202,7 +212,7 @@ export const InitiativeSettingsMembersTab = ({
                 <SelectValue placeholder="Role" />
               </SelectTrigger>
               <SelectContent>
-                {roles.map((role) => (
+                {options.map((role) => (
                   <SelectItem key={role.id} value={String(role.id)}>
                     {role.display_name}
                   </SelectItem>

--- a/frontend/src/hooks/useInitiativeAccess.ts
+++ b/frontend/src/hooks/useInitiativeAccess.ts
@@ -165,8 +165,11 @@ export function useInitiativeAccess() {
 
   const access = useMemo(() => deriveGuildAccess(activeGuild, user), [activeGuild, user]);
   const { isGuildAdmin, isGrantGuild, grantReadWrite } = access;
-  // Admins and PAM grantees see every initiative in the guild.
-  const seesAllInitiatives = isGuildAdmin || isGrantGuild;
+  // A PAM grantee holds no membership row in the guild — the grant is what
+  // they navigate by, so every initiative it reaches is theirs for its window.
+  // A guild admin is not an exception here: their authority still reaches the
+  // whole guild, but what they navigate is what they joined.
+  const seesAllInitiatives = isGrantGuild;
 
   /** Narrow a guild's initiative list to the ones the user may see. */
   const filterVisible = useCallback(

--- a/frontend/src/pages/GuildHomePage.test.tsx
+++ b/frontend/src/pages/GuildHomePage.test.tsx
@@ -10,8 +10,10 @@ import {
   buildInitiative,
   buildInitiativeDirectoryEntry,
   buildInitiativeJoinRequest,
+  buildInitiativeMember,
   buildProject,
   buildRecentActivityEntry,
+  buildUser,
 } from "@/__tests__/factories";
 import { buildQueueSummary } from "@/__tests__/factories/queue.factory";
 import { guildHttp } from "@/__tests__/helpers/guildHttp";
@@ -22,6 +24,10 @@ import { queryClient } from "@/lib/queryClient";
 import { GuildHomePage } from "./GuildHomePage";
 
 const INITIATIVE_ID = 7;
+
+/** Whoever is reading the page. Pinned so the stubbed listing can carry their
+ *  membership row — which is what the endpoint returns, guild admin or not. */
+const READER = buildUser({ id: 42 });
 
 const page = (items: unknown[], totalCount = items.length) =>
   HttpResponse.json({
@@ -55,12 +61,20 @@ function stubTools({
   );
 }
 
-/** A guild admin sees every initiative, so the rail reflects the initiative's
- *  own tool switches rather than one membership row. */
+/** The listing is the reader's own memberships, guild admin or not, so the
+ *  stub carries their row. For an admin the rail still reflects the
+ *  initiative's own tool switches rather than that row's flags. */
 function stubInitiatives(overrides: Record<string, boolean> = {}) {
   server.use(
     guildHttp.get("/initiatives/", () =>
-      HttpResponse.json([buildInitiative({ id: INITIATIVE_ID, name: "Apollo", ...overrides })])
+      HttpResponse.json([
+        buildInitiative({
+          id: INITIATIVE_ID,
+          name: "Apollo",
+          members: [buildInitiativeMember({ user: { ...READER } })],
+          ...overrides,
+        }),
+      ])
     )
   );
 }
@@ -72,14 +86,15 @@ function stubDirectory(entries: unknown[]) {
 
 const renderHome = (search?: Record<string, unknown>) =>
   renderPage(GuildHomePage, {
+    auth: { user: READER },
     guilds: { activeGuildId: 1, activeGuild: buildGuild({ id: 1, role: "admin" }) },
     routerSearch: search,
   });
 
-/** The same page seen by a plain member — no create affordance, no admin view
- *  of every initiative. */
+/** The same page seen by a plain member — no create affordance. */
 const renderHomeAsMember = (search?: Record<string, unknown>) =>
   renderPage(GuildHomePage, {
+    auth: { user: READER },
     guilds: { activeGuildId: 1, activeGuild: buildGuild({ id: 1, role: "member" }) },
     routerSearch: search,
   });


### PR DESCRIPTION
## Problem

A community admin's sidebar was already scoped to their own memberships (#1362's follow-on), but the community front page still listed the whole community to them — every private initiative filed under "Your initiatives", entered by standing rather than by a membership row. Running a community of thirty meant a front page of thirty.

Separately, a project manager could not invite a community admin into their initiative at all: the invite answered `400 INITIATIVE_GUILD_ADMIN_ROLE_RESTRICTED`, because an admin may only hold the project manager role there. A manager had to know who was an admin before they could add anyone.

## Changes

**The front page reads the same way for everyone.** `list_directory_entries` drops its `include_unlisted` leg, so a private initiative an admin is not in is not listed to them any more than to anyone else. `filterVisible` stops making an admin an exception too — the PAM-grantee leg stays, since a grantee holds no membership row and navigates by their grant. Settings › Initiatives (`?scope=guild`) is still the whole-community list.

**An admin walks in rather than knocks.** That change left them needing a way in from the page itself, so `POST /{id}/join` now takes a community admin whatever the initiative's join policy says, and their card offers Join instead of Request to join. It is the same act as ticking themselves in Settings › Initiatives. `create_join_request` keeps its existing 409 — they need not ask.

**One rule decides a membership row's role.** New `resolve_membership_role`: a community admin's row carries the project manager role, settled on the way in rather than refused. Every route that writes a row resolves through it — invite, self-join, an approved join request, auto-join — so the join-request approval no longer has a case that fails outright, and a project manager can invite an admin without first working out who is one.

The explicit role change (`PATCH /members/{user_id}`) keeps its 400: substituting there would answer a question nobody asked. The members table renders an admin's role as a badge rather than a picker, so the UI never sends it, and the member picker now offers admins like anybody else with the role locked to project manager.

**Promotion reconciles the rows that already existed.** Becoming a guild admin changed the guild role and nothing else, so every initiative membership the person already held stayed on the role they joined with — and everything reading `is_manager` went on treating them as ordinary there: no notification when somebody asked to join, and a zero on the front page's waiting-requests badge. `align_guild_admin_membership_roles` moves those rows to project manager, called from the two endpoints that perform a promotion through a routed excursion inside a savepoint, so reconciling rows underneath the role change is never what makes the role change fail. A demotion leaves the manager role alone — it is an ordinary role for an ordinary member.

Two places also stop assuming the invariant already holds, so a row left behind by an earlier promotion is neither stranded nor silently downgraded:

- the members table keeps its role picker for an admin whose row is not yet managerial (narrowed to the manager roles), which is where such a row gets put right;
- the directory badges the queue for a guild admin who is **in** the initiative whatever their row carries, since answering a request is authority they hold as admin. It stays off the initiatives they are not in.

Group sync is deliberately left alone: initiative roles there come from claim mappings, and reconciling under them would fight the mapping on every sync. A row it leaves behind is correctable in the members table.

## Notable consequences

- The pending-join-request badge on a directory card is now for whoever may answer it — a manager, or a guild admin inside the initiative. An admin *outside* it reads zero; they get the badge the moment they join.
- A community whose initiatives are all private shows a new admin an empty sidebar and an empty front page. Settings › Initiatives is the way in. Consistent with the model, but a real change in what a fresh admin sees.

## Schema / env

None. No migration, no new settings, no API-schema change (`include_unlisted` was never a request parameter).

## Testing

```
cd backend && pytest -n 0 app/api/v1/tenant_endpoints/initiatives_test.py       # 97 passed
cd backend && pytest -n 0 app/services/platform/guilds_test.py \
                          app/services/oidc_sync_test.py                        # 41 passed
cd backend && ruff check app && ruff format app && ty check                      # clean
cd frontend && pnpm vitest run                                                   # green
cd frontend && pnpm tsc --noEmit && pnpm biome check src                         # clean
```

New backend tests cover: a promotion lifting an existing `member` row to project manager, the queue badge surviving a role a promotion left behind, the directory reading the same for an admin, the queue badge being managers-only, an invite naming a standard role landing an admin on `project_manager`, a project manager (not an admin) inviting an admin, and an admin joining a `private`/`request` initiative as manager. Frontend tests cover the directory no longer filing an unjoined initiative as an admin's own, and offering them Join rather than Request to join.

A full-suite run at `-n auto` in this worktree collapsed under `max_locks_per_transaction` (13 workers each creating and dropping a ~60-table guild schema); the serial runs above are the real result.
