### PR TITLE
Ask a listed community's members their age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Say how you're around, or don't.** A dot under your picture in the sidebar opens the four states: online, idle, busy, or offline. Offline means offline — nobody sees you as here, whatever you have open. Idle sets itself once nothing has been touched for a while, and you can also pick it outright to say you have stepped away. The same dot on your profile card in Settings › Profile opens the same menu.
 
+- **Communities ask their members' age.** Where a deployment runs a community directory, taking a place in a listed community now means confirming you are 13 or older. The directory's Join button asks first, so ticking the box is what joins; anyone who arrived another way — an invite, a group sync, an admin adding them, or a community that listed itself after they were already in it — is asked once on their next visit. The answer is kept on the account, so the second community you join asks nothing. Platform owners can switch the question off under Settings › Admin › Community by confirming every account on the deployment belongs to someone 18 or older.
+
 ### Changed
 
 - **Guilds are now communities.** The name was picked for gaming guilds, and people turned out to be running far more than that. Pages moved from `/g/…` to `/c/…`, and a new install's first community is called "Primary Community".

--- a/backend/alembic/versions/20260904_0219_community_age_gate.py
+++ b/backend/alembic/versions/20260904_0219_community_age_gate.py
@@ -1,0 +1,70 @@
+"""The age confirmation a listed guild's members give, and the switch behind it.
+
+Two columns, no new table and nothing to carry into one.
+
+* ``users.age_confirmed_at`` — when an account said it belongs to somebody at
+  least 13 years old, NULL where it never has. Nullable with no default, so
+  every account that already exists starts out having said nothing, which is
+  the truth about them: the confirmation is theirs to give and cannot be
+  inferred from a row that predates the question.
+* ``app_settings.community_age_gate_enabled`` — whether the question is asked
+  on this deployment at all. Defaults true so a deployment that upgrades into
+  a running community directory starts out asking; a platform owner turns it
+  off to assert that every account here already belongs to an adult.
+
+``app_settings`` is granted table-wide to the owner tier, so its new column
+arrives writable. ``public.users`` is not: the request path holds its UPDATE
+per column (0144), so a new column there is named for each request-path floor
+or it is unwritable. Every column but ``role`` is writable by all three, and
+this one is no exception — ``security_invariants_test`` holds that line.
+
+Neither column is referenced by a policy, so there is no RLS to lift: an
+``ADD COLUMN`` is not a policy-bound write.
+
+Revision ID: 20260904_0219
+Revises: 20260904_0218
+Create Date: 2026-09-04
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260904_0219"
+down_revision = "20260904_0218"
+branch_labels = None
+depends_on = None
+
+
+#: The request-path floors, which hold their UPDATE on ``users`` per column.
+def _write_roles() -> tuple[str, ...]:
+    return (
+        "app_guild_base",
+        f'"{settings.PLATFORM_ROLE_PREFIX}platform_base"',
+        "app_user",
+    )
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("age_confirmed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "app_settings",
+        sa.Column(
+            "community_age_gate_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="true",
+        ),
+    )
+    for role in _write_roles():
+        op.execute(f"GRANT UPDATE (age_confirmed_at) ON TABLE public.users TO {role}")
+
+
+def downgrade() -> None:
+    op.drop_column("app_settings", "community_age_gate_enabled")
+    # The grant goes with the column it names.
+    op.drop_column("users", "age_confirmed_at")

--- a/backend/app/api/v1/platform_endpoints/config.py
+++ b/backend/app/api/v1/platform_endpoints/config.py
@@ -68,6 +68,11 @@ class AppConfig(BaseModel):
     # control. Unlike the fields above this one is a database setting rather
     # than an env var, so it changes without a redeploy.
     community_directory_enabled: bool
+    # Whether this deployment asks an account to confirm it is 13 or older
+    # before it belongs to a listed guild. The SPA reads it to decide whether
+    # the directory's Join button asks first; the server refuses either way, so
+    # this is which question gets asked and not whether the rule applies.
+    community_age_gate_enabled: bool
 
 
 _SUPPORTED_CAPTCHA_PROVIDERS = {"hcaptcha", "turnstile", "recaptcha"}
@@ -108,4 +113,5 @@ async def get_app_config(session: SessionDep) -> AppConfig:
         billing=billing,
         max_upload_bytes=MAX_DOCUMENT_FILE_SIZE,
         community_directory_enabled=app_settings.community_directory_enabled,
+        community_age_gate_enabled=app_settings.community_age_gate_enabled,
     )

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -362,6 +362,12 @@ async def join_community_guild(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
         ) from exc
+    except guilds_service.AgeConfirmationRequiredError as exc:
+        # The one thing the caller can fix by answering, so it is its own code:
+        # the SPA ticks the box and repeats the request.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
     except guilds_service.GuildCapacityError as exc:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)

--- a/backend/app/api/v1/platform_endpoints/guilds_community_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_community_test.py
@@ -1124,3 +1124,214 @@ async def test_a_profile_names_no_communities_where_the_directory_is_off(
 
     assert response.status_code == 200
     assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
+# The age gate: who is asked, who is not, and what the answer is worth.
+# ---------------------------------------------------------------------------
+
+
+async def test_join_refuses_an_account_that_has_not_confirmed_its_age(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="minor@example.com", age_confirmed_at=None)
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "GUILD_AGE_CONFIRMATION_REQUIRED"
+    membership = (
+        await session.exec(
+            select(GuildMembership).where(
+                GuildMembership.guild_id == guild.id,
+                GuildMembership.user_id == user.id,
+            )
+        )
+    ).one_or_none()
+    assert membership is None
+
+
+async def test_confirming_age_lets_the_same_account_join(
+    client: AsyncClient, session: AsyncSession
+):
+    """The whole loop: refused, tick the box, join."""
+    user = await create_user(session, email="joiner@example.com", age_confirmed_at=None)
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    headers = get_auth_headers(user)
+
+    refused = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=headers
+    )
+    assert refused.status_code == 403
+
+    confirmed = await client.post(
+        "/api/v1/users/me/age-confirmation", json={"confirmed": True}, headers=headers
+    )
+    assert confirmed.status_code == 200
+    assert confirmed.json()["age_confirmed_at"] is not None
+
+    joined = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=headers
+    )
+    assert joined.status_code == 200
+    assert joined.json()["id"] == guild.id
+
+
+async def test_join_allows_an_unconfirmed_account_when_the_gate_is_off(
+    client: AsyncClient, session: AsyncSession
+):
+    """An owner who asserts every account here is an adult is not asking."""
+    await app_settings_service.update_community_settings(
+        session, community_directory_enabled=True, community_age_gate_enabled=False
+    )
+    user = await create_user(session, email="adult@example.com", age_confirmed_at=None)
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+
+    response = await client.post(
+        f"/api/v1/guilds/communities/{guild.id}/join", headers=get_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+
+
+async def test_unconfirmed_member_of_a_listed_guild_is_asked_on_next_read(
+    client: AsyncClient, session: AsyncSession
+):
+    """The catch-all: a membership that arrived without anyone to ask.
+
+    Written straight to the table the way a group sync or an admin would, so
+    the join endpoint's refusal is not what is under test here.
+    """
+    user = await create_user(session, email="synced@example.com", age_confirmed_at=None)
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    session.add(
+        GuildMembership(guild_id=guild.id, user_id=user.id, role=GuildRole.member)
+    )
+    await session.commit()
+
+    response = await client.get("/api/v1/users/me", headers=get_auth_headers(user))
+
+    assert response.status_code == 200
+    assert response.json()["age_confirmation_required"] is True
+
+
+async def test_unlisted_guild_asks_nobody_their_age(
+    client: AsyncClient, session: AsyncSession
+):
+    """A private guild is not a public community, so the gate never applies."""
+    user = await create_user(
+        session, email="private@example.com", age_confirmed_at=None
+    )
+    guild = await create_guild(session, name="Just Us")
+    await create_guild_membership(session, user=user, guild=guild)
+
+    response = await client.get("/api/v1/users/me", headers=get_auth_headers(user))
+
+    assert response.status_code == 200
+    assert response.json()["age_confirmation_required"] is False
+
+
+async def test_listing_a_guild_asks_the_members_it_already_had(
+    client: AsyncClient, session: AsyncSession
+):
+    """The gate is asked, not stored: it follows the guild onto the shelf."""
+    user = await create_user(session, email="early@example.com", age_confirmed_at=None)
+    guild = await create_guild(session, name="Open Table")
+    await create_guild_membership(session, user=user, guild=guild)
+    headers = get_auth_headers(user)
+
+    before = await client.get("/api/v1/users/me", headers=headers)
+    assert before.json()["age_confirmation_required"] is False
+
+    await _list_as_community(session, guild)
+
+    after = await client.get("/api/v1/users/me", headers=headers)
+    assert after.json()["age_confirmation_required"] is True
+
+
+async def test_confirmation_clears_the_standing_gate(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(
+        session, email="answers@example.com", age_confirmed_at=None
+    )
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await create_guild_membership(session, user=user, guild=guild)
+    headers = get_auth_headers(user)
+
+    assert (await client.get("/api/v1/users/me", headers=headers)).json()[
+        "age_confirmation_required"
+    ] is True
+
+    await client.post(
+        "/api/v1/users/me/age-confirmation", json={"confirmed": True}, headers=headers
+    )
+
+    assert (await client.get("/api/v1/users/me", headers=headers)).json()[
+        "age_confirmation_required"
+    ] is False
+
+
+async def test_an_unticked_box_confirms_nothing(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(
+        session, email="declines@example.com", age_confirmed_at=None
+    )
+
+    response = await client.post(
+        "/api/v1/users/me/age-confirmation",
+        json={"confirmed": False},
+        headers=get_auth_headers(user),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "USER_AGE_NOT_CONFIRMED"
+    await session.refresh(user)
+    assert user.age_confirmed_at is None
+
+
+async def test_confirming_twice_keeps_the_first_answer(
+    client: AsyncClient, session: AsyncSession
+):
+    """The record is when they first said it, not when they last clicked."""
+    user = await create_user(
+        session, email="repeats@example.com", age_confirmed_at=None
+    )
+    headers = get_auth_headers(user)
+
+    first = await client.post(
+        "/api/v1/users/me/age-confirmation", json={"confirmed": True}, headers=headers
+    )
+    second = await client.post(
+        "/api/v1/users/me/age-confirmation", json={"confirmed": True}, headers=headers
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["age_confirmed_at"] == second.json()["age_confirmed_at"]
+
+
+async def test_directory_off_asks_nobody(client: AsyncClient, session: AsyncSession):
+    """With no directory there is no listed guild for anyone to be asked about."""
+    user = await create_user(
+        session, email="nowhere@example.com", age_confirmed_at=None
+    )
+    guild = await create_guild(session, name="Open Table")
+    await _list_as_community(session, guild)
+    await create_guild_membership(session, user=user, guild=guild)
+    await app_settings_service.update_community_settings(
+        session, community_directory_enabled=False
+    )
+
+    response = await client.get("/api/v1/users/me", headers=get_auth_headers(user))
+
+    assert response.json()["age_confirmation_required"] is False

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -206,13 +206,21 @@ async def update_community_settings(
     Switching it off hides the directory and refuses new listings; it does not
     clear the opt-in a guild already made, so switching it back on restores the
     same set of listed guilds.
+
+    ``age_gate_enabled`` is the second switch: whether an account must confirm
+    it belongs to somebody 13 or older before it takes a place in a listed
+    guild. Turning it off is the owner asserting that every account on this
+    deployment already belongs to an adult, which is why it is a deliberate
+    write and not a side effect of the first — omitting it leaves it alone.
     """
     settings_obj = await app_settings_service.update_community_settings(
         session,
         community_directory_enabled=payload.community_directory_enabled,
+        community_age_gate_enabled=payload.age_gate_enabled,
     )
     return CommunitySettingsResponse(
         community_directory_enabled=settings_obj.community_directory_enabled,
+        age_gate_enabled=settings_obj.community_age_gate_enabled,
     )
 
 

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -62,6 +62,7 @@ from app.schemas.platform.guild import (
     GuildCategory,
 )
 from app.schemas.platform.user import (
+    AgeConfirmation,
     DecorationPack,
     DecorationPackListResponse,
     OwnedDecoration,
@@ -158,6 +159,12 @@ async def read_users_me(
     # is linked (drives the "SSO account" affordances in the profile UI).
     payload.has_federated_identity = await has_federated_identity(
         session, user_id=current_user.id
+    )
+    # The standing age gate. Costs a query only for an account that has not
+    # confirmed on a deployment that asks — it short-circuits on the column
+    # for everyone else, and stops for good once they answer.
+    payload.age_confirmation_required = (
+        await guilds_service.age_confirmation_outstanding(session, user=current_user)
     )
     return payload
 
@@ -694,6 +701,39 @@ async def claim_my_username(
     session.add(current_user)
     await session.commit()
     await session.refresh(current_user)
+    return UserRead.model_validate(current_user)
+
+
+@router.post("/me/age-confirmation", response_model=UserRead)
+async def confirm_my_age(
+    payload: AgeConfirmation,
+    session: UserSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+) -> UserRead:
+    """Record that this account belongs to somebody at least 13 years old.
+
+    Asked for by a deployment that runs a community directory, of every account
+    that belongs to a guild listed in it. The answer is kept on the account
+    rather than per guild: it is a fact about the person, and the second listed
+    guild they join asks nothing.
+
+    Saying it again is not an error and does not move the timestamp — the
+    record is when they first said it. Saying it with the box unticked is
+    refused, because an unticked box is not a confirmation.
+    """
+    if not payload.confirmed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=UserMessages.AGE_NOT_CONFIRMED,
+        )
+
+    if current_user.age_confirmed_at is None:
+        current_user.age_confirmed_at = datetime.now(timezone.utc)
+        current_user.updated_at = datetime.now(timezone.utc)
+        session.add(current_user)
+        await session.commit()
+        await session.refresh(current_user)
+
     return UserRead.model_validate(current_user)
 
 

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -74,6 +74,10 @@ class GuildMessages:
     # on. Distinct from the four rules above, which are about one guild — this
     # one says the surface does not exist here at all.
     COMMUNITY_DIRECTORY_DISABLED = "COMMUNITY_DIRECTORY_DISABLED"
+    # The caller has not said they are 13 or older, and the guild they asked to
+    # join is listed in the directory. The deployment's own switch decides
+    # whether this is ever raised at all.
+    AGE_CONFIRMATION_REQUIRED = "GUILD_AGE_CONFIRMATION_REQUIRED"
     # A guild icon or banner rendition that is not one. Each names the rule it
     # broke, so the settings page can say what to do about it rather than
     # "that didn't work".
@@ -414,6 +418,9 @@ class UserMessages:
     API_KEY_READ_ONLY = "USER_API_KEY_READ_ONLY"
     API_KEY_GUILD_FORBIDDEN = "USER_API_KEY_GUILD_FORBIDDEN"
     USERNAME_ALREADY_CHOSEN = "USERNAME_ALREADY_CHOSEN"
+    #: Sent an age confirmation with the box unticked. The confirmation is the
+    #: account saying something about itself, so declining is not a write.
+    AGE_NOT_CONFIRMED = "USER_AGE_NOT_CONFIRMED"
     CURRENT_PASSWORD_REQUIRED = "USER_CURRENT_PASSWORD_REQUIRED"
     CURRENT_PASSWORD_INCORRECT = "USER_CURRENT_PASSWORD_INCORRECT"
     INVALID_TIMEZONE = "USER_INVALID_TIMEZONE"

--- a/backend/app/models/platform/app_setting.py
+++ b/backend/app/models/platform/app_setting.py
@@ -76,6 +76,17 @@ class AppSetting(SQLModel, table=True):
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
 
+    # Whether an account must say it is 13 or older before it belongs to a
+    # guild listed in that directory. On by default, and only a platform owner
+    # turns it off — doing so is that owner asserting that every account on the
+    # deployment already belongs to an adult, which is a thing an enterprise
+    # rollout knows and a public one does not. Independent of the directory
+    # switch above so the assertion survives the directory being toggled.
+    community_age_gate_enabled: bool = Field(
+        default=True,
+        sa_column=Column(Boolean, nullable=False, server_default="true"),
+    )
+
     # AI config ownership mode: "platform" (the operator's connections apply to
     # every guild), "guild" (each guild admin configures its own), or "disabled".
     # Provider config itself lives in platform_ai_connections /

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -220,6 +220,16 @@ class User(SQLModel, table=True):
         default=True,
         sa_column=Column(Boolean, nullable=False, server_default="true"),
     )
+    #: When this account said it belongs to somebody at least 13 years old.
+    #: NULL means it never has. A timestamp rather than a flag because the
+    #: record of *when* is the point: it is what a deployment running a
+    #: community directory keeps for every account in a listed guild.
+    #: Whether it is asked for at all is the platform owner's switch
+    #: (``AppSetting.community_age_gate_enabled``).
+    age_confirmed_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
     timezone: str = Field(
         default="UTC",
         sa_column=Column(String(64), nullable=False, server_default="UTC"),

--- a/backend/app/schemas/platform/settings.py
+++ b/backend/app/schemas/platform/settings.py
@@ -151,10 +151,15 @@ class CommunitySettingsResponse(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     community_directory_enabled: bool
+    age_gate_enabled: bool
 
 
 class CommunitySettingsUpdate(SanitizedBaseModel):
     community_directory_enabled: bool
+    #: Whether an account must confirm it is 13 or older to belong to a listed
+    #: guild. Omitted leaves it as it was — the two switches are separate
+    #: decisions and the directory one is written far more often.
+    age_gate_enabled: Optional[bool] = None
 
 
 class EmailSettingsResponse(SanitizedBaseModel):

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -410,6 +410,18 @@ class UserRead(UserBase):
     # Whether this account picked its handle. False routes the SPA to the
     # choose-your-handle screen before anything else.
     username_chosen: bool = False
+    #: When this account said it belongs to somebody 13 or older, ``None``
+    #: where it never has. Read by the directory's Join button, which asks
+    #: before it joins rather than letting the server refuse.
+    age_confirmed_at: Optional[datetime] = None
+    #: Whether it must say so before it can carry on. True only for an account
+    #: that is already in a listed guild without having confirmed — every other
+    #: way in leaves the membership standing and lands here. False routes
+    #: nowhere; true blocks the app on the confirmation screen, the way
+    #: ``username_chosen`` false routes to the handle screen. Populated by the
+    #: self endpoints (``/users/me`` and ``PATCH /users/me``), which is where
+    #: the SPA reads its own account; defaults false elsewhere.
+    age_confirmation_required: bool = False
     status: UserStatus
     email_verified: bool
     created_at: datetime
@@ -483,6 +495,17 @@ class UsernameClaim(SanitizedBaseModel):
     """
 
     username: str = Field(max_length=64)
+
+
+class AgeConfirmation(SanitizedBaseModel):
+    """An account saying it belongs to somebody at least 13 years old.
+
+    A body rather than a bare POST because the box has to be ticked: an
+    unticked one is a request that arrives, and is refused, rather than one
+    that is never sent.
+    """
+
+    confirmed: bool
 
 
 class UserInitiativeRole(SanitizedBaseModel):

--- a/backend/app/services/platform/app_settings.py
+++ b/backend/app/services/platform/app_settings.py
@@ -198,19 +198,38 @@ async def community_directory_enabled(session: AsyncSession) -> bool:
     return bool(settings_row.community_directory_enabled)
 
 
+async def community_age_gate_enabled(session: AsyncSession) -> bool:
+    """Whether an account must confirm its age to belong to a listed guild.
+
+    The one read of the switch, for the same reason
+    :func:`community_directory_enabled` is: the two places that ask — the join
+    that refuses, and the standing check that routes an unconfirmed account to
+    the screen — must agree at every moment.
+    """
+    settings_row = await get_app_settings(session)
+    return bool(settings_row.community_age_gate_enabled)
+
+
 async def update_community_settings(
     session: AsyncSession,
     *,
     community_directory_enabled: bool,
+    community_age_gate_enabled: bool | None = None,
 ) -> AppSetting:
     """Turn the community directory on or off for the whole deployment.
 
     Switching it off leaves every guild's own opt-in exactly as it was: the
     listings simply have nowhere to appear until it is switched back on, so an
     operator flipping this twice does not silently unpublish anybody.
+
+    ``community_age_gate_enabled`` is a second, independent decision and is
+    left alone when omitted: an owner who has asserted that every account here
+    belongs to an adult has not un-asserted it by toggling the directory.
     """
     settings_row = await _ensure_app_settings(session)
     settings_row.community_directory_enabled = bool(community_directory_enabled)
+    if community_age_gate_enabled is not None:
+        settings_row.community_age_gate_enabled = bool(community_age_gate_enabled)
     session.add(settings_row)
     await session.commit()
     await session.refresh(settings_row)

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -55,6 +55,10 @@ class CommunityDirectoryDisabledError(Exception):
     """Raised when the deployment runs no community directory at all."""
 
 
+class AgeConfirmationRequiredError(Exception):
+    """The caller has not confirmed their age and asked to join a listed guild."""
+
+
 class BannerColorError(Exception):
     """Raised when a banner colour is not a ``#rrggbb`` value."""
 
@@ -1093,6 +1097,75 @@ async def is_listed_in_directory(session: AsyncSession, *, guild_id: int) -> boo
     return bool((await session.exec(statement)).one())
 
 
+async def age_confirmation_outstanding(
+    session: AsyncSession,
+    *,
+    user: User,
+) -> bool:
+    """Whether this account owes the deployment an age confirmation.
+
+    True when the deployment asks for one, the account has not given one, and
+    it belongs to at least one guild that is listed right now. That last clause
+    is why this is asked rather than stored: a guild lists itself long after
+    its members joined, and every member it already had owes the confirmation
+    from that moment — as does anyone a group sync or an admin put there, who
+    was never shown a form to tick.
+
+    Which guilds count is ``community_listing_filters()``, the same list the
+    directory and the join it authorizes ask, so a guild that leaves the shelf
+    stops holding anybody to this in the same instant.
+
+    Reads another shape of the caller's own membership rows, so it wants a
+    session that can see ``guilds`` unfiltered (the system engine) or the
+    caller's own platform-tier session, which is scoped to exactly these rows.
+    """
+    from app.services.platform import app_settings as app_settings_service
+
+    if user.age_confirmed_at is not None:
+        return False
+    settings_row = await app_settings_service.get_app_settings(session)
+    # Two switches, both off-ramps: a deployment with no directory lists no
+    # guild for anyone to be in, and an owner may have asserted that every
+    # account here belongs to an adult.
+    if not (
+        settings_row.community_directory_enabled
+        and settings_row.community_age_gate_enabled
+    ):
+        return False
+    # One row is the whole answer — this is asked on every read of the caller's
+    # own account until they answer, so it stops at the first listed guild
+    # rather than counting them.
+    statement = (
+        select(GuildMembership.guild_id)
+        .join(Guild, Guild.id == GuildMembership.guild_id)
+        .join(
+            GuildAdministration, GuildAdministration.guild_id == Guild.id, isouter=True
+        )
+        .where(GuildMembership.user_id == user.id, *community_listing_filters())
+        .limit(1)
+    )
+    return (await session.exec(statement)).first() is not None
+
+
+async def assert_age_confirmed(session: AsyncSession, *, user: User) -> None:
+    """Raise unless this account may take a place in a listed guild.
+
+    The directory's Join button asks first and this backs it, so ticking the
+    box is what joins rather than what is checked afterwards. Every other way
+    into a listed guild — an invite, a group sync, an admin adding somebody —
+    lands the membership and is caught by
+    :func:`age_confirmation_outstanding` instead, which is the enforcement:
+    there is nobody at a keyboard on those paths to answer a question.
+    """
+    from app.services.platform import app_settings as app_settings_service
+
+    if user.age_confirmed_at is not None:
+        return
+    if not await app_settings_service.community_age_gate_enabled(session):
+        return
+    raise AgeConfirmationRequiredError(GuildMessages.AGE_CONFIRMATION_REQUIRED)
+
+
 async def list_profile_communities(
     session: AsyncSession,
     *,
@@ -1235,6 +1308,9 @@ async def join_community_guild(
     # joined by asking for it directly either.
     if not await is_listed_in_directory(session, guild_id=guild_id):
         raise CommunityJoinError(GuildMessages.GUILD_NOT_A_COMMUNITY)
+    # Asked before the seat is taken, so the box is what joins rather than
+    # something checked once they are already in.
+    await assert_age_confirmed(session, user=user)
     # Capacity is enforced inside ensure_membership, which is also where a
     # repeat join short-circuits to the existing membership.
     await ensure_membership(

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -124,6 +124,10 @@ async def create_user(
         "username": usernames.random_name(),
         "discriminator": usernames.random_discriminator(),
         "username_chosen": True,
+        # Answered, for the same reason the handle is chosen: a test that is
+        # not about the age gate should never meet it. The gate's own tests
+        # pass ``age_confirmed_at=None`` to get an account that has not.
+        "age_confirmed_at": datetime.now(timezone.utc),
         "full_name": "Test User",
         "hashed_password": get_password_hash("testpassword123"),
         "role": UserRole.member,

--- a/frontend/public/locales/de/auth.json
+++ b/frontend/public/locales/de/auth.json
@@ -140,5 +140,13 @@
     "subtitle": "Dein Konto hat automatisch einen bekommen. Wähle den Namen, den andere sehen – eine Nummer hält ihn eindeutig.",
     "submit": "Weiter",
     "error": "Dieser Benutzername konnte nicht gesetzt werden. Bitte einen anderen wählen."
+  },
+  "confirmAge": {
+    "title": "Alter bestätigen",
+    "subtitle": "Du gehörst zu einer Community, die jede angemeldete Person finden kann. Bestätige, dass du alt genug dafür bist, bevor es weitergeht.",
+    "checkboxLabel": "Ich bestätige, dass ich mindestens 13 Jahre alt bin.",
+    "submit": "Bestätigen und fortfahren",
+    "signOut": "Stattdessen abmelden",
+    "error": "Die Bestätigung konnte nicht gespeichert werden. Bitte erneut versuchen."
   }
 }

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -480,6 +480,8 @@
   "GUILD_COMMUNITY_ADULT_CONTENT": "Eine als 18+ markierte Community kann nicht im Community-Verzeichnis eingetragen werden.",
   "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Diese Community hat nur für eine Person Platz und kann deshalb nicht im Community-Verzeichnis eingetragen werden.",
   "COMMUNITY_DIRECTORY_DISABLED": "Diese Instanz betreibt kein Community-Verzeichnis.",
+  "GUILD_AGE_CONFIRMATION_REQUIRED": "Bestätige vor dem Beitritt zu einer Community, dass du mindestens 13 Jahre alt bist.",
+  "USER_AGE_NOT_CONFIRMED": "Setze das Häkchen, um dein Alter zu bestätigen.",
   "IMAGE_EMPTY": "Dieses Bild war leer.",
   "IMAGE_TOO_LARGE": "Dieses Bild ist zu groß.",
   "IMAGE_INVALID": "Diese Datei ist kein PNG-, JPEG-, WebP- oder GIF-Bild.",

--- a/frontend/public/locales/de/guilds.json
+++ b/frontend/public/locales/de/guilds.json
@@ -411,7 +411,9 @@
       "certifyHate": "Hassrede, Belästigung oder Drohungen",
       "certifyDuty": "Du bist Admin dieser Community, also liegt die Durchsetzung bei dir. Von dir wird erwartet, dass du auf solche Inhalte achtest und sie entfernst. Eine Community, die das nicht mehr erfüllt, wird aus dem Verzeichnis entfernt.",
       "confirm": "Community eintragen"
-    }
+    },
+    "ageGateBody": "Communities hier kann jede angemeldete Person finden. Beim ersten Beitritt wird daher einmal nach deinem Alter gefragt – danach nie wieder.",
+    "ageGateConfirm": "Bestätigen und beitreten"
   },
   "nameDisplay": {
     "title": "Wie Mitglieder benannt werden",

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -1118,7 +1118,12 @@
     "enabledToast": "Das Community-Verzeichnis ist aktiv.",
     "disabledToast": "Das Community-Verzeichnis ist deaktiviert.",
     "saveError": "Das Community-Verzeichnis konnte nicht geändert werden. Bitte versuche es erneut.",
-    "adminOnly": "Du benötigst die Plattform-Eigentümerrolle, um ein Community-Verzeichnis zu betreiben."
+    "adminOnly": "Du benötigst die Plattform-Eigentümerrolle, um ein Community-Verzeichnis zu betreiben.",
+    "ageGateLabel": "Mitglieder bestätigen lassen, dass sie mindestens 13 sind",
+    "ageGateHelpText": "Solange dies aktiv ist, wird jede Person in einer gelisteten Community einmal um eine Altersbestätigung gebeten; die Antwort bleibt an ihrem Konto. Nur dort deaktivieren, wo bereits feststeht, dass jedes Konto einer erwachsenen Person gehört.",
+    "ageGateOffTitle": "Nicht mehr nach dem Alter fragen?",
+    "ageGateOffBody": "Das Deaktivieren erklärt, dass jedes Konto dieser Installation einer Person ab 18 Jahren gehört. Niemand wird erneut um eine Altersbestätigung gebeten – auch nicht bei einem späteren Beitritt zu einer gelisteten Community.",
+    "ageGateOffConfirm": "Hier sind alle mindestens 18"
   },
   "audit": {
     "title": "Prüfprotokoll",

--- a/frontend/public/locales/en/auth.json
+++ b/frontend/public/locales/en/auth.json
@@ -140,5 +140,13 @@
     "subtitle": "Your account was given one automatically. Pick the name people will see — a number is added to keep it unique.",
     "submit": "Continue",
     "error": "That username could not be set. Try another."
+  },
+  "confirmAge": {
+    "title": "Confirm your age",
+    "subtitle": "You belong to a community anyone signed in can find. Before you carry on, confirm you are old enough to be in one.",
+    "checkboxLabel": "I confirm I am 13 years of age or older.",
+    "submit": "Confirm and continue",
+    "signOut": "Sign out instead",
+    "error": "That confirmation could not be saved. Please try again."
   }
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -480,6 +480,8 @@
   "GUILD_COMMUNITY_ADULT_CONTENT": "A community marked 18+ cannot be listed in the community directory.",
   "GUILD_COMMUNITY_REQUIRES_CAPACITY": "This community has room for only one person, so it cannot be listed in the community directory.",
   "COMMUNITY_DIRECTORY_DISABLED": "This deployment doesn't run a community directory.",
+  "GUILD_AGE_CONFIRMATION_REQUIRED": "Confirm you are 13 or older before joining a community.",
+  "USER_AGE_NOT_CONFIRMED": "Tick the box to confirm your age.",
   "IMAGE_EMPTY": "That image was empty.",
   "IMAGE_TOO_LARGE": "That image is too large.",
   "IMAGE_INVALID": "That file is not a PNG, JPEG, WebP or GIF image.",

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -411,7 +411,9 @@
       "certifyHate": "Hate speech, harassment, or threats",
       "certifyDuty": "You are an admin of this community, so this is yours to enforce. You are expected to watch for this content and remove it. A community that stops meeting this is removed from the directory.",
       "confirm": "List this community"
-    }
+    },
+    "ageGateBody": "Communities here can be found by anyone signed in, so joining one asks your age once. You will not be asked again.",
+    "ageGateConfirm": "Confirm and join"
   },
   "nameDisplay": {
     "title": "How members are named",

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -1118,7 +1118,12 @@
     "enabledToast": "The community directory is on.",
     "disabledToast": "The community directory is off.",
     "saveError": "Could not change the community directory. Please try again.",
-    "adminOnly": "You need the platform owner role to run a community directory."
+    "adminOnly": "You need the platform owner role to run a community directory.",
+    "ageGateLabel": "Ask members to confirm they are 13 or older",
+    "ageGateHelpText": "While this is on, anyone who belongs to a listed community is asked once to confirm their age, and the answer is kept on their account. Turn it off only where you already know every account belongs to an adult.",
+    "ageGateOffTitle": "Stop asking members their age?",
+    "ageGateOffBody": "Turning this off asserts that every account on this deployment belongs to someone 18 or older. Nobody will be asked to confirm their age again, including people who join a listed community later.",
+    "ageGateOffConfirm": "Everyone here is 18 or older"
   },
   "audit": {
     "title": "Audit",

--- a/frontend/public/locales/es/auth.json
+++ b/frontend/public/locales/es/auth.json
@@ -140,5 +140,13 @@
     "subtitle": "Tu cuenta recibió uno automáticamente. Elige el nombre que verán los demás; se añade un número para que sea único.",
     "submit": "Continuar",
     "error": "No se pudo asignar ese nombre de usuario. Prueba con otro."
+  },
+  "confirmAge": {
+    "title": "Confirma tu edad",
+    "subtitle": "Perteneces a una comunidad que puede encontrar cualquier persona con sesión iniciada. Antes de continuar, confirma que tienes edad suficiente para estar en una.",
+    "checkboxLabel": "Confirmo que tengo 13 años o más.",
+    "submit": "Confirmar y continuar",
+    "signOut": "Cerrar sesión en su lugar",
+    "error": "No se pudo guardar la confirmación. Inténtalo de nuevo."
   }
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -480,6 +480,8 @@
   "GUILD_COMMUNITY_ADULT_CONTENT": "Una comunidad marcada como +18 no puede publicarse en el directorio de comunidades.",
   "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Esta comunidad solo tiene sitio para una persona, así que no puede publicarse en el directorio de comunidades.",
   "COMMUNITY_DIRECTORY_DISABLED": "Esta instalación no ofrece un directorio de comunidades.",
+  "GUILD_AGE_CONFIRMATION_REQUIRED": "Confirma que tienes 13 años o más antes de unirte a una comunidad.",
+  "USER_AGE_NOT_CONFIRMED": "Marca la casilla para confirmar tu edad.",
   "IMAGE_EMPTY": "Esa imagen estaba vacía.",
   "IMAGE_TOO_LARGE": "Esa imagen es demasiado grande.",
   "IMAGE_INVALID": "Ese archivo no es una imagen PNG, JPEG, WebP o GIF.",

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -411,7 +411,9 @@
       "certifyHate": "Discurso de odio, acoso o amenazas",
       "certifyDuty": "Eres administrador de esta comunidad, así que hacerlo cumplir te corresponde a ti. Se espera que vigiles este tipo de contenido y lo elimines. Una comunidad que deje de cumplirlo se retira del directorio.",
       "confirm": "Publicar comunidad"
-    }
+    },
+    "ageGateBody": "Cualquier persona con sesión iniciada puede encontrar estas comunidades, así que al unirte a una se te pregunta la edad una vez. No se te volverá a preguntar.",
+    "ageGateConfirm": "Confirmar y unirse"
   },
   "nameDisplay": {
     "title": "Cómo se nombra a los miembros",

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -1118,7 +1118,12 @@
     "enabledToast": "El directorio de comunidades está activado.",
     "disabledToast": "El directorio de comunidades está desactivado.",
     "saveError": "No se pudo cambiar el directorio de comunidades. Inténtalo de nuevo.",
-    "adminOnly": "Necesitas el rol de propietario de la plataforma para ofrecer un directorio de comunidades."
+    "adminOnly": "Necesitas el rol de propietario de la plataforma para ofrecer un directorio de comunidades.",
+    "ageGateLabel": "Pedir a los miembros que confirmen que tienen 13 años o más",
+    "ageGateHelpText": "Mientras esto esté activo, a quien pertenezca a una comunidad listada se le pide una vez que confirme su edad, y la respuesta queda en su cuenta. Desactívalo solo donde ya sepas que todas las cuentas pertenecen a personas adultas.",
+    "ageGateOffTitle": "¿Dejar de preguntar la edad?",
+    "ageGateOffBody": "Desactivarlo afirma que todas las cuentas de esta instalación pertenecen a personas de 18 años o más. No se volverá a pedir a nadie que confirme su edad, ni siquiera a quien se una más adelante a una comunidad listada.",
+    "ageGateOffConfirm": "Aquí todo el mundo tiene 18 o más"
   },
   "audit": {
     "title": "Auditoría",

--- a/frontend/public/locales/fr/auth.json
+++ b/frontend/public/locales/fr/auth.json
@@ -140,5 +140,13 @@
     "subtitle": "Votre compte en a reçu un automatiquement. Choisissez le nom que les autres verront ; un numéro est ajouté pour le rendre unique.",
     "submit": "Continuer",
     "error": "Ce nom d'utilisateur n'a pas pu être défini. Essayez-en un autre."
+  },
+  "confirmAge": {
+    "title": "Confirmez votre âge",
+    "subtitle": "Vous appartenez à une communauté que toute personne connectée peut trouver. Avant de continuer, confirmez que vous avez l'âge requis pour en faire partie.",
+    "checkboxLabel": "Je confirme avoir 13 ans ou plus.",
+    "submit": "Confirmer et continuer",
+    "signOut": "Se déconnecter plutôt",
+    "error": "Cette confirmation n'a pas pu être enregistrée. Veuillez réessayer."
   }
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -480,6 +480,8 @@
   "GUILD_COMMUNITY_ADULT_CONTENT": "Une communauté marquée 18+ ne peut pas être inscrite à l’annuaire des communautés.",
   "GUILD_COMMUNITY_REQUIRES_CAPACITY": "Cette communauté n’a de place que pour une personne : elle ne peut pas être inscrite à l’annuaire des communautés.",
   "COMMUNITY_DIRECTORY_DISABLED": "Cette instance ne propose pas d'annuaire des communautés.",
+  "GUILD_AGE_CONFIRMATION_REQUIRED": "Confirmez que vous avez 13 ans ou plus avant de rejoindre une communauté.",
+  "USER_AGE_NOT_CONFIRMED": "Cochez la case pour confirmer votre âge.",
   "IMAGE_EMPTY": "Cette image était vide.",
   "IMAGE_TOO_LARGE": "Cette image est trop volumineuse.",
   "IMAGE_INVALID": "Ce fichier n'est pas une image PNG, JPEG, WebP ou GIF.",

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -411,7 +411,9 @@
       "certifyHate": "Discours haineux, harcèlement ou menaces",
       "certifyDuty": "Vous êtes administrateur de cette communauté : c’est à vous de le faire respecter. Vous êtes censé surveiller ce type de contenu et le supprimer. Une communauté qui cesse de respecter cela est retirée de l’annuaire.",
       "confirm": "Inscrire la communauté"
-    }
+    },
+    "ageGateBody": "N'importe quelle personne connectée peut trouver ces communautés : rejoindre la première demande donc votre âge une fois. On ne vous le redemandera pas.",
+    "ageGateConfirm": "Confirmer et rejoindre"
   },
   "nameDisplay": {
     "title": "Comment les membres sont nommés",

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -1118,7 +1118,12 @@
     "enabledToast": "L'annuaire des communautés est activé.",
     "disabledToast": "L'annuaire des communautés est désactivé.",
     "saveError": "Impossible de modifier l'annuaire des communautés. Veuillez réessayer.",
-    "adminOnly": "Vous devez avoir le rôle de propriétaire de la plateforme pour proposer un annuaire des communautés."
+    "adminOnly": "Vous devez avoir le rôle de propriétaire de la plateforme pour proposer un annuaire des communautés.",
+    "ageGateLabel": "Demander aux membres de confirmer qu'ils ont 13 ans ou plus",
+    "ageGateHelpText": "Tant que ceci est actif, toute personne appartenant à une communauté référencée doit confirmer son âge une fois, et la réponse reste attachée à son compte. Ne le désactivez que là où vous savez déjà que chaque compte appartient à une personne adulte.",
+    "ageGateOffTitle": "Ne plus demander l'âge des membres ?",
+    "ageGateOffBody": "Désactiver ceci affirme que chaque compte de cette installation appartient à une personne de 18 ans ou plus. Plus personne ne sera invité à confirmer son âge, y compris en rejoignant plus tard une communauté référencée.",
+    "ageGateOffConfirm": "Tout le monde ici a 18 ans ou plus"
   },
   "audit": {
     "title": "Audit",

--- a/frontend/src/__tests__/factories/user.factory.ts
+++ b/frontend/src/__tests__/factories/user.factory.ts
@@ -101,6 +101,10 @@ export function buildUser(overrides: Partial<UserRead> = {}): UserRead {
     username: `user-${counter}`,
     discriminator: 1000 + counter,
     username_chosen: true,
+    // Answered, like the handle: a test that is not about the age gate should
+    // never meet it. The gate's own tests override these two.
+    age_confirmed_at: "2026-01-01T00:00:00Z",
+    age_confirmation_required: false,
     full_name: `User ${counter}`,
     avatar_url: null,
     role: "member",

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -327,6 +327,17 @@ export interface AdminUsernameUpdate {
 }
 
 /**
+ * An account saying it belongs to somebody at least 13 years old.
+ *
+ * A body rather than a bare POST because the box has to be ticked: an
+ * unticked one is a request that arrives, and is refused, rather than one
+ * that is never sent.
+ */
+export interface AgeConfirmation {
+  confirmed: boolean;
+}
+
+/**
  * What kind of news this is — drives the icon and accent, nothing else.
  */
 export type AnnouncementCategory = (typeof AnnouncementCategory)[keyof typeof AnnouncementCategory];
@@ -560,6 +571,7 @@ export interface AppConfig {
   billing?: BillingConfig | null;
   max_upload_bytes: number;
   community_directory_enabled: boolean;
+  community_age_gate_enabled: boolean;
 }
 
 export type AppDataParamLabel = { [key: string]: string };
@@ -1784,10 +1796,12 @@ export interface CommunityGuildPage {
  */
 export interface CommunitySettingsResponse {
   community_directory_enabled: boolean;
+  age_gate_enabled: boolean;
 }
 
 export interface CommunitySettingsUpdate {
   community_directory_enabled: boolean;
+  age_gate_enabled?: boolean | null;
 }
 
 /**
@@ -5371,6 +5385,8 @@ export interface UserRead {
   username: string;
   discriminator: number;
   username_chosen: boolean;
+  age_confirmed_at: string | null;
+  age_confirmation_required: boolean;
   status: UserStatus;
   email_verified: boolean;
   created_at: string;

--- a/frontend/src/api/generated/settings/settings.ts
+++ b/frontend/src/api/generated/settings/settings.ts
@@ -551,6 +551,12 @@ export const useUpdateInterfaceSettingsApiV1SettingsInterfacePut = <
  * Switching it off hides the directory and refuses new listings; it does not
  * clear the opt-in a guild already made, so switching it back on restores the
  * same set of listed guilds.
+ *
+ * ``age_gate_enabled`` is the second switch: whether an account must confirm
+ * it belongs to somebody 13 or older before it takes a place in a listed
+ * guild. Turning it off is the owner asserting that every account on this
+ * deployment already belongs to an adult, which is why it is a deliberate
+ * write and not a side effect of the first — omitting it leaves it alone.
  * @summary Update Community Settings
  */
 export const updateCommunitySettingsApiV1SettingsCommunityPut = (

--- a/frontend/src/api/generated/users/users.ts
+++ b/frontend/src/api/generated/users/users.ts
@@ -23,6 +23,7 @@ import type {
 import type {
   AccountDeletionRequest,
   AccountDeletionResponse,
+  AgeConfirmation,
   ApiKeyCreateRequest,
   ApiKeyCreateResponse,
   ApiKeyListResponse,
@@ -1195,6 +1196,107 @@ export const useClaimMyUsernameApiV1UsersMeUsernamePatch = <
 > => {
   return useMutation(
     getClaimMyUsernameApiV1UsersMeUsernamePatchMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Record that this account belongs to somebody at least 13 years old.
+ *
+ * Asked for by a deployment that runs a community directory, of every account
+ * that belongs to a guild listed in it. The answer is kept on the account
+ * rather than per guild: it is a fact about the person, and the second listed
+ * guild they join asks nothing.
+ *
+ * Saying it again is not an error and does not move the timestamp — the
+ * record is when they first said it. Saying it with the box unticked is
+ * refused, because an unticked box is not a confirmation.
+ * @summary Confirm My Age
+ */
+export const confirmMyAgeApiV1UsersMeAgeConfirmationPost = (
+  ageConfirmation: BodyType<AgeConfirmation>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<UserRead>(
+    {
+      url: `/api/v1/users/me/age-confirmation`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: ageConfirmation,
+      signal,
+    },
+    options
+  );
+};
+
+export const getConfirmMyAgeApiV1UsersMeAgeConfirmationPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof confirmMyAgeApiV1UsersMeAgeConfirmationPost>>,
+    TError,
+    { data: BodyType<AgeConfirmation> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof confirmMyAgeApiV1UsersMeAgeConfirmationPost>>,
+  TError,
+  { data: BodyType<AgeConfirmation> },
+  TContext
+> => {
+  const mutationKey = ["confirmMyAgeApiV1UsersMeAgeConfirmationPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof confirmMyAgeApiV1UsersMeAgeConfirmationPost>>,
+    { data: BodyType<AgeConfirmation> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return confirmMyAgeApiV1UsersMeAgeConfirmationPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type ConfirmMyAgeApiV1UsersMeAgeConfirmationPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof confirmMyAgeApiV1UsersMeAgeConfirmationPost>>
+>;
+export type ConfirmMyAgeApiV1UsersMeAgeConfirmationPostMutationBody = BodyType<AgeConfirmation>;
+export type ConfirmMyAgeApiV1UsersMeAgeConfirmationPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Confirm My Age
+ */
+export const useConfirmMyAgeApiV1UsersMeAgeConfirmationPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof confirmMyAgeApiV1UsersMeAgeConfirmationPost>>,
+      TError,
+      { data: BodyType<AgeConfirmation> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof confirmMyAgeApiV1UsersMeAgeConfirmationPost>>,
+  TError,
+  { data: BodyType<AgeConfirmation> },
+  TContext
+> => {
+  return useMutation(
+    getConfirmMyAgeApiV1UsersMeAgeConfirmationPostMutationOptions(options),
     queryClient
   );
 };

--- a/frontend/src/components/ConfirmAge.tsx
+++ b/frontend/src/components/ConfirmAge.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { apiClient } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/hooks/useAuth";
+import { getErrorMessage } from "@/lib/errorMessage";
+
+/**
+ * The screen an account meets when it is already in a community the whole
+ * deployment can browse, without having said how old it is.
+ *
+ * It blocks the app for the same reason the handle screen does: the answer is
+ * owed before anything else happens, and there is no version of the app that
+ * works without it. Most people never see it — the directory's Join button
+ * asks first, and ticking the box there is the whole of it. This is for the
+ * ways in that had nobody at a keyboard to ask: an invite redeemed on the way
+ * to somewhere else, a group sync, an admin adding somebody, or a guild that
+ * listed itself long after they joined it.
+ *
+ * There is deliberately no "no" button. Declining is signing out, which the
+ * account can already do, and a decline that emptied their memberships would
+ * be this screen deciding something far larger than it was asked.
+ */
+export const ConfirmAge = () => {
+  const { t } = useTranslation(["auth", "common"]);
+  const { refreshUser, logout } = useAuth();
+  const [checked, setChecked] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiClient.post("/users/me/age-confirmation", { confirmed: true });
+      await refreshUser();
+    } catch (err) {
+      setError(getErrorMessage(err, "auth:confirmAge.error"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>{t("confirmAge.title")}</CardTitle>
+          <CardDescription>{t("confirmAge.subtitle")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="confirm-age"
+                checked={checked}
+                onCheckedChange={(value) => setChecked(value === true)}
+                disabled={submitting}
+              />
+              <Label htmlFor="confirm-age" className="font-normal leading-snug">
+                {t("confirmAge.checkboxLabel")}
+              </Label>
+            </div>
+            {error && <p className="text-destructive text-sm">{error}</p>}
+            <Button type="submit" className="w-full" disabled={submitting || !checked}>
+              {submitting ? t("common:submitting") : t("confirmAge.submit")}
+            </Button>
+            <Button type="button" variant="ghost" className="w-full" onClick={() => void logout()}>
+              {t("confirmAge.signOut")}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/frontend/src/components/guilds/AgeConfirmationDialog.tsx
+++ b/frontend/src/components/guilds/AgeConfirmationDialog.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { apiClient } from "@/api/client";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/hooks/useAuth";
+import { getErrorMessage } from "@/lib/errorMessage";
+
+/**
+ * The box a directory Join asks to have ticked, once per account.
+ *
+ * Asked here, before the join, so the answer is what joins rather than
+ * something the server comes back and demands. Once given it is kept on the
+ * account, so the second community somebody joins asks nothing.
+ *
+ * ``onConfirmed`` runs after the confirmation is recorded and the account has
+ * been refreshed, which is what the caller resumes its join from.
+ */
+export const AgeConfirmationDialog = ({
+  open,
+  onOpenChange,
+  onConfirmed,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirmed: () => void;
+}) => {
+  const { t } = useTranslation(["guilds", "auth", "common"]);
+  const { refreshUser } = useAuth();
+  const [checked, setChecked] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const confirm = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiClient.post("/users/me/age-confirmation", { confirmed: true });
+      await refreshUser();
+      onOpenChange(false);
+      setChecked(false);
+      onConfirmed();
+    } catch (err) {
+      setError(getErrorMessage(err, "auth:confirmAge.error"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("auth:confirmAge.title")}</DialogTitle>
+          <DialogDescription>{t("guilds:community.ageGateBody")}</DialogDescription>
+        </DialogHeader>
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="community-confirm-age"
+            checked={checked}
+            onCheckedChange={(value) => setChecked(value === true)}
+            disabled={submitting}
+          />
+          <Label htmlFor="community-confirm-age" className="font-normal leading-snug">
+            {t("auth:confirmAge.checkboxLabel")}
+          </Label>
+        </div>
+        {error ? <p className="text-destructive text-sm">{error}</p> : null}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {t("common:cancel")}
+          </Button>
+          <Button onClick={() => void confirm()} disabled={!checked || submitting}>
+            {submitting ? t("common:submitting") : t("guilds:community.ageGateConfirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/guilds/CommunityCard.tsx
+++ b/frontend/src/components/guilds/CommunityCard.tsx
@@ -15,13 +15,17 @@
 
 import { useNavigate } from "@tanstack/react-router";
 import { Loader2, Users } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { CommunityGuildRead } from "@/api/generated/initiativeAPI.schemas";
+import { AgeConfirmationDialog } from "@/components/guilds/AgeConfirmationDialog";
 import { GuildAvatar } from "@/components/guilds/GuildSidebar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { useAppConfig } from "@/hooks/useAppConfig";
+import { useAuth } from "@/hooks/useAuth";
 import { useJoinCommunityGuild } from "@/hooks/useCommunities";
 import { useGuilds } from "@/hooks/useGuilds";
 import { renderableBanner } from "@/lib/banner";
@@ -35,13 +39,27 @@ export const CommunityCard = ({ guild }: { guild: CommunityGuildRead }) => {
   const navigate = useNavigate();
   const { refreshGuilds, switchGuild } = useGuilds();
   const join = useJoinCommunityGuild();
+  const { user } = useAuth();
+  const { communityAgeGateEnabled } = useAppConfig();
+  const [askingAge, setAskingAge] = useState(false);
+
+  // Somebody may only take a place in a listed guild once they have said they
+  // are 13 or older. Asked here, before the join, so ticking the box is what
+  // joins — the server refuses it either way, and being refused after clicking
+  // Join is a worse way to be asked a question you can answer.
+  const needsAgeConfirmation = communityAgeGateEnabled && !user?.age_confirmed_at;
 
   const open = () => {
     void switchGuild(guild.id);
     void navigate({ to: guildPath(guild.id, "/") });
   };
 
-  const handleJoin = async () => {
+  // The join itself, with no age check in it. The dialog resumes through this
+  // rather than through ``handleJoin``: it calls back the moment the
+  // confirmation is recorded, which is before React has re-rendered this card
+  // with the refreshed account — so a check here would still read the stale
+  // "not confirmed" and reopen the dialog it was just dismissed from.
+  const performJoin = async () => {
     try {
       await join.mutateAsync(guild.id);
       // The switcher is built from the caller's memberships, so it has to learn
@@ -55,91 +73,106 @@ export const CommunityCard = ({ guild }: { guild: CommunityGuildRead }) => {
     }
   };
 
+  const handleJoin = () => {
+    if (needsAgeConfirmation) {
+      setAskingAge(true);
+      return;
+    }
+    void performJoin();
+  };
+
   const banner = renderableBanner(guild.banner);
 
   return (
-    <Card className="flex h-full flex-col overflow-hidden">
-      {banner.image_url ? (
-        <img
-          src={banner.image_url}
-          alt=""
-          className="aspect-[4/1] w-full object-cover"
-          loading="lazy"
-        />
-      ) : (
-        <div
-          className="aspect-[4/1] w-full"
-          style={{ backgroundColor: banner.color }}
-          aria-hidden="true"
-        />
-      )}
-      <CardContent className="flex flex-1 flex-col gap-3 p-4">
-        <div className="flex items-start gap-3">
-          <GuildAvatar name={guild.name} icon={guild.icon_url} active={false} />
-          <div className="min-w-0 flex-1">
-            <h3 className="truncate font-semibold text-base" title={guild.name}>
-              {guild.name}
-            </h3>
-            <p className="flex flex-wrap items-center gap-x-1.5 text-muted-foreground text-xs">
-              {/* Who is here now, then how many there are in all. A guild with
+    <>
+      <AgeConfirmationDialog
+        open={askingAge}
+        onOpenChange={setAskingAge}
+        onConfirmed={() => void performJoin()}
+      />
+      <Card className="flex h-full flex-col overflow-hidden">
+        {banner.image_url ? (
+          <img
+            src={banner.image_url}
+            alt=""
+            className="aspect-[4/1] w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div
+            className="aspect-[4/1] w-full"
+            style={{ backgroundColor: banner.color }}
+            aria-hidden="true"
+          />
+        )}
+        <CardContent className="flex flex-1 flex-col gap-3 p-4">
+          <div className="flex items-start gap-3">
+            <GuildAvatar name={guild.name} icon={guild.icon_url} active={false} />
+            <div className="min-w-0 flex-1">
+              <h3 className="truncate font-semibold text-base" title={guild.name}>
+                {guild.name}
+              </h3>
+              <p className="flex flex-wrap items-center gap-x-1.5 text-muted-foreground text-xs">
+                {/* Who is here now, then how many there are in all. A guild with
                   nobody in it says nothing rather than "0 online", which reads
                   as a verdict on the guild rather than on the moment. */}
-              {guild.online_count > 0 ? (
-                <>
-                  <span className="flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
-                    <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
-                    {t("guilds:community.onlineCount", { count: guild.online_count })}
-                  </span>
-                  <span aria-hidden="true">·</span>
-                </>
-              ) : null}
-              <span className="flex items-center gap-1">
-                <Users className="h-3 w-3" aria-hidden="true" />
-                {t("guilds:memberCount", { count: guild.member_count })}
-              </span>
-            </p>
+                {guild.online_count > 0 ? (
+                  <>
+                    <span className="flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+                      <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden="true" />
+                      {t("guilds:community.onlineCount", { count: guild.online_count })}
+                    </span>
+                    <span aria-hidden="true">·</span>
+                  </>
+                ) : null}
+                <span className="flex items-center gap-1">
+                  <Users className="h-3 w-3" aria-hidden="true" />
+                  {t("guilds:memberCount", { count: guild.member_count })}
+                </span>
+              </p>
+            </div>
           </div>
-        </div>
 
-        <p
-          className={
-            guild.description
-              ? "line-clamp-3 text-muted-foreground text-sm"
-              : "text-muted-foreground/70 text-sm italic"
-          }
-        >
-          {guild.description || t("guilds:community.noDescription")}
-        </p>
+          <p
+            className={
+              guild.description
+                ? "line-clamp-3 text-muted-foreground text-sm"
+                : "text-muted-foreground/70 text-sm italic"
+            }
+          >
+            {guild.description || t("guilds:community.noDescription")}
+          </p>
 
-        {guild.categories.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5">
-            {guild.categories.map((category) => (
-              <Badge key={category} variant="secondary" className="font-normal">
-                {guildCategoryLabel(category, t)}
-              </Badge>
-            ))}
+          {guild.categories.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {guild.categories.map((category) => (
+                <Badge key={category} variant="secondary" className="font-normal">
+                  {guildCategoryLabel(category, t)}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="mt-auto pt-1">
+            {guild.already_member ? (
+              <Button variant="outline" className="w-full" onClick={open}>
+                {t("guilds:community.open")}
+              </Button>
+            ) : (
+              <Button className="w-full" onClick={handleJoin} disabled={join.isPending}>
+                {join.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    {t("guilds:community.joining")}
+                  </>
+                ) : (
+                  t("guilds:community.join")
+                )}
+              </Button>
+            )}
           </div>
-        ) : null}
-
-        <div className="mt-auto pt-1">
-          {guild.already_member ? (
-            <Button variant="outline" className="w-full" onClick={open}>
-              {t("guilds:community.open")}
-            </Button>
-          ) : (
-            <Button className="w-full" onClick={handleJoin} disabled={join.isPending}>
-              {join.isPending ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                  {t("guilds:community.joining")}
-                </>
-              ) : (
-                t("guilds:community.join")
-              )}
-            </Button>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </>
   );
 };

--- a/frontend/src/hooks/useAgeGateRefresh.test.tsx
+++ b/frontend/src/hooks/useAgeGateRefresh.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * The age gate has to be answerable in a tab that was already open.
+ *
+ * What matters here is the pair: an account that still owes a confirmation
+ * re-reads itself when its tab comes back, and one that has already answered
+ * costs nothing — no listener, no request, forever.
+ */
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildUser } from "@/__tests__/factories";
+
+const refreshUser = vi.fn();
+const state = vi.hoisted(() => ({
+  user: null as ReturnType<typeof import("@/__tests__/factories").buildUser> | null,
+  ageGate: true,
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: state.user, refreshUser }),
+}));
+
+vi.mock("@/hooks/useAppConfig", () => ({
+  useAppConfig: () => ({ communityAgeGateEnabled: state.ageGate }),
+}));
+
+import { useAgeGateRefresh } from "./useAgeGateRefresh";
+
+const returnToTab = () => act(() => void window.dispatchEvent(new Event("focus")));
+
+describe("useAgeGateRefresh", () => {
+  beforeEach(() => {
+    refreshUser.mockClear().mockResolvedValue(undefined);
+    state.ageGate = true;
+    state.user = buildUser({ age_confirmed_at: null });
+  });
+
+  it("re-reads an unconfirmed account when its tab comes back", () => {
+    renderHook(() => useAgeGateRefresh());
+
+    returnToTab();
+
+    expect(refreshUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks nothing of an account that has already answered", () => {
+    state.user = buildUser({ age_confirmed_at: "2026-01-01T00:00:00Z" });
+    renderHook(() => useAgeGateRefresh());
+
+    returnToTab();
+
+    expect(refreshUser).not.toHaveBeenCalled();
+  });
+
+  it("asks nothing where the deployment does not ask", () => {
+    state.ageGate = false;
+    renderHook(() => useAgeGateRefresh());
+
+    returnToTab();
+
+    expect(refreshUser).not.toHaveBeenCalled();
+  });
+
+  it("stops listening once it is unmounted", () => {
+    const { unmount } = renderHook(() => useAgeGateRefresh());
+    unmount();
+
+    returnToTab();
+
+    expect(refreshUser).not.toHaveBeenCalled();
+  });
+
+  it("leaves the gate as it was when the re-read fails", async () => {
+    refreshUser.mockRejectedValue(new Error("offline"));
+    renderHook(() => useAgeGateRefresh());
+
+    returnToTab();
+
+    // Rejection is swallowed: switching tabs is not a moment for an error.
+    await expect(Promise.resolve()).resolves.toBeUndefined();
+    expect(refreshUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useAgeGateRefresh.test.tsx
+++ b/frontend/src/hooks/useAgeGateRefresh.test.tsx
@@ -71,6 +71,48 @@ describe("useAgeGateRefresh", () => {
     expect(refreshUser).not.toHaveBeenCalled();
   });
 
+  it("re-reads on a backstop interval, for a tab that is never left", () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useAgeGateRefresh());
+
+      // No focus event ever fires: this tab has been open and focused all day.
+      act(() => void vi.advanceTimersByTime(5 * 60 * 1000));
+
+      expect(refreshUser).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("runs no backstop for an account that has already answered", () => {
+    vi.useFakeTimers();
+    try {
+      state.user = buildUser({ age_confirmed_at: "2026-01-01T00:00:00Z" });
+      renderHook(() => useAgeGateRefresh());
+
+      act(() => void vi.advanceTimersByTime(60 * 60 * 1000));
+
+      expect(refreshUser).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops the backstop when it is unmounted", () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = renderHook(() => useAgeGateRefresh());
+      unmount();
+
+      act(() => void vi.advanceTimersByTime(60 * 60 * 1000));
+
+      expect(refreshUser).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("leaves the gate as it was when the re-read fails", async () => {
     refreshUser.mockRejectedValue(new Error("offline"));
     renderHook(() => useAgeGateRefresh());

--- a/frontend/src/hooks/useAgeGateRefresh.ts
+++ b/frontend/src/hooks/useAgeGateRefresh.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+
+import { useAppConfig } from "@/hooks/useAppConfig";
+import { useAuth } from "@/hooks/useAuth";
+
+/**
+ * Keeps the age gate answerable in a tab that was already open.
+ *
+ * The signed-in account is read once at boot and then only when something asks
+ * for it again, so a tab open since this morning is deciding the gate on this
+ * morning's answer. Most of what that answer contains cannot change underneath
+ * it — but this can: somebody is added to a listed community by an admin or a
+ * group sync, or a community they were already in lists itself, and from that
+ * moment they are owed a confirmation they will not be asked for until the tab
+ * next loads.
+ *
+ * So the account is re-read when the tab is brought back, which is the moment
+ * something may have changed while its owner was elsewhere — the same reason
+ * the deployment's own config is re-read there.
+ *
+ * Only for an account that has not confirmed yet. Once it has, no membership
+ * or listing anywhere can make the gate apply again, so the listener is not
+ * installed at all and the steady state costs nothing.
+ */
+export const useAgeGateRefresh = () => {
+  const { user, refreshUser } = useAuth();
+  const { communityAgeGateEnabled } = useAppConfig();
+  const outstanding = communityAgeGateEnabled && !!user && !user.age_confirmed_at;
+
+  useEffect(() => {
+    if (!outstanding) return;
+    const recheck = () => {
+      if (document.visibilityState !== "visible") return;
+      void refreshUser().catch(() => {
+        // A failed re-read leaves the gate exactly as it was. The next
+        // navigation or reload asks again; nothing here is worth an error in
+        // front of somebody who only switched tabs.
+      });
+    };
+    window.addEventListener("focus", recheck);
+    document.addEventListener("visibilitychange", recheck);
+    return () => {
+      window.removeEventListener("focus", recheck);
+      document.removeEventListener("visibilitychange", recheck);
+    };
+  }, [outstanding, refreshUser]);
+};

--- a/frontend/src/hooks/useAgeGateRefresh.ts
+++ b/frontend/src/hooks/useAgeGateRefresh.ts
@@ -16,12 +16,22 @@ import { useAuth } from "@/hooks/useAuth";
  *
  * So the account is re-read when the tab is brought back, which is the moment
  * something may have changed while its owner was elsewhere — the same reason
- * the deployment's own config is re-read there.
+ * the deployment's own config is re-read there — and, as a backstop, on a slow
+ * interval, because a tab that is never left never fires a focus event and
+ * would otherwise carry this morning's answer all day.
  *
  * Only for an account that has not confirmed yet. Once it has, no membership
- * or listing anywhere can make the gate apply again, so the listener is not
- * installed at all and the steady state costs nothing.
+ * or listing anywhere can make the gate apply again, so nothing is installed
+ * at all and the steady state costs nothing. The interval is deliberately slow:
+ * the population it runs for is every unconfirmed account, including the ones
+ * in no listed community at all, and what it is catching up with is a prompt
+ * rather than a withdrawal of access — the join itself is refused server-side
+ * regardless of what any tab believes.
  */
+
+/** Backstop cadence for a tab that is never left. Minutes, not seconds. */
+const RECHECK_INTERVAL_MS = 5 * 60 * 1000;
+
 export const useAgeGateRefresh = () => {
   const { user, refreshUser } = useAuth();
   const { communityAgeGateEnabled } = useAppConfig();
@@ -39,9 +49,11 @@ export const useAgeGateRefresh = () => {
     };
     window.addEventListener("focus", recheck);
     document.addEventListener("visibilitychange", recheck);
+    const timer = window.setInterval(recheck, RECHECK_INTERVAL_MS);
     return () => {
       window.removeEventListener("focus", recheck);
       document.removeEventListener("visibilitychange", recheck);
+      window.clearInterval(timer);
     };
   }, [outstanding, refreshUser]);
 };

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -62,5 +62,10 @@ export const useAppConfig = () => {
      *  config loads, and false is also the default — every way into the
      *  directory stays hidden unless the platform owner turned it on. */
     communityDirectoryEnabled: query.data?.community_directory_enabled ?? false,
+    /** Whether this deployment asks an account to confirm it is 13 or older
+     *  before it belongs to a listed guild. True until the config loads, and
+     *  true is also the default — the question is the safe thing to ask when
+     *  we do not yet know, and the server refuses the join either way. */
+    communityAgeGateEnabled: query.data?.community_age_gate_enabled ?? true,
   };
 };

--- a/frontend/src/pages/SettingsCommunityPage.test.tsx
+++ b/frontend/src/pages/SettingsCommunityPage.test.tsx
@@ -13,11 +13,12 @@ import { buildUser } from "@/__tests__/factories";
 import { renderWithProviders } from "@/__tests__/helpers/render";
 
 const updateMutate = vi.fn();
-const config = vi.hoisted(() => ({ communityDirectory: false }));
+const config = vi.hoisted(() => ({ communityDirectory: false, ageGate: true }));
 
 vi.mock("@/hooks/useAppConfig", () => ({
   useAppConfig: () => ({
     communityDirectoryEnabled: config.communityDirectory,
+    communityAgeGateEnabled: config.ageGate,
     isLoading: false,
   }),
 }));
@@ -39,6 +40,7 @@ describe("SettingsCommunityPage", () => {
   beforeEach(() => {
     updateMutate.mockClear();
     config.communityDirectory = false;
+    config.ageGate = true;
   });
 
   it("starts off, matching a deployment that has never turned it on", async () => {
@@ -62,6 +64,53 @@ describe("SettingsCommunityPage", () => {
     fireEvent.click(toggle());
 
     expect(updateMutate).toHaveBeenCalledWith({ community_directory_enabled: false });
+  });
+
+  const ageToggle = () => screen.getByLabelText("Ask members to confirm they are 13 or older");
+
+  it("starts asking members their age", async () => {
+    renderPage();
+
+    expect(
+      await screen.findByLabelText("Ask members to confirm they are 13 or older")
+    ).toBeChecked();
+  });
+
+  it("only stops asking once the owner asserts everyone here is an adult", async () => {
+    renderPage();
+    fireEvent.click(ageToggle());
+
+    // The switch alone writes nothing — the assertion is the confirmation.
+    expect(updateMutate).not.toHaveBeenCalled();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Everyone here is 18 or older" }));
+
+    expect(updateMutate).toHaveBeenCalledWith({
+      community_directory_enabled: false,
+      age_gate_enabled: false,
+    });
+  });
+
+  it("turns the question back on without asking anything", () => {
+    config.ageGate = false;
+    renderPage();
+
+    expect(ageToggle()).not.toBeChecked();
+    fireEvent.click(ageToggle());
+
+    expect(updateMutate).toHaveBeenCalledWith({
+      community_directory_enabled: false,
+      age_gate_enabled: true,
+    });
+  });
+
+  it("carries the age gate through a directory toggle unchanged", () => {
+    renderPage();
+    fireEvent.click(toggle());
+
+    // The directory switch writes only its own half; omitting the other is
+    // what leaves the owner's assertion alone.
+    expect(updateMutate).toHaveBeenCalledWith({ community_directory_enabled: true });
   });
 
   it("is not offered below the owner tier", () => {

--- a/frontend/src/pages/SettingsCommunityPage.tsx
+++ b/frontend/src/pages/SettingsCommunityPage.tsx
@@ -12,9 +12,11 @@
  * everyone else's.
  */
 
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useAppConfig } from "@/hooks/useAppConfig";
@@ -28,7 +30,10 @@ export const SettingsCommunityPage = () => {
   const { t } = useTranslation("settings");
   const { user } = useAuth();
   const isPlatformAdmin = hasCapability(user, Capability.configManage);
-  const { communityDirectoryEnabled, isLoading } = useAppConfig();
+  const { communityDirectoryEnabled, communityAgeGateEnabled, isLoading } = useAppConfig();
+  // Turning the age gate off is an assertion about every account here, not a
+  // preference, so it is confirmed. Turning it back on is not.
+  const [confirmingAgeGateOff, setConfirmingAgeGateOff] = useState(false);
 
   const update = useUpdateCommunitySettings({
     onSuccess: (result) => {
@@ -69,6 +74,45 @@ export const SettingsCommunityPage = () => {
         {/* Turning it back off is not a punishment for the guilds that opted
             in, and saying so up front stops it reading like one. */}
         <p className="text-muted-foreground text-xs">{t("community.reversibleNote")}</p>
+
+        {/* The second switch. Shown regardless of the first, so an owner can
+            settle it before opening the directory rather than discovering it
+            once people are already arriving. */}
+        <div className="space-y-4 border-t pt-4">
+          <div className="flex items-center gap-3">
+            <Switch
+              id="community-age-gate-enabled"
+              checked={communityAgeGateEnabled}
+              disabled={isLoading || update.isPending}
+              onCheckedChange={(checked) => {
+                if (checked) {
+                  update.mutate({
+                    community_directory_enabled: communityDirectoryEnabled,
+                    age_gate_enabled: true,
+                  });
+                  return;
+                }
+                setConfirmingAgeGateOff(true);
+              }}
+            />
+            <Label htmlFor="community-age-gate-enabled">{t("community.ageGateLabel")}</Label>
+          </div>
+          <p className="text-muted-foreground text-sm">{t("community.ageGateHelpText")}</p>
+        </div>
+
+        <ConfirmDialog
+          open={confirmingAgeGateOff}
+          onOpenChange={setConfirmingAgeGateOff}
+          title={t("community.ageGateOffTitle")}
+          description={t("community.ageGateOffBody")}
+          confirmLabel={t("community.ageGateOffConfirm")}
+          onConfirm={() =>
+            update.mutate({
+              community_directory_enabled: communityDirectoryEnabled,
+              age_gate_enabled: false,
+            })
+          }
+        />
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/communities/CommunitiesPage.test.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.test.tsx
@@ -10,7 +10,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildBanner } from "@/__tests__/factories";
+import { buildBanner, buildUser } from "@/__tests__/factories";
 import { renderPage } from "@/__tests__/helpers/render";
 import type { CommunityGuildRead } from "@/api/generated/initiativeAPI.schemas";
 
@@ -27,11 +27,12 @@ vi.mock("@/hooks/useCommunities", () => ({
 
 // Whether this deployment has a directory at all is the platform owner's
 // setting; everything below is about one that does, bar the test that says so.
-const config = vi.hoisted(() => ({ communityDirectory: true }));
+const config = vi.hoisted(() => ({ communityDirectory: true, ageGate: true }));
 
 vi.mock("@/hooks/useAppConfig", () => ({
   useAppConfig: () => ({
     communityDirectoryEnabled: config.communityDirectory,
+    communityAgeGateEnabled: config.ageGate,
     isLoading: false,
   }),
 }));
@@ -49,8 +50,15 @@ const community = (overrides: Partial<CommunityGuildRead> = {}): CommunityGuildR
   ...overrides,
 });
 
-const renderDirectory = (search: Record<string, unknown> = {}) =>
-  renderPage(CommunitiesPage, { initialRoute: "/communities", routerSearch: search });
+const renderDirectory = (
+  search: Record<string, unknown> = {},
+  auth?: { user: ReturnType<typeof buildUser> }
+) =>
+  renderPage(CommunitiesPage, {
+    initialRoute: "/communities",
+    routerSearch: search,
+    ...(auth ? { auth } : {}),
+  });
 
 /** The infinite-query shape the page reads: pages of items plus the paging
  *  flags. `total` is how many matched, so it can exceed what is loaded. */
@@ -67,6 +75,7 @@ const directoryResult = (items: CommunityGuildRead[], overrides: Record<string, 
 beforeEach(() => {
   vi.clearAllMocks();
   config.communityDirectory = true;
+  config.ageGate = true;
   directoryFor.mockReturnValue(directoryResult([community()]));
 });
 
@@ -255,6 +264,30 @@ describe("CommunitiesPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Join" }));
 
     await waitFor(() => expect(join).toHaveBeenCalledWith(1));
+  });
+
+  it("asks an unconfirmed account its age before joining, not after", async () => {
+    join.mockResolvedValue({ id: 1 });
+    renderDirectory({}, { user: buildUser({ age_confirmed_at: null }) });
+    await screen.findByText("Riverside Players");
+
+    await userEvent.click(screen.getByRole("button", { name: "Join" }));
+
+    expect(await screen.findByText("Confirm your age")).toBeInTheDocument();
+    // Nothing joined on the strength of an unanswered question.
+    expect(join).not.toHaveBeenCalled();
+  });
+
+  it("joins without asking where the deployment does not ask", async () => {
+    config.ageGate = false;
+    join.mockResolvedValue({ id: 1 });
+    renderDirectory({}, { user: buildUser({ age_confirmed_at: null }) });
+    await screen.findByText("Riverside Players");
+
+    await userEvent.click(screen.getByRole("button", { name: "Join" }));
+
+    await waitFor(() => expect(join).toHaveBeenCalledWith(1));
+    expect(screen.queryByText("Confirm your age")).not.toBeInTheDocument();
   });
 
   it("offers a way in, not a second join, for a guild already joined", async () => {

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -9,6 +9,7 @@ import { AnnouncementCenter } from "@/components/announcements/AnnouncementCente
 import { UpdateAnnouncementDialog } from "@/components/announcements/UpdateAnnouncementDialog";
 import { ChooseHandle } from "@/components/ChooseHandle";
 import { CommandCenter } from "@/components/CommandCenter";
+import { ConfirmAge } from "@/components/ConfirmAge";
 import { CreateDocumentWizard } from "@/components/documents/CreateDocumentWizard";
 import { GuildAccessBanner } from "@/components/guilds/GuildAccessBanner";
 import { Galaxy } from "@/components/icons/Galaxy";
@@ -108,6 +109,14 @@ function AppLayout() {
   // here, before anything else: it is how everyone else will see them.
   if (!loading && user && !user.username_chosen) {
     return <ChooseHandle />;
+  }
+
+  // Already in a community the whole deployment can browse, without having
+  // said how old they are. Every way into a listed guild that had nobody at a
+  // keyboard to ask lands here — and so does anyone who was already a member
+  // when their guild listed itself.
+  if (!loading && user && user.age_confirmation_required) {
+    return <ConfirmAge />;
   }
 
   // Now we can have conditional returns

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -22,6 +22,7 @@ import { CreateTaskWizard } from "@/components/tasks/CreateTaskWizard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { useAgeGateRefresh } from "@/hooks/useAgeGateRefresh";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { useAuth } from "@/hooks/useAuth";
 import { useBackButton } from "@/hooks/useBackButton";
@@ -85,6 +86,8 @@ function AppLayout() {
   const location = useLocation();
   const { updateAvailable, closeDialog } = useVersionCheck();
 
+  // Only listens while this account still owes a confirmation; see the hook.
+  useAgeGateRefresh();
   useRealtimeUpdates();
   // Personal, cross-guild, and mounted here rather than beside the bell so it
   // survives the bell unmounting with a collapsed sidebar.


### PR DESCRIPTION
## Problem

A deployment that runs the community directory publishes a browsable list of
communities anyone signed in can join without an invite. Social-media
compliance requires that people taking a place in one confirm they are 13 or
older, and there was nowhere for an account to say so.

## Changes

**One flag, one rule.** `users.age_confirmed_at` (NULL = never confirmed) plus
a standing gate that works exactly like `username_chosen`: an account that
belongs to at least one *currently listed* community without having confirmed
meets a blocking screen before anything else. That single rule covers every way
into a listed community — the directory's own Join, an invite, an OIDC group
sync, an admin adding somebody, and a community that listed itself long after
its members joined — so the SSO path needs no case of its own, the same way
handles don't.

The directory's Join button additionally asks up front, so the ordinary path is
a checkbox in a dialog rather than a refusal after the click. The answer lives
on the account, so the second community someone joins asks nothing.

**The owner's off-switch.** `app_settings.community_age_gate_enabled`, on by
default. A platform owner turns it off under Settings › Admin › Community by
confirming every account on the deployment belongs to someone 18 or older —
an assertion, so it is behind a confirm dialog. It is independent of the
directory switch, so toggling the directory does not silently un-assert it.

- [`20260904_0219_community_age_gate.py`](backend/alembic/versions/20260904_0219_community_age_gate.py) — both columns. `public.users` holds its request-path UPDATE per column (0144), so the new column is named for each request floor; `app_settings` is granted table-wide to the owner tier and needs nothing.
- [`guilds.py`](backend/app/services/platform/guilds.py) — `age_confirmation_outstanding` (the standing gate) and `assert_age_confirmed` (the join refusal). Which communities count is `community_listing_filters()`, the same list the directory and the join it authorizes already ask, so a community that leaves the shelf stops holding anybody to this in the same instant.
- [`users.py`](backend/app/api/v1/platform_endpoints/users.py) — `POST /users/me/age-confirmation`, and `/users/me` populates `age_confirmation_required`. It costs a query only for an account that has not confirmed on a deployment that asks, and stops for good once they answer.
- [`ConfirmAge.tsx`](frontend/src/components/ConfirmAge.tsx) — the blocking screen, alongside `ChooseHandle`.
- [`AgeConfirmationDialog.tsx`](frontend/src/components/guilds/AgeConfirmationDialog.tsx) + [`CommunityCard.tsx`](frontend/src/components/guilds/CommunityCard.tsx) — the ask-before-joining half.
- [`SettingsCommunityPage.tsx`](frontend/src/pages/SettingsCommunityPage.tsx) — the owner's second switch.

### Notes for review

- **Existing members of already-listed communities are asked once on next
  load.** That follows from the rule being asked rather than stored, and it is
  the intended behaviour on upgrade.
- Orval output regenerated and committed; new i18n keys added to all four
  locales (`de`/`en`/`es`/`fr`), including the two `errors.json` codes.

## Testing

- `cd backend && pytest app/api/v1/platform_endpoints/guilds_community_test.py` — 54 passed (9 new, covering the join refusal, the confirm-then-join loop, the gate-off path, a membership written the way a sync would, a community listing itself after the fact, the unticked box, and repeat confirmation)
- `cd backend && pytest -n 8 app/api/v1/platform_endpoints/ app/services/platform/` — 955 passed
- `cd backend && pytest -n 8 app/schemas app/core app/db` — 747 passed, 79 skipped
- `cd backend && ruff check app && ty check app` — clean
- `cd frontend && pnpm test:run` — 216 files, 2405 passed (6 new)
- `cd frontend && npx tsc --noEmit && pnpm lint` — clean