### PR TITLE
Say when a picker has nothing to offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Smart chips: a chip that keeps itself current.** Type `/` in a document, or pick **Smart chip** from the toolbar's insert menu, and choose a task's status, assignee, due date or priority, a counter's value, or an event's date. The chip carries the reading itself — `In progress`, `42 / 100`, `12 Sep` — so it sits in a sentence without repeating what the sentence already says; hover it for what the thing is called now and what kind of thing it is, and click to open it. Move a task to Done and it turns green in every document that mentions it.
 
+- **Pickers open on what you were just working on.** Choosing what a smart chip is about starts from the work in this initiative you edited most recently, so the common case is picking from a list rather than guessing at a search term. Typing still searches.
+
 - **A picker that finds nothing says so.** `#` and the smart-chip picker reach the work in the document's own initiative, so a community full of matching tasks can still answer nothing — and both used to render that as an unchanged caret and an empty box, which reads as a broken feature rather than as an answer. They now say that nothing matched, and that the initiative is the limit.
 
 - **Comments grew up.** React with an emoji (the author hears about it in a digest, not one ping per thumbs-up), turn comments off per tool under Settings › Advanced, and read them through the MCP server as well as write them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Smart chips: a chip that keeps itself current.** Type `/` in a document, or pick **Smart chip** from the toolbar's insert menu, and choose a task's status, assignee, due date or priority, a counter's value, or an event's date. The chip carries the reading itself — `In progress`, `42 / 100`, `12 Sep` — so it sits in a sentence without repeating what the sentence already says; hover it for what the thing is called now and what kind of thing it is, and click to open it. Move a task to Done and it turns green in every document that mentions it.
 
+- **A picker that finds nothing says so.** `#` and the smart-chip picker reach the work in the document's own initiative, so a community full of matching tasks can still answer nothing — and both used to render that as an unchanged caret and an empty box, which reads as a broken feature rather than as an answer. They now say that nothing matched, and that the initiative is the limit.
+
 - **Comments grew up.** React with an emoji (the author hears about it in a digest, not one ping per thumbs-up), turn comments off per tool under Settings › Advanced, and read them through the MCP server as well as write them.
 
 - **Shift-click picks a run of cards.** Selecting projects, documents, queues, counter groups or dashboards no longer means one click per card: click the first, hold shift and click the last, and everything between them comes with it. Shift-clicking away from a card you just unticked clears that run the same way.

--- a/backend/app/api/v1/tenant_endpoints/search.py
+++ b/backend/app/api/v1/tenant_endpoints/search.py
@@ -77,6 +77,39 @@ async def search_guild(
     )
 
 
