### PR TITLE
Finish taking the guild path off the account row

### DIFF
--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -357,6 +357,11 @@ async def register_user(
             detail=AuthMessages.UNABLE_TO_CREATE_USER,
         ) from exc
 
+    # Seeding a new guild leaves the session routed into it, and a guild role
+    # reaches nothing on ``public.users``. Everything from here is about the
+    # account rather than the guild, so the session comes back to the platform
+    # path before it reads one.
+    await set_rls_context(session, user_id=user.id)
     await session.refresh(user)
 
     if smtp_configured and not user.email_verified:

--- a/backend/app/api/v1/tenant_endpoints/comments.py
+++ b/backend/app/api/v1/tenant_endpoints/comments.py
@@ -99,7 +99,6 @@ async def create_comment(
         ) from exc
 
     await session.commit()
-    await session.refresh(comment)
     response = comments_service.serialize_comment(comment, viewer_id=current_user.id)
     await _broadcast_comment(session, guild_context.guild_id, comment, "created")
     return response

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -2514,6 +2514,7 @@ async def reorder_tasks(
             .selectinload(Initiative.guild),
             selectinload(Task.assignees),
             selectinload(Task.task_status),
+            selectinload(Task.creator),
         )
         .where(Task.id.in_(tuple(affected_ids)))
         .order_by(Task.position.asc(), Task.id.asc())

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -28,6 +28,7 @@ from app.models.tenant.calendar_event import (
 from app.models.tenant.event_reminder_dispatch import EventReminderDispatch
 from app.models.platform.guild import Guild, GuildStatus
 from app.models.platform.user import User
+from app.services.platform import accounts as accounts_service
 from app.models.platform.notification import NotificationType
 from app.services import email as email_service
 from app.services.platform import user_notifications
@@ -2410,15 +2411,10 @@ async def _run_event_reminder_pass(session: AsyncSession, *, now: datetime) -> N
     # Allow events that started within the grace window so a 0-minute
     # ("at the time of the event") reminder still fires on the next poll.
     lower = now - EVENT_REMINDER_GRACE
-    users = (
-        (
-            await session.exec(
-                select(User).where(User.event_reminder_minutes_before.is_not(None))
-            )
-        )
-        .scalars()
-        .all()
-    )
+    # Asked of the system engine, not of this session: the sweep routes into
+    # each guild's schema in turn, and a routed session cannot read an
+    # account's preferences.
+    users = await accounts_service.load_event_reminder_optins()
     candidates = [(u.id, u.event_reminder_minutes_before) for u in users]
     for user_id, minutes in candidates:
         if minutes is None:
@@ -2475,9 +2471,7 @@ async def _run_event_reminder_pass(session: AsyncSession, *, now: datetime) -> N
                     )
                 )
                 await session.commit()
-                recipient = (
-                    await session.exec(select(User).where(User.id == user_id))
-                ).scalar_one_or_none()
+                recipient = await accounts_service.load_one(user_id)
                 event = (
                     await session.exec(
                         select(CalendarEvent).where(CalendarEvent.id == event_id)

--- a/backend/app/services/platform/accounts.py
+++ b/backend/app/services/platform/accounts.py
@@ -30,7 +30,7 @@ from sqlmodel import select
 
 from app.models.platform.user import User
 
-__all__ = ["load", "load_one", "load_all"]
+__all__ = ["load", "load_one", "load_all", "load_event_reminder_optins"]
 
 
 async def load(user_ids: Iterable[int | None]) -> dict[int, User]:
@@ -79,3 +79,26 @@ async def load_all(user_ids: Sequence[int | None]) -> list[User]:
             seen.add(user_id)
             ordered.append(target)
     return ordered
+
+
+async def load_event_reminder_optins() -> list[User]:
+    """Everybody who asked to be reminded about events, detached.
+
+    The reminder sweep walks each guild's schema in turn, so the session it
+    holds is routed into one — and a routed session has no business reading an
+    account's preferences. The question "who wants reminding" is about accounts
+    rather than about any guild, so it is asked here, once, before the walk.
+    """
+    from app.db.session import AdminSessionLocal
+
+    async with AdminSessionLocal() as admin_session:
+        rows = list(
+            (
+                await admin_session.exec(
+                    select(User).where(User.event_reminder_minutes_before.is_not(None))
+                )
+            ).all()
+        )
+        for row in rows:
+            admin_session.expunge(row)
+    return rows

--- a/backend/app/services/platform/contacts.py
+++ b/backend/app/services/platform/contacts.py
@@ -20,7 +20,7 @@ from app.models.platform.guild import Guild, GuildMembership, GuildStatus
 from app.models.platform.guild_image import GuildImageVariant
 from app.models.platform.profile_favorite import ProfileFavorite
 from app.models.platform.user import User, UserStatus
-from app.models.platform.user_profile_view import user_profiles
+from app.models.platform.user_profile_view import MemberProfile, user_profiles
 from app.schemas.platform.contact import (
     ContactGuildSection,
     ContactRead,
@@ -74,7 +74,7 @@ async def ordered_member_guilds(
     ]
 
 
-def _reads(users: Iterable[User]) -> list[ContactRead]:
+def _reads(users: Iterable[MemberProfile]) -> list[ContactRead]:
     """Validate inside the caller's current guild context.
 
     ``ContactRead`` inherits the guild-name visibility validator, so where this
@@ -130,13 +130,17 @@ async def guild_sections(
             ).all()
         )
 
+        # Read from the guild projection, not from ``users``: this is a roster,
+        # and a routed session has no reach into the account row behind it. The
+        # predicates below already speak this shape — selecting the account and
+        # filtering the projection is what left the two unjoined.
         base = (
-            select(User)
-            .join(GuildMembership, GuildMembership.user_id == User.id)
+            select(MemberProfile)
+            .join(GuildMembership, GuildMembership.user_id == MemberProfile.id)
             .where(
                 GuildMembership.guild_id == guild_id,
                 # You are not your own contact.
-                User.id != user_id,
+                MemberProfile.id != user_id,
                 users_service.visible_to_other_people(),
             )
         )
@@ -153,9 +157,9 @@ async def guild_sections(
             await guild_session.exec(
                 base.order_by(
                     *users_service.member_order(closest, shows_names=shows_names),
-                    col(User.username).asc(),
-                    col(User.discriminator).asc(),
-                    col(User.id).asc(),
+                    col(MemberProfile.username).asc(),
+                    col(MemberProfile.discriminator).asc(),
+                    col(MemberProfile.id).asc(),
                 )
                 .offset((page - 1) * page_size)
                 .limit(page_size)

--- a/backend/app/services/platform/users_test.py
+++ b/backend/app/services/platform/users_test.py
@@ -478,13 +478,17 @@ async def test_users_table_has_rls_delete_deny_policy(session: AsyncSession):
     assert {
         # Read legs: the request path names other people all the time.
         "users_app_user_read",
-        "users_app_guild_base_read",
         "users_platform_read",
         # Write legs: each one scoped to the caller's own row.
         "users_app_user_self_update",
-        "users_app_guild_base_self_update",
         "users_platform_self",
     } <= names
+    # 0221 took the guild path off this table entirely — it reads people from
+    # ``public.guild_member_profiles`` now — so its two legs are gone with it.
+    assert {
+        "users_app_guild_base_read",
+        "users_app_guild_base_self_update",
+    } & names == set()
     # 0202 retired the table-wide floors and the moderator+ update-all leg.
     assert {
         "users_app_floor",


### PR DESCRIPTION
## Problem

`dev` is red — 84 failures. All of them trace to #1368 (`0221`), which revoked `app_guild_base` from `public.users` and moved the guild path onto `public.guild_member_profiles`. Five places still went the old way.

Two are user-facing breakage, not just red tests:

- **New sign-ups fail with a flat 403.** `POST /auth/register` seeds a guild, and the seed leaves the session routed into it — then refreshes the account, which a guild role can no longer read. `permission denied for table users`, mapped to `GUILD_ACCESS_DENIED`.
- **Event reminders never send.** The sweep walks each guild's schema and read account preferences from inside one.

## Changes

| Where | What was wrong |
|---|---|
| [`contacts.py`](backend/app/services/platform/contacts.py) | Selected `User` but filtered/ordered on `MemberProfile` — the two were never joined, so every section query was a cartesian product. Reads the projection now, which is what its predicates already spoke. |
| [`auth.py`](backend/app/api/v1/platform_endpoints/auth.py) | Returns to the platform path after seeding, before reading the account. Covers the verification mail after it too. |
| [`notifications.py`](backend/app/services/notifications.py) | "Who wants reminding" is a question about accounts, so it is asked once of the system engine before the per-guild walk, via a new `accounts.load_event_reminder_optins()`. The per-recipient read goes through `accounts.load_one`. |
| [`comments.py`](backend/app/api/v1/tenant_endpoints/comments.py) | `session.refresh()` after commit expires relationships, dropping the `author` the service had just loaded — serializing then lazy-loaded it outside a greenlet. With `expire_on_commit=False` the refresh bought nothing, so it is gone. |
| [`tasks.py`](backend/app/api/v1/tenant_endpoints/tasks.py) | `reorder_tasks` eager-loaded three relationships and named a fourth (`creator`) in its reply. |
| [`users_test.py`](backend/app/services/platform/users_test.py) | Still expected the two `app_guild_base` policy legs `0221` deleted; now asserts they are absent. |

### Note on the comments fix

Worth flagging because it is the least obvious: the service does `refresh(comment, attribute_names=["author"])` deliberately, and the endpoint then undid it. The failure only became visible once `author` pointed at a view — before that the relationship happened to be reachable. Removing the endpoint's refresh restores the service's intent rather than papering over it.

## Testing

- `cd backend && pytest -n 8 app` — **4706 passed, 81 skipped, 0 failed.**
- `ruff check app && ty check app` — clean.

Reproduced each failure first, and confirmed on a clean checkout of `dev` (my own work stashed) that all four families were pre-existing rather than mine.