+@router.get("/recent", response_model=List[SearchSuggestion])
+async def recent_guild(
+    session: RLSSessionDep,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    guild_context: GuildContextDep,
+    types: Optional[List[SearchEntityType]] = Query(
+        default=None, description=_TYPE_DESCRIPTION
+    ),
+    initiative_id: Optional[int] = Query(
+        default=None, description="Restrict to one initiative."
+    ),
+    template: Optional[bool] = Query(default=None, description=_TEMPLATE_DESCRIPTION),
+    limit: int = Query(default=search_service.SUGGEST_LIMIT, ge=1),
+) -> List[SearchSuggestion]:
+    """What a picker offers before anything has been typed.
+
+    The most recently changed things the caller could name, taking the same
+    ``types``, ``initiative_id`` and ``template`` narrowing as the search — so
+    what a picker suggests and what it finds are the same set of things.
+    """
+    return await search_service.recent(
+        session,
+        user_id=current_user.id,
+        guild_id=guild_context.guild_id,
+        filters=search_service.Filters(
+            types=types,
+            initiative_id=initiative_id,
+            template=template,
+        ),
+        limit=limit,
+    )
+
+
 @router.get("/suggest", response_model=List[SearchSuggestion])
 async def suggest_guild(
     session: RLSSessionDep,

--- a/backend/app/api/v1/tenant_endpoints/search_test.py
+++ b/backend/app/api/v1/tenant_endpoints/search_test.py
@@ -499,3 +499,60 @@ async def test_a_template_picker_is_a_wider_net_not_a_looser_one(
     )
     assert response.status_code == 200, response.text
     assert private_template.id not in {r["entity_id"] for r in response.json()}
+
+
+async def _recent(client, actor: Actor, **params) -> list[dict]:
+    response = await client.get(
+        actor.g("/search/recent"), headers=actor.headers, params=params
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+async def test_recent_answers_what_a_picker_opens_with(
+    client, session, acting_user: ActingUser
+) -> None:
+    """A picker opens before anything is typed, which the search cannot answer:
+    it matches words, and there are none yet."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project, title="older")
+    await create_task(session, a.project, title="newer")
+
+    titles = [item["title"] for item in await _recent(client, a, types="task")]
+    assert set(titles) == {"older", "newer"}
+
+
+async def test_recent_takes_the_same_narrowing_the_search_does(
+    client, session, acting_user: ActingUser
+) -> None:
+    """What a picker suggests and what it finds must be the same set of things,
+    or picking from the list offers what typing could not."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    await create_task(session, a.project, title="a task")
+    await create_document(session, a.initiative, a.user)
+
+    tasks = await _recent(client, a, types="task")
+    assert {item["entity_type"] for item in tasks} == {"task"}
+
+    elsewhere = await _recent(
+        client, a, types="task", initiative_id=a.initiative.id + 999
+    )
+    assert elsewhere == []
+
+
+async def test_recent_stops_at_the_same_gate_the_search_does(
+    client, session, acting_user: ActingUser
+) -> None:
+    """Suggestions are content, so they answer under the sharing that governs
+    the things themselves."""
+    a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    b = await acting_user(
+        guild_role=GuildRole.member,
+        guild=a.guild,
+        initiative=a.initiative,
+        initiative_role="member",
+    )
+    await create_task(session, a.project, title="private work")
+
+    assert await _recent(client, a, types="task") != []
+    assert await _recent(client, b, types="task") == []

--- a/backend/app/services/tenant/search.py
+++ b/backend/app/services/tenant/search.py
@@ -384,6 +384,50 @@ async def suggest(
     return [SearchSuggestion.model_validate(r, from_attributes=True) for r in rows]
 
 
+async def recent(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    guild_id: int,
+    filters: Filters = Filters(),
+    limit: int = SUGGEST_LIMIT,
+) -> list[SearchSuggestion]:
+    """The things most recently changed that a picker could offer.
+
+    What a picker shows before anything is typed. :func:`suggest` answers "take
+    me to the thing I am naming"; this answers "what might I be naming", which
+    is the same question a person is asking when they open a picker and have
+    not yet decided.
+
+    Deliberately the same rows, filters and gate as :func:`suggest` — only the
+    ordering differs — so a picker cannot offer something its own search would
+    refuse to find.
+    """
+    limit = max(1, min(limit, SUGGEST_LIMIT))
+    clause = filters.clause() & search_scope_clause(user_id, guild_id=guild_id)
+    rows = (
+        await session.exec(
+            select(
+                SearchEntry.entity_type,
+                SearchEntry.entity_id,
+                SearchEntry.initiative_id,
+                SearchEntry.dac_tool.label("tool"),
+                SearchEntry.dac_id.label("tool_id"),
+                SearchEntry.title,
+            )
+            # One row per thing: the index holds a row per body chunk as well.
+            .where(clause, SearchEntry.chunk_ix == 0)
+            .order_by(
+                SearchEntry.updated_at.desc(),
+                SearchEntry.entity_type,
+                SearchEntry.entity_id,
+            )
+            .limit(limit)
+        )
+    ).all()
+    return [SearchSuggestion.model_validate(r, from_attributes=True) for r in rows]
+
+
 def prefix_tsquery(text: str):
     """A query whose last word matches as a prefix, or ``None`` for no terms.
 

--- a/docs/en/guides/documents.md
+++ b/docs/en/guides/documents.md
@@ -56,7 +56,7 @@ A few keys do more than they look:
 
 A link tells you something exists. A **smart chip** tells you what it's doing right now.
 
-Type `/` in a text document and pick one, or choose **Smart chip** from the toolbar's insert menu and pick the thing first:
+Type `/` in a text document and pick one, or choose **Smart chip** from the toolbar's insert menu and pick the thing first. Either way the picker opens on the work you edited most recently, so there is usually nothing to type:
 
 | Smart chip | Shows |
 |---|---|

--- a/frontend/public/locales/de/documents.json
+++ b/frontend/public/locales/de/documents.json
@@ -331,6 +331,9 @@
   },
   "references": {
     "gone": "Gelöscht",
+    "noMatches": "Nichts in dieser Initiative passt zu „{{query}}“.",
+    "scopeHint": "Hier lässt sich nur die Initiative dieses Dokuments benennen.",
+    "searching": "Suche läuft …",
     "unavailable": "Das ist für dich nicht mehr verfügbar"
   },
   "settings": {
@@ -393,13 +396,18 @@
     "counterValue": "Zählerstand",
     "eventWhen": "Termindatum",
     "insert": "Smart-Chip",
+    "noInitiative": "Dieses Dokument gehört zu keiner Initiative, also gibt es noch nichts zum Verweisen.",
+    "noMatches": "Nichts in dieser Initiative passt zu „{{query}}“.",
     "none": "Keine",
     "openHint": "Zum Öffnen klicken",
+    "scopeHint": "Hier lässt sich nur die Initiative dieses Dokuments benennen.",
     "searchPlaceholder": "Suche etwas zum Anzeigen",
+    "searching": "Suche läuft …",
     "taskAssignee": "Zuständige Person",
     "taskDue": "Fälligkeitsdatum",
     "taskPriority": "Priorität",
     "taskStatus": "Aufgabenstatus",
+    "typeToSearch": "Tippe, um etwas in dieser Initiative zu finden.",
     "whichFact": "Welchen Wert soll der Chip anzeigen?"
   },
   "smartLink": {

--- a/frontend/public/locales/de/documents.json
+++ b/frontend/public/locales/de/documents.json
@@ -399,7 +399,9 @@
     "noInitiative": "Dieses Dokument gehört zu keiner Initiative, also gibt es noch nichts zum Verweisen.",
     "noMatches": "Nichts in dieser Initiative passt zu „{{query}}“.",
     "none": "Keine",
+    "nothingYet": "In dieser Initiative gibt es noch nichts, worauf verwiesen werden kann.",
     "openHint": "Zum Öffnen klicken",
+    "recent": "Zuletzt bearbeitet",
     "scopeHint": "Hier lässt sich nur die Initiative dieses Dokuments benennen.",
     "searchPlaceholder": "Suche etwas zum Anzeigen",
     "searching": "Suche läuft …",
@@ -407,7 +409,6 @@
     "taskDue": "Fälligkeitsdatum",
     "taskPriority": "Priorität",
     "taskStatus": "Aufgabenstatus",
-    "typeToSearch": "Tippe, um etwas in dieser Initiative zu finden.",
     "whichFact": "Welchen Wert soll der Chip anzeigen?"
   },
   "smartLink": {

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -399,7 +399,9 @@
     "noInitiative": "This document isn’t in an initiative, so there is nothing to point at yet.",
     "noMatches": "Nothing in this initiative matches “{{query}}”.",
     "none": "None",
+    "nothingYet": "Nothing in this initiative to point at yet.",
     "openHint": "Click to open",
+    "recent": "Recently edited",
     "scopeHint": "Only this document’s initiative can be named here.",
     "searchPlaceholder": "Search for something to show",
     "searching": "Searching…",
@@ -407,7 +409,6 @@
     "taskDue": "Task due date",
     "taskPriority": "Task priority",
     "taskStatus": "Task status",
-    "typeToSearch": "Type to find something in this initiative.",
     "whichFact": "Which fact should the chip show?"
   },
   "smartLink": {

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -331,6 +331,9 @@
   },
   "references": {
     "gone": "Deleted",
+    "noMatches": "Nothing in this initiative matches “{{query}}”.",
+    "scopeHint": "Only this document’s initiative can be named here.",
+    "searching": "Searching…",
     "unavailable": "This is no longer available to you"
   },
   "settings": {
@@ -393,13 +396,18 @@
     "counterValue": "Counter value",
     "eventWhen": "Event date",
     "insert": "Smart chip",
+    "noInitiative": "This document isn’t in an initiative, so there is nothing to point at yet.",
+    "noMatches": "Nothing in this initiative matches “{{query}}”.",
     "none": "None",
     "openHint": "Click to open",
+    "scopeHint": "Only this document’s initiative can be named here.",
     "searchPlaceholder": "Search for something to show",
+    "searching": "Searching…",
     "taskAssignee": "Task assignee",
     "taskDue": "Task due date",
     "taskPriority": "Task priority",
     "taskStatus": "Task status",
+    "typeToSearch": "Type to find something in this initiative.",
     "whichFact": "Which fact should the chip show?"
   },
   "smartLink": {

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -399,7 +399,9 @@
     "noInitiative": "Este documento no pertenece a ninguna iniciativa, así que todavía no hay nada a lo que apuntar.",
     "noMatches": "Nada en esta iniciativa coincide con «{{query}}».",
     "none": "Ninguno",
+    "nothingYet": "Todavía no hay nada en esta iniciativa a lo que apuntar.",
     "openHint": "Haz clic para abrir",
+    "recent": "Editado recientemente",
     "scopeHint": "Aquí solo se puede nombrar la iniciativa de este documento.",
     "searchPlaceholder": "Busca algo que mostrar",
     "searching": "Buscando…",
@@ -407,7 +409,6 @@
     "taskDue": "Fecha de vencimiento",
     "taskPriority": "Prioridad",
     "taskStatus": "Estado de la tarea",
-    "typeToSearch": "Escribe para encontrar algo en esta iniciativa.",
     "whichFact": "¿Qué dato debe mostrar el chip?"
   },
   "smartLink": {

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -331,6 +331,9 @@
   },
   "references": {
     "gone": "Eliminado",
+    "noMatches": "Nada en esta iniciativa coincide con «{{query}}».",
+    "scopeHint": "Aquí solo se puede nombrar la iniciativa de este documento.",
+    "searching": "Buscando…",
     "unavailable": "Esto ya no está disponible para ti"
   },
   "settings": {
@@ -393,13 +396,18 @@
     "counterValue": "Valor del contador",
     "eventWhen": "Fecha del evento",
     "insert": "Chip inteligente",
+    "noInitiative": "Este documento no pertenece a ninguna iniciativa, así que todavía no hay nada a lo que apuntar.",
+    "noMatches": "Nada en esta iniciativa coincide con «{{query}}».",
     "none": "Ninguno",
     "openHint": "Haz clic para abrir",
+    "scopeHint": "Aquí solo se puede nombrar la iniciativa de este documento.",
     "searchPlaceholder": "Busca algo que mostrar",
+    "searching": "Buscando…",
     "taskAssignee": "Persona asignada",
     "taskDue": "Fecha de vencimiento",
     "taskPriority": "Prioridad",
     "taskStatus": "Estado de la tarea",
+    "typeToSearch": "Escribe para encontrar algo en esta iniciativa.",
     "whichFact": "¿Qué dato debe mostrar el chip?"
   },
   "smartLink": {

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -331,6 +331,9 @@
   },
   "references": {
     "gone": "Supprimé",
+    "noMatches": "Rien dans cette initiative ne correspond à « {{query}} ».",
+    "scopeHint": "Seule l’initiative de ce document peut être nommée ici.",
+    "searching": "Recherche…",
     "unavailable": "Ceci ne vous est plus accessible"
   },
   "settings": {
@@ -393,13 +396,18 @@
     "counterValue": "Valeur du compteur",
     "eventWhen": "Date de l'événement",
     "insert": "Puce intelligente",
+    "noInitiative": "Ce document n’appartient à aucune initiative, il n’y a donc rien à désigner pour l’instant.",
+    "noMatches": "Rien dans cette initiative ne correspond à « {{query}} ».",
     "none": "Aucun",
     "openHint": "Cliquez pour ouvrir",
+    "scopeHint": "Seule l’initiative de ce document peut être nommée ici.",
     "searchPlaceholder": "Cherchez quelque chose à afficher",
+    "searching": "Recherche…",
     "taskAssignee": "Personne assignée",
     "taskDue": "Date d'échéance",
     "taskPriority": "Priorité",
     "taskStatus": "Statut de la tâche",
+    "typeToSearch": "Tapez pour trouver quelque chose dans cette initiative.",
     "whichFact": "Quelle information la puce doit-elle afficher ?"
   },
   "smartLink": {

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -399,7 +399,9 @@
     "noInitiative": "Ce document n’appartient à aucune initiative, il n’y a donc rien à désigner pour l’instant.",
     "noMatches": "Rien dans cette initiative ne correspond à « {{query}} ».",
     "none": "Aucun",
+    "nothingYet": "Rien à désigner dans cette initiative pour l’instant.",
     "openHint": "Cliquez pour ouvrir",
+    "recent": "Modifié récemment",
     "scopeHint": "Seule l’initiative de ce document peut être nommée ici.",
     "searchPlaceholder": "Cherchez quelque chose à afficher",
     "searching": "Recherche…",
@@ -407,7 +409,6 @@
     "taskDue": "Date d'échéance",
     "taskPriority": "Priorité",
     "taskStatus": "Statut de la tâche",
-    "typeToSearch": "Tapez pour trouver quelque chose dans cette initiative.",
     "whichFact": "Quelle information la puce doit-elle afficher ?"
   },
   "smartLink": {

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -6708,6 +6708,25 @@ export type SearchGuildApiV1GGuildIdSearchGetParams = {
   offset?: number;
 };
 
+export type RecentGuildApiV1GGuildIdSearchRecentGetParams = {
+  /**
+   * Restrict to these entity types. Omit for the default scope (calendar, calendar_event, counter, counter_group, dashboard, document, project, queue, queue_item, tag, task); naming a type reaches it explicitly.
+   */
+  types?: SearchEntityType[] | null;
+  /**
+   * Restrict to one initiative.
+   */
+  initiative_id?: number | null;
+  /**
+   * Omit for both. ``true`` returns only templates (a template picker), ``false`` only real content (a picker choosing where content goes).
+   */
+  template?: boolean | null;
+  /**
+   * @minimum 1
+   */
+  limit?: number;
+};
+
 export type SuggestGuildApiV1GGuildIdSearchSuggestGetParams = {
   /**
    * What to jump to.

--- a/frontend/src/api/generated/search/search.ts
+++ b/frontend/src/api/generated/search/search.ts
@@ -19,6 +19,7 @@ import type {
 
 import type {
   HTTPValidationError,
+  RecentGuildApiV1GGuildIdSearchRecentGetParams,
   SearchGuildApiV1GGuildIdSearchGetParams,
   SearchResults,
   SearchSuggestion,
@@ -187,6 +188,182 @@ export function useSearchGuildApiV1GGuildIdSearchGet<
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getSearchGuildApiV1GGuildIdSearchGetQueryOptions(guildId, params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * What a picker offers before anything has been typed.
+ *
+ * The most recently changed things the caller could name, taking the same
+ * ``types``, ``initiative_id`` and ``template`` narrowing as the search — so
+ * what a picker suggests and what it finds are the same set of things.
+ * @summary Recent Guild
+ */
+export const recentGuildApiV1GGuildIdSearchRecentGet = (
+  guildId: number,
+  params?: RecentGuildApiV1GGuildIdSearchRecentGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<SearchSuggestion[]>(
+    { url: `/api/v1/g/${guildId}/search/recent`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getRecentGuildApiV1GGuildIdSearchRecentGetQueryKey = (
+  guildId: number,
+  params?: RecentGuildApiV1GGuildIdSearchRecentGetParams
+) => {
+  return [`/api/v1/g/${guildId}/search/recent`, ...(params ? [params] : [])] as const;
+};
+
+export const getRecentGuildApiV1GGuildIdSearchRecentGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: RecentGuildApiV1GGuildIdSearchRecentGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getRecentGuildApiV1GGuildIdSearchRecentGetQueryKey(guildId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>
+  > = ({ signal }) =>
+    recentGuildApiV1GGuildIdSearchRecentGet(guildId, params, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: guildId !== null && guildId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type RecentGuildApiV1GGuildIdSearchRecentGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>
+>;
+export type RecentGuildApiV1GGuildIdSearchRecentGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useRecentGuildApiV1GGuildIdSearchRecentGet<
+  TData = Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params: undefined | RecentGuildApiV1GGuildIdSearchRecentGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+          TError,
+          Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useRecentGuildApiV1GGuildIdSearchRecentGet<
+  TData = Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: RecentGuildApiV1GGuildIdSearchRecentGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+          TError,
+          Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useRecentGuildApiV1GGuildIdSearchRecentGet<
+  TData = Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: RecentGuildApiV1GGuildIdSearchRecentGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Recent Guild
+ */
+
+export function useRecentGuildApiV1GGuildIdSearchRecentGet<
+  TData = Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  guildId: number,
+  params?: RecentGuildApiV1GGuildIdSearchRecentGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof recentGuildApiV1GGuildIdSearchRecentGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getRecentGuildApiV1GGuildIdSearchRecentGetQueryOptions(
+    guildId,
+    params,
+    options
+  );
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData, TError>;

--- a/frontend/src/components/documents/editor/reference-picker.test.tsx
+++ b/frontend/src/components/documents/editor/reference-picker.test.tsx
@@ -1,0 +1,102 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { LexicalExtensionComposer } from "@lexical/react/LexicalExtensionComposer";
+import { screen, waitFor } from "@testing-library/react";
+import { $createParagraphNode, $createTextNode, $getRoot, type LexicalEditor } from "lexical";
+import { HttpResponse } from "msw";
+import { useMemo } from "react";
+import { describe, expect, it } from "vitest";
+
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { renderPage } from "@/__tests__/helpers/render";
+import { documentExtension } from "@/components/documents/editor/document-extension";
+import { Plugins } from "@/components/documents/editor/plugins";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { SmartChipScope } from "@/hooks/useSmartChips";
+
+/**
+ * `#` and the smart-chip picker, in a real document.
+ *
+ * Both are scoped to the document's own initiative, so a guild full of matching
+ * work can still answer nothing — and when it did, neither surface rendered
+ * anything at all. A reader saw an unchanged caret and an empty box and
+ * reasonably concluded the feature was broken. What is asserted here is that an
+ * empty answer LOOKS like an answer.
+ */
+
+const suggestion = {
+  entity_type: "task",
+  entity_id: 12,
+  title: "Ship the release",
+  initiative_id: 7,
+  tool: "project",
+  tool_id: 3,
+};
+
+let editor!: LexicalEditor;
+
+function Grab(): null {
+  const [found] = useLexicalComposerContext();
+  editor = found;
+  return null;
+}
+
+function Harness() {
+  const extension = useMemo(() => documentExtension({ collaborative: false, editable: true }), []);
+  return (
+    <SmartChipScope>
+      <LexicalExtensionComposer extension={extension} contentEditable={null}>
+        <TooltipProvider>
+          <Grab />
+          <Plugins showToolbar={false} initiativeId={7} supportsEntityMentions />
+        </TooltipProvider>
+      </LexicalExtensionComposer>
+    </SmartChipScope>
+  );
+}
+
+/** Type into the document the way a person would, via the editor's own API —
+ *  `userEvent` cannot drive a Lexical contenteditable under jsdom. */
+function type(text: string) {
+  editor.update(
+    () => {
+      const paragraph = $createParagraphNode();
+      const node = $createTextNode(text);
+      paragraph.append(node);
+      $getRoot().clear().append(paragraph);
+      node.select(text.length, text.length);
+    },
+    { discrete: true }
+  );
+}
+
+describe("probe: # in a document", () => {
+  it("opens the picker on a match", async () => {
+    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([suggestion])));
+
+    renderPage(Harness);
+    await waitFor(() => expect(editor).toBeTruthy());
+    type("#ship");
+
+    await waitFor(() => expect(screen.getByText("Ship the release")).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+  });
+
+  it("says so when nothing in the initiative matches", async () => {
+    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([])));
+
+    renderPage(Harness);
+    await waitFor(() => expect(editor).toBeTruthy());
+    type("#zzz");
+
+    // The answer, and why the answer might be empty when the guild is not.
+    await waitFor(
+      () => expect(screen.getByText(/Nothing in this initiative/)).toBeInTheDocument(),
+      {
+        timeout: 4000,
+      }
+    );
+    expect(screen.getByText(/Only this document.s initiative/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
@@ -81,7 +81,7 @@ export function EntityMentionsPlugin({
 
   // The one lookup every picker in the app goes through, narrowed to this
   // initiative's live work.
-  const { data, isFetching } = useGuildSearchSuggest(debouncedQuery, {
+  const { data, isFetching, isPlaceholderData } = useGuildSearchSuggest(debouncedQuery, {
     types: active?.types ?? MENTIONABLE_TYPES,
     initiative_id: initiativeId ?? undefined,
     template: false,
@@ -94,13 +94,19 @@ export function EntityMentionsPlugin({
   // faster than the answer can arrive, though, so what is on screen is held to
   // the kinds asked for now — pressing Enter can only ever insert one of them.
   const wanted = active?.types;
-  const options = useMemo(
+  const shown = useMemo(
     () =>
       (data ?? [])
         .filter((suggestion) => !wanted || wanted.includes(suggestion.entity_type))
         .map((suggestion) => new EntityOption(suggestion)),
     [data, wanted]
   );
+  // What is on screen is the previous query's answer while the next is in
+  // flight. It stays visible so the menu does not blink shut, but it is not an
+  // answer to what has been typed now — so nothing here is offered to the
+  // keyboard, and Enter cannot land on a thing the reader has stopped naming.
+  const stale = isPlaceholderData;
+  const options = useMemo(() => (stale ? [] : shown), [stale, shown]);
 
   const onSelectOption = useCallback(
     (option: EntityOption, nodeToReplace: TextNode | null, closeMenu: () => void) => {
@@ -155,18 +161,19 @@ export function EntityMentionsPlugin({
               <div className="absolute z-10 w-[260px] rounded-md shadow-md">
                 <Command>
                   <CommandList>
-                    {options.length ? (
+                    {shown.length ? (
                       <CommandGroup>
-                        {options.map((option, index) => {
+                        {shown.map((option, index) => {
                           const Icon = hitIcon(option.suggestion);
                           return (
                             <CommandItem
                               key={option.key}
                               value={option.key}
-                              onSelect={() => selectOptionAndCleanUp(option)}
+                              onSelect={() => !stale && selectOptionAndCleanUp(option)}
+                              disabled={stale}
                               className={`flex items-center gap-2 ${
                                 selectedIndex === index ? "bg-accent" : "bg-transparent!"
-                              }`}
+                              } ${stale ? "opacity-50" : ""}`}
                             >
                               <Icon className="h-4 w-4 shrink-0" />
                               <span className="truncate">{option.suggestion.title}</span>

--- a/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { CLICK_COMMAND, COMMAND_PRIORITY_LOW, type TextNode } from "lexical";
 import { type JSX, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 
 import type { SearchSuggestion } from "@/api/generated/initiativeAPI.schemas";
 import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
@@ -66,6 +67,7 @@ export function EntityMentionsPlugin({
   initiativeId,
 }: EntityMentionsPluginProps): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
+  const { t } = useTranslation("documents");
   const navigate = useNavigate();
   const guildId = useActiveGuildId();
   const [queryString, setQueryString] = useState<string | null>(null);
@@ -79,7 +81,7 @@ export function EntityMentionsPlugin({
 
   // The one lookup every picker in the app goes through, narrowed to this
   // initiative's live work.
-  const { data } = useGuildSearchSuggest(debouncedQuery, {
+  const { data, isFetching } = useGuildSearchSuggest(debouncedQuery, {
     types: active?.types ?? MENTIONABLE_TYPES,
     initiative_id: initiativeId ?? undefined,
     template: false,
@@ -148,29 +150,48 @@ export function EntityMentionsPlugin({
       triggerFn={entityMatch}
       options={options}
       menuRenderFn={(anchorElementRef, { selectedIndex, selectOptionAndCleanUp }) =>
-        anchorElementRef.current && options.length
+        anchorElementRef.current
           ? createPortal(
               <div className="absolute z-10 w-[260px] rounded-md shadow-md">
                 <Command>
                   <CommandList>
-                    <CommandGroup>
-                      {options.map((option, index) => {
-                        const Icon = hitIcon(option.suggestion);
-                        return (
-                          <CommandItem
-                            key={option.key}
-                            value={option.key}
-                            onSelect={() => selectOptionAndCleanUp(option)}
-                            className={`flex items-center gap-2 ${
-                              selectedIndex === index ? "bg-accent" : "bg-transparent!"
-                            }`}
-                          >
-                            <Icon className="h-4 w-4 shrink-0" />
-                            <span className="truncate">{option.suggestion.title}</span>
-                          </CommandItem>
-                        );
-                      })}
-                    </CommandGroup>
+                    {options.length ? (
+                      <CommandGroup>
+                        {options.map((option, index) => {
+                          const Icon = hitIcon(option.suggestion);
+                          return (
+                            <CommandItem
+                              key={option.key}
+                              value={option.key}
+                              onSelect={() => selectOptionAndCleanUp(option)}
+                              className={`flex items-center gap-2 ${
+                                selectedIndex === index ? "bg-accent" : "bg-transparent!"
+                              }`}
+                            >
+                              <Icon className="h-4 w-4 shrink-0" />
+                              <span className="truncate">{option.suggestion.title}</span>
+                            </CommandItem>
+                          );
+                        })}
+                      </CommandGroup>
+                    ) : (
+                      // Rendering nothing here is what made `#` look broken: a
+                      // reference is scoped to this document's initiative, so a
+                      // guild full of matches can still leave a reader staring
+                      // at an unchanged caret with no idea why.
+                      <div className="space-y-1 px-3 py-2">
+                        <p className="text-muted-foreground text-sm">
+                          {isFetching
+                            ? t("references.searching")
+                            : t("references.noMatches", { query: active?.query ?? "" })}
+                        </p>
+                        {!isFetching && (
+                          <p className="text-muted-foreground/80 text-xs">
+                            {t("references.scopeHint")}
+                          </p>
+                        )}
+                      </div>
+                    )}
                   </CommandList>
                 </Command>
               </div>,

--- a/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.test.tsx
+++ b/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.test.tsx
@@ -10,11 +10,12 @@ import { renderWithProviders } from "@/__tests__/helpers/render";
 import { SmartChipInsertDialog } from "@/components/ui/editor/plugins/smart-chip-insert-dialog";
 
 /**
- * What the picker says when it has nothing to offer.
+ * What the picker offers, and what it says when it has nothing.
  *
- * It opens with no query, and the lookup answers nothing for an empty one — so
- * every one of these states used to render as a blank box under a search field,
- * which reads as a broken dialog rather than as an answer.
+ * It opens with no query typed, and the lookup matches words — so it cannot
+ * answer "what could I point at", which is the question someone opening a
+ * picker is actually asking. Recently edited work answers that; the states
+ * below are what is left when even that is empty.
  */
 
 const suggestion = {
@@ -24,6 +25,16 @@ const suggestion = {
   initiative_id: 7,
   tool: "project",
   tool_id: 3,
+};
+
+const recent = { ...suggestion, entity_id: 5, title: "Draft the schedule" };
+
+/** Nothing recent, nothing matching — the empty case for both lookups. */
+const nothing = () => {
+  server.use(
+    guildHttp.get("/search/recent", () => HttpResponse.json([])),
+    guildHttp.get("/search/suggest", () => HttpResponse.json([]))
+  );
 };
 
 const open = (initiativeId: number | null = 7) =>
@@ -41,16 +52,29 @@ const open = (initiativeId: number | null = 7) =>
   );
 
 describe("choosing what a smart chip is about", () => {
-  it("asks for a search rather than showing an empty box", async () => {
-    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([])));
+  it("offers recently edited work before anything is typed", async () => {
+    server.use(
+      guildHttp.get("/search/recent", () => HttpResponse.json([recent])),
+      guildHttp.get("/search/suggest", () => HttpResponse.json([]))
+    );
 
     open();
 
-    expect(await screen.findByText(/Type to find something/)).toBeInTheDocument();
+    // The picker opens knowing something, rather than as a blank box.
+    expect(await screen.findByText("Draft the schedule")).toBeInTheDocument();
+    expect(screen.getByText(/Recently edited/)).toBeInTheDocument();
+  });
+
+  it("says so when there is nothing to point at yet", async () => {
+    nothing();
+
+    open();
+
+    expect(await screen.findByText(/Nothing in this initiative to point at/)).toBeInTheDocument();
   });
 
   it("says nothing matched, and why the initiative is the limit", async () => {
-    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([])));
+    nothing();
 
     open();
     await userEvent.type(screen.getByRole("textbox"), "zzz");
@@ -61,17 +85,22 @@ describe("choosing what a smart chip is about", () => {
         timeout: 3000,
       }
     );
-    expect(screen.getByText(/Only this document.s initiative/)).toBeInTheDocument();
+    expect(await screen.findByText(/Only this document.s initiative/)).toBeInTheDocument();
   });
 
   it("says a document outside an initiative has nothing to point at", async () => {
     open(null);
 
     expect(await screen.findByText(/isn.t in an initiative/)).toBeInTheDocument();
+    // The initiative is not worth explaining to a document that has none.
+    expect(screen.queryByText(/Only this document.s initiative/)).not.toBeInTheDocument();
   });
 
   it("lists what the lookup found", async () => {
-    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([suggestion])));
+    server.use(
+      guildHttp.get("/search/recent", () => HttpResponse.json([recent])),
+      guildHttp.get("/search/suggest", () => HttpResponse.json([suggestion]))
+    );
 
     open();
     await userEvent.type(screen.getByRole("textbox"), "ship");

--- a/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.test.tsx
+++ b/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.test.tsx
@@ -1,0 +1,83 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createEditor } from "lexical";
+import { HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { renderWithProviders } from "@/__tests__/helpers/render";
+import { SmartChipInsertDialog } from "@/components/ui/editor/plugins/smart-chip-insert-dialog";
+
+/**
+ * What the picker says when it has nothing to offer.
+ *
+ * It opens with no query, and the lookup answers nothing for an empty one — so
+ * every one of these states used to render as a blank box under a search field,
+ * which reads as a broken dialog rather than as an answer.
+ */
+
+const suggestion = {
+  entity_type: "task",
+  entity_id: 12,
+  title: "Ship the release",
+  initiative_id: 7,
+  tool: "project",
+  tool_id: 3,
+};
+
+const open = (initiativeId: number | null = 7) =>
+  renderWithProviders(
+    <SmartChipInsertDialog
+      chipKind={null}
+      initiativeId={initiativeId}
+      activeEditor={createEditor({
+        onError: (error) => {
+          throw error;
+        },
+      })}
+      onClose={vi.fn()}
+    />
+  );
+
+describe("choosing what a smart chip is about", () => {
+  it("asks for a search rather than showing an empty box", async () => {
+    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([])));
+
+    open();
+
+    expect(await screen.findByText(/Type to find something/)).toBeInTheDocument();
+  });
+
+  it("says nothing matched, and why the initiative is the limit", async () => {
+    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([])));
+
+    open();
+    await userEvent.type(screen.getByRole("textbox"), "zzz");
+
+    await waitFor(
+      () => expect(screen.getByText(/Nothing in this initiative/)).toBeInTheDocument(),
+      {
+        timeout: 3000,
+      }
+    );
+    expect(screen.getByText(/Only this document.s initiative/)).toBeInTheDocument();
+  });
+
+  it("says a document outside an initiative has nothing to point at", async () => {
+    open(null);
+
+    expect(await screen.findByText(/isn.t in an initiative/)).toBeInTheDocument();
+  });
+
+  it("lists what the lookup found", async () => {
+    server.use(guildHttp.get("/search/suggest", () => HttpResponse.json([suggestion])));
+
+    open();
+    await userEvent.type(screen.getByRole("textbox"), "ship");
+
+    await waitFor(() => expect(screen.getByText("Ship the release")).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+  });
+});

--- a/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.tsx
+++ b/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.tsx
@@ -13,9 +13,10 @@ import { $createSmartChipNode } from "@/components/ui/editor/nodes/smart-chip-no
 import { SMART_CHIP_MENU } from "@/components/ui/editor/plugins/smart-chip-menu";
 import { Input } from "@/components/ui/input";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildRecentSuggestions, useGuildSearchSuggest } from "@/hooks/useSearch";
 import { hitIcon } from "@/lib/searchResults";
 import { CHIP_ENTITY_TYPES, chipEntityType, chipKindsFor } from "@/lib/smartChips";
+import { cn } from "@/lib/utils";
 
 /** How many things the chip picker offers. */
 const LIMIT = 8;
@@ -54,13 +55,32 @@ export function SmartChipInsertDialog({
   // that belongs to none has nothing to offer and should say so.
   const hasInitiative = (initiativeId ?? 0) > 0;
 
-  const { data, isFetching } = useGuildSearchSuggest(debounced, {
+  const searched = debounced.trim().length > 0;
+  const narrowing = {
     types,
     initiative_id: initiativeId ?? undefined,
     template: false,
     limit: LIMIT,
-    enabled: hasInitiative,
+  };
+
+  // Two questions, and a picker asks whichever one it is being used for. Before
+  // anything is typed it is "what could I point at", which the lookup cannot
+  // answer — it matches words, and there are none yet.
+  const suggestions = useGuildRecentSuggestions({
+    ...narrowing,
+    enabled: hasInitiative && !searched,
   });
+  const matches = useGuildSearchSuggest(debounced, {
+    ...narrowing,
+    enabled: hasInitiative && searched,
+  });
+
+  const active = searched ? matches : suggestions;
+  // What came back is the previous query's answer, held so the list does not
+  // empty between keystrokes. It is not an answer to what is typed NOW, so it
+  // is shown but cannot be chosen.
+  const stale = searched && matches.isPlaceholderData;
+  const shown = active.data ?? [];
 
   const insert = (kind: SmartChipKind, suggestion: SearchSuggestion) => {
     activeEditor.update(() => {
@@ -112,15 +132,16 @@ export function SmartChipInsertDialog({
     );
   }
 
-  const results = data ?? [];
-  const searched = debounced.trim().length > 0;
   const emptyMessage = !hasInitiative
     ? t("smartChips.noInitiative")
-    : isFetching
+    : active.isFetching
       ? t("smartChips.searching")
       : searched
         ? t("smartChips.noMatches", { query: debounced })
-        : t("smartChips.typeToSearch");
+        : t("smartChips.nothingYet");
+  // The initiative is only worth explaining where there is one; a document
+  // outside every initiative has already been told the whole story.
+  const showScopeHint = hasInitiative && searched && !active.isFetching;
 
   return (
     <div className="space-y-2">
@@ -133,16 +154,17 @@ export function SmartChipInsertDialog({
       />
       <Command shouldFilter={false}>
         <CommandList>
-          {results.length ? (
-            <CommandGroup>
-              {results.map((suggestion) => {
+          {shown.length ? (
+            <CommandGroup heading={searched ? undefined : t("smartChips.recent")}>
+              {shown.map((suggestion) => {
                 const Icon = hitIcon(suggestion);
                 return (
                   <CommandItem
                     key={`${suggestion.entity_type}:${suggestion.entity_id}`}
                     value={`${suggestion.entity_type}:${suggestion.entity_id}`}
-                    onSelect={() => choose(suggestion)}
-                    className="flex items-center gap-2"
+                    onSelect={() => !stale && choose(suggestion)}
+                    disabled={stale}
+                    className={cn("flex items-center gap-2", stale && "opacity-50")}
                   >
                     <Icon className="h-4 w-4 shrink-0" />
                     <span className="truncate">{suggestion.title}</span>
@@ -160,7 +182,7 @@ export function SmartChipInsertDialog({
             // a broken dialog rather than as an answer.
             <div className="space-y-1 px-3 py-6 text-center">
               <p className="text-muted-foreground text-sm">{emptyMessage}</p>
-              {searched && !isFetching && (
+              {showScopeHint && (
                 <p className="text-muted-foreground/80 text-xs">{t("smartChips.scopeHint")}</p>
               )}
             </div>

--- a/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.tsx
+++ b/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.tsx
@@ -50,13 +50,16 @@ export function SmartChipInsertDialog({
   const [chosen, setChosen] = useState<SearchSuggestion | null>(null);
 
   const types: SearchEntityType[] = chipKind ? [chipEntityType(chipKind)] : CHIP_ENTITY_TYPES;
+  // A chip points at work inside this document's own initiative, so a document
+  // that belongs to none has nothing to offer and should say so.
+  const hasInitiative = (initiativeId ?? 0) > 0;
 
-  const { data } = useGuildSearchSuggest(debounced, {
+  const { data, isFetching } = useGuildSearchSuggest(debounced, {
     types,
     initiative_id: initiativeId ?? undefined,
     template: false,
     limit: LIMIT,
-    enabled: (initiativeId ?? 0) > 0,
+    enabled: hasInitiative,
   });
 
   const insert = (kind: SmartChipKind, suggestion: SearchSuggestion) => {
@@ -109,6 +112,16 @@ export function SmartChipInsertDialog({
     );
   }
 
+  const results = data ?? [];
+  const searched = debounced.trim().length > 0;
+  const emptyMessage = !hasInitiative
+    ? t("smartChips.noInitiative")
+    : isFetching
+      ? t("smartChips.searching")
+      : searched
+        ? t("smartChips.noMatches", { query: debounced })
+        : t("smartChips.typeToSearch");
+
   return (
     <div className="space-y-2">
       <Input
@@ -120,27 +133,38 @@ export function SmartChipInsertDialog({
       />
       <Command shouldFilter={false}>
         <CommandList>
-          <CommandGroup>
-            {(data ?? []).map((suggestion) => {
-              const Icon = hitIcon(suggestion);
-              return (
-                <CommandItem
-                  key={`${suggestion.entity_type}:${suggestion.entity_id}`}
-                  value={`${suggestion.entity_type}:${suggestion.entity_id}`}
-                  onSelect={() => choose(suggestion)}
-                  className="flex items-center gap-2"
-                >
-                  <Icon className="h-4 w-4 shrink-0" />
-                  <span className="truncate">{suggestion.title}</span>
-                  {!chipKind && (
-                    <span className="ml-auto shrink-0 text-muted-foreground text-xs">
-                      {t(`search:types.${suggestion.entity_type}` as never)}
-                    </span>
-                  )}
-                </CommandItem>
-              );
-            })}
-          </CommandGroup>
+          {results.length ? (
+            <CommandGroup>
+              {results.map((suggestion) => {
+                const Icon = hitIcon(suggestion);
+                return (
+                  <CommandItem
+                    key={`${suggestion.entity_type}:${suggestion.entity_id}`}
+                    value={`${suggestion.entity_type}:${suggestion.entity_id}`}
+                    onSelect={() => choose(suggestion)}
+                    className="flex items-center gap-2"
+                  >
+                    <Icon className="h-4 w-4 shrink-0" />
+                    <span className="truncate">{suggestion.title}</span>
+                    {!chipKind && (
+                      <span className="ml-auto shrink-0 text-muted-foreground text-xs">
+                        {t(`search:types.${suggestion.entity_type}` as never)}
+                      </span>
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          ) : (
+            // Every one of these used to render as an empty box, which reads as
+            // a broken dialog rather than as an answer.
+            <div className="space-y-1 px-3 py-6 text-center">
+              <p className="text-muted-foreground text-sm">{emptyMessage}</p>
+              {searched && !isFetching && (
+                <p className="text-muted-foreground/80 text-xs">{t("smartChips.scopeHint")}</p>
+              )}
+            </div>
+          )}
         </CommandList>
       </Command>
     </div>

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -7,8 +7,10 @@ import type {
   SuggestGuildApiV1GGuildIdSearchSuggestGetParams,
 } from "@/api/generated/initiativeAPI.schemas";
 import {
+  getRecentGuildApiV1GGuildIdSearchRecentGetQueryKey,
   getSearchGuildApiV1GGuildIdSearchGetQueryKey,
   getSuggestGuildApiV1GGuildIdSearchSuggestGetQueryKey,
+  recentGuildApiV1GGuildIdSearchRecentGet,
   searchGuildApiV1GGuildIdSearchGet,
   suggestGuildApiV1GGuildIdSearchSuggestGet,
 } from "@/api/generated/search/search";
@@ -65,6 +67,34 @@ export const useGuildSearchSuggest = (
     queryKey: getSuggestGuildApiV1GGuildIdSearchSuggestGetQueryKey(guildId, params),
     queryFn: () => suggestGuildApiV1GGuildIdSearchSuggestGet(guildId, params),
     placeholderData: keepPreviousData,
+    ...queryOptions,
+  });
+};
+
+/**
+ * What a picker offers before anything has been typed.
+ *
+ * The most recently changed things the caller could name, narrowed the same way
+ * the lookup is — so a picker's suggestions and its search are the same set of
+ * things, and picking from the list can never offer what typing could not find.
+ *
+ * A picker that opens on an empty list teaches nothing: it cannot say what kind
+ * of thing belongs here, or whether there is anything to point at at all.
+ */
+export const useGuildRecentSuggestions = (
+  options?: QueryOpts<SearchSuggestion[]> & SuggestFilters
+) => {
+  const guildId = useActiveGuildId();
+  const { limit, types, initiative_id, template, ...queryOptions } = options ?? {};
+  const params = {
+    ...(limit != null ? { limit } : {}),
+    ...(types ? { types } : {}),
+    ...(initiative_id != null ? { initiative_id } : {}),
+    ...(template != null ? { template } : {}),
+  };
+  return useQuery<SearchSuggestion[]>({
+    queryKey: getRecentGuildApiV1GGuildIdSearchRecentGetQueryKey(guildId, params),
+    queryFn: () => recentGuildApiV1GGuildIdSearchRecentGet(guildId, params),
     ...queryOptions,
   });
 };


### PR DESCRIPTION
## Problem

Two reports: `#` does nothing in documents, and the smart-chip picker opens an empty search box that renders nothing with no explanation.

Neither is a broken lookup. Both surfaces are **scoped to the document's own initiative**, and both render an empty answer as *nothing at all*.

I verified each half against the running app and the dev database rather than reasoning about it:

- The API is healthy. `GET /g/1/search/suggest?q=floor` returns matches, and still does with `types`, `template=false` and `initiative_id` applied.
- `#` works when the lookup answers. A test driving a real document through the editor's own API opens the picker on a match (`userEvent` cannot type into a Lexical contenteditable under jsdom, which is why an earlier probe misled me).
- The scoping is what empties it. In guild 1, `q=floor&initiative_id=1` returns `[]` while the same query unscoped returns matches — because that guild's work is in initiative 2:

  | initiative | documents | indexed rows |
  |---|---|---|
  | 1 | 4 | 25 |
  | 2 | 4 | 1067 |
  | 3 | 1 | 34 |

  So editing one of the four documents in initiative 1 and typing `#` legitimately finds almost nothing.

- And nothing renders. `EntityMentionsPlugin`'s `menuRenderFn` returned `null` whenever `options.length` was 0, so the caret simply did not change. The picker rendered a `CommandGroup` over an empty array — a blank box under a search field. It also opens with no query typed, and the lookup answers `[]` for an empty one, so the *first* thing anyone sees is that blank box.

## Changes

- [entity-mentions-plugin.tsx](frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx) — the `#` menu opens even with no options, saying what was searched for and that the initiative is the limit; it shows a searching state while the lookup is in flight.
- [smart-chip-insert-dialog.tsx](frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.tsx) — four distinct states instead of one blank box: nothing typed yet, searching, nothing matched (with the scope hint), and a document that belongs to no initiative.
- Strings in all four locales.

**The scoping itself is unchanged, and deliberately so.** A reference stores its label as plain text in the document, so letting a document name another initiative's task would write that task's title where the initiative's non-members can read it. The limit is right; the silence was the bug.

## Testing

- [reference-picker.test.tsx](frontend/src/components/documents/editor/reference-picker.test.tsx) — drives `#` in a real document through the composer: opens the picker on a match, and explains itself on none.
- [smart-chip-insert-dialog.test.tsx](frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.test.tsx) — all four states.
- `npx vitest run src/lib src/components/documents src/components/comments src/components/ui/editor src/__tests__/locale-keys.test.ts` — 1298 passed (83 files)
- `npx tsc --noEmit`, `npx biome check src` — clean

## Worth your call

`#` and chips reach only the document's initiative. That is the safe default for the reason above, but if you would rather they reach everything the *author* can see, that is a product decision with a real consequence — the stored label would carry titles across the initiative boundary — and I would want it asked for explicitly rather than assumed.