### PR TITLE
Say who may ask to message whom

### DIFF
--- a/backend/alembic/versions/20260904_0222_direct_messages.py
+++ b/backend/alembic/versions/20260904_0222_direct_messages.py
@@ -1,0 +1,492 @@
+"""Who may ask to message whom.
+
+Four tables in ``public``, all per-account and cross-guild:
+
+* ``user_dm_settings`` — the policy an account picked, one row per account.
+  Kept off ``public.users`` because that table is read whole by the platform
+  tiers, and this is the account holder's own business.
+* ``user_dm_guild_optouts`` — the communities it switched off, stored as the
+  exceptions so a newly joined one counts with no write.
+* ``contact_grants`` — the canonical pair, one row per ``kind``: a connection,
+  and the accepted message request that opens a channel.
+* ``user_ignores`` — the accounts it has chosen not to hear from.
+
+Access shape, the same for all four: **the account holder's own rows, and
+nothing else on the request path.** No platform-tier policy, no guild-admin
+leg, no PAM leg. ``app_guild_base`` — what every ``guild_<id>`` role inherits —
+is granted nothing at all, matching the shape 0221 put the guild path into.
+
+Two functions answer questions the request path cannot ask directly, on the
+``app_profile_reader`` pattern from 0214: a ``NOLOGIN`` role holding SELECT and
+an all-rows policy on what the rule reads, owning ``SECURITY DEFINER``
+functions that return a decision rather than a row. Neither takes a caller id —
+they read ``app.current_user_id`` — so the caller is the current user by
+construction.
+
+``user_dm_settings`` is backfilled for every existing account, which decides
+the order: the rows go in before ``FORCE ROW LEVEL SECURITY``, because the
+policies key on request GUCs a migration has no value for.
+
+Revision ID: 20260904_0222
+Revises: 20260904_0221
+Create Date: 2026-09-04
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+
+from app.core.config import settings
+
+revision = "20260904_0222"
+down_revision = "20260904_0221"
+branch_labels = None
+depends_on = None
+
+#: The reader role behind the two functions. Cluster-wide and unprefixed, like
+#: ``app_profile_reader`` (0214) and the other base roles.
+READER = "app_dm_reader"
+
+_TABLES = (
+    "user_dm_settings",
+    "user_dm_guild_optouts",
+    "contact_grants",
+    "user_ignores",
+)
+
+# NULLIF-guarded: an unset context leaves the value empty, and a bare ''::int
+# would raise and fault the whole query rather than fail the policy.
+_USER_ID = "NULLIF(current_setting('app.current_user_id', true), '')::int"
+
+
+def _platform_base() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+def _run(statements: list[str]) -> None:
+    for statement in statements:
+        op.execute(statement)
+
+
+def _create_tables() -> None:
+    op.create_table(
+        "user_dm_settings",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "dm_policy",
+            sa.Enum("private", "community", "public", name="user_dm_policy"),
+            nullable=False,
+            server_default="private",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+    op.create_table(
+        "user_dm_guild_optouts",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "guild_id"),
+    )
+    op.create_table(
+        "contact_grants",
+        sa.Column("user_id_low", sa.Integer(), nullable=False),
+        sa.Column("user_id_high", sa.Integer(), nullable=False),
+        sa.Column(
+            "kind",
+            sa.Enum("connection", "message", name="contact_grant_kind"),
+            nullable=False,
+        ),
+        sa.Column(
+            "state",
+            sa.Enum("pending", "accepted", name="contact_grant_state"),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("requested_by", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("responded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id_low"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id_high"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["requested_by"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id_low", "user_id_high", "kind"),
+        sa.CheckConstraint(
+            "user_id_low < user_id_high", name="ck_contact_grants_ordered_pair"
+        ),
+        sa.CheckConstraint(
+            "requested_by IN (user_id_low, user_id_high)",
+            name="ck_contact_grants_requester_in_pair",
+        ),
+    )
+    op.create_index("ix_contact_grants_user_high", "contact_grants", ["user_id_high"])
+    op.create_table(
+        "user_ignores",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("ignored_user_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["ignored_user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "ignored_user_id"),
+        sa.CheckConstraint(
+            "user_id <> ignored_user_id", name="ck_user_ignores_not_self"
+        ),
+    )
+    op.create_index("ix_user_ignores_ignored_user", "user_ignores", ["ignored_user_id"])
+
+
+#: The rule, in one place. ``dm_can_ask`` is the policy table; the two entry
+#: points below compose it and add what their own callers need.
+_FUNCTIONS = [
+    """
+    CREATE OR REPLACE FUNCTION public.dm_can_ask(from_id int, to_id int)
+    RETURNS boolean
+    LANGUAGE sql STABLE PARALLEL SAFE SECURITY DEFINER
+    SET search_path = pg_catalog, public
+    AS $fn$
+      SELECT CASE
+        WHEN EXISTS (
+          SELECT 1 FROM public.contact_grants g
+          WHERE g.user_id_low = LEAST(from_id, to_id)
+            AND g.user_id_high = GREATEST(from_id, to_id)
+            AND g.kind = 'connection'
+            AND g.state = 'accepted'
+        ) THEN true
+        ELSE COALESCE((
+          SELECT CASE s.dm_policy
+            WHEN 'public' THEN true
+            WHEN 'community' THEN EXISTS (
+              SELECT 1
+              FROM public.guild_memberships a
+              JOIN public.guild_memberships b ON b.guild_id = a.guild_id
+              JOIN public.guilds gg ON gg.id = a.guild_id
+              WHERE a.user_id = from_id
+                AND b.user_id = to_id
+                AND gg.status <> 'suspended'
+                AND NOT EXISTS (
+                  SELECT 1 FROM public.user_dm_guild_optouts o
+                  WHERE o.user_id = to_id AND o.guild_id = a.guild_id
+                )
+            )
+            ELSE false
+          END
+          FROM public.user_dm_settings s WHERE s.user_id = to_id
+        ), false)
+      END
+    $fn$
+    """,
+    """
+    CREATE OR REPLACE FUNCTION public.dm_reachable(account_id int)
+    RETURNS boolean
+    LANGUAGE sql STABLE PARALLEL SAFE SECURITY DEFINER
+    SET search_path = pg_catalog, public
+    AS $fn$
+      SELECT EXISTS (
+        SELECT 1 FROM public.users u
+        WHERE u.id = account_id
+          AND u.status = 'active'
+          AND u.age_confirmed_at IS NOT NULL
+      )
+    $fn$
+    """,
+    """
+    CREATE OR REPLACE FUNCTION public.dm_mutual_ask(a_id int, b_id int)
+    RETURNS boolean
+    LANGUAGE sql STABLE PARALLEL SAFE SECURITY DEFINER
+    SET search_path = pg_catalog, public
+    AS $fn$
+      SELECT a_id <> b_id
+         AND public.dm_reachable(a_id)
+         AND public.dm_reachable(b_id)
+         AND public.dm_can_ask(a_id, b_id)
+         AND public.dm_can_ask(b_id, a_id)
+    $fn$
+    """,
+    """
+    CREATE OR REPLACE FUNCTION public.dm_apparent_permission(target_id int)
+    RETURNS text
+    LANGUAGE plpgsql STABLE PARALLEL SAFE SECURITY DEFINER
+    SET search_path = pg_catalog, public
+    AS $fn$
+    DECLARE
+      actor_id int := NULLIF(current_setting('app.current_user_id', true), '')::int;
+    BEGIN
+      IF actor_id IS NULL THEN
+        RAISE EXCEPTION 'dm_apparent_permission requires app.current_user_id';
+      END IF;
+      IF NOT public.dm_mutual_ask(actor_id, target_id) THEN
+        RETURN 'denied';
+      END IF;
+      IF EXISTS (
+        SELECT 1 FROM public.contact_grants g
+        WHERE g.user_id_low = LEAST(actor_id, target_id)
+          AND g.user_id_high = GREATEST(actor_id, target_id)
+          AND g.kind = 'message'
+          AND g.state = 'accepted'
+      ) THEN
+        RETURN 'open';
+      END IF;
+      RETURN 'may_request';
+    END;
+    $fn$
+    """,
+    """
+    CREATE OR REPLACE FUNCTION public.dm_listable_in_guild(target_guild_id int)
+    RETURNS SETOF int
+    LANGUAGE plpgsql STABLE PARALLEL SAFE SECURITY DEFINER
+    SET search_path = pg_catalog, public
+    AS $fn$
+    DECLARE
+      viewer_id int := NULLIF(current_setting('app.current_user_id', true), '')::int;
+    BEGIN
+      IF viewer_id IS NULL THEN
+        RAISE EXCEPTION 'dm_listable_in_guild requires app.current_user_id';
+      END IF;
+      -- The viewer's own gates decide the whole answer, so they are asked once
+      -- rather than once per member.
+      IF NOT public.dm_reachable(viewer_id) THEN
+        RETURN;
+      END IF;
+      RETURN QUERY
+        SELECT m.user_id
+        FROM public.guild_memberships m
+        WHERE m.guild_id = target_guild_id
+          AND m.user_id <> viewer_id
+          AND NOT EXISTS (
+            SELECT 1 FROM public.user_ignores i
+            WHERE i.user_id = viewer_id AND i.ignored_user_id = m.user_id
+          )
+          AND public.dm_mutual_ask(viewer_id, m.user_id);
+    END;
+    $fn$
+    """,
+]
+
+#: What the reader may see, and no more. Column-scoped where the table holds
+#: anything beyond what the rule reads.
+_READER_GRANTS = [
+    "GRANT SELECT (id, status, age_confirmed_at) ON TABLE public.users TO {r}",
+    "GRANT SELECT (id, status) ON TABLE public.guilds TO {r}",
+    "GRANT SELECT (user_id, guild_id) ON TABLE public.guild_memberships TO {r}",
+    "GRANT SELECT ON TABLE public.user_dm_settings TO {r}",
+    "GRANT SELECT ON TABLE public.user_dm_guild_optouts TO {r}",
+    "GRANT SELECT ON TABLE public.contact_grants TO {r}",
+    "GRANT SELECT ON TABLE public.user_ignores TO {r}",
+]
+
+#: All rows of each, for the reader only.
+_READER_POLICIES = [
+    ("users", "dm_reader_read"),
+    ("guilds", "dm_reader_read"),
+    ("guild_memberships", "dm_reader_read"),
+    ("user_dm_settings", "dm_reader_read"),
+    ("user_dm_guild_optouts", "dm_reader_read"),
+    ("contact_grants", "dm_reader_read"),
+    ("user_ignores", "dm_reader_read"),
+]
+
+
+def upgrade() -> None:
+    base = _platform_base()
+    request_roles = f'app_guild_base, "{base}", app_user'
+
+    _create_tables()
+
+    # The starting policy a newly created account is given. The enum was
+    # created with ``user_dm_settings`` just above, so this reuses it.
+    op.add_column(
+        "app_settings",
+        sa.Column(
+            "default_dm_policy",
+            postgresql.ENUM(
+                "private",
+                "community",
+                "public",
+                name="user_dm_policy",
+                create_type=False,
+            ),
+            nullable=False,
+            server_default="private",
+        ),
+    )
+
+    # Every existing account gets ``private`` rather than the operator default:
+    # an account that predates the feature chose nothing, and the closed value
+    # is the only one it can be given. This runs before RLS is forced on, while
+    # the migration's own role can still write the rows.
+    conn = op.get_bind()
+    conn.execute(
+        text(
+            "INSERT INTO public.user_dm_settings "
+            "(user_id, dm_policy, created_at, updated_at) "
+            "SELECT id, 'private', now(), now() FROM public.users"
+        )
+    )
+    seeded = conn.execute(
+        text("SELECT count(*) FROM public.user_dm_settings")
+    ).scalar_one()
+    accounts = conn.execute(text("SELECT count(*) FROM public.users")).scalar_one()
+    if seeded != accounts:
+        raise RuntimeError(
+            f"user_dm_settings backfill covered {seeded} of {accounts} accounts"
+        )
+
+    statements: list[str] = []
+    for table in _TABLES:
+        qualified = f"public.{table}"
+        statements += [
+            f"ALTER TABLE {qualified} ENABLE ROW LEVEL SECURITY",
+            f"ALTER TABLE {qualified} FORCE ROW LEVEL SECURITY",
+            # The schema's default privileges hand every new public table to the
+            # routed base roles, so they are wound back before anything is given.
+            f"REVOKE ALL ON TABLE {qualified} FROM {request_roles}",
+            f'GRANT SELECT, INSERT, DELETE ON TABLE {qualified} TO "{base}"',
+        ]
+    # Only these two are ever edited in place: a policy is changed, and a
+    # pending grant becomes accepted.
+    statements += [
+        f'GRANT UPDATE ON TABLE public.user_dm_settings TO "{base}"',
+        f'GRANT UPDATE ON TABLE public.contact_grants TO "{base}"',
+    ]
+
+    # Own-row policies. ``contact_grants`` names both parties on the row, so
+    # "own" there means either side of the pair.
+    own_row = {
+        "user_dm_settings": f"user_id = {_USER_ID}",
+        "user_dm_guild_optouts": f"user_id = {_USER_ID}",
+        "contact_grants": (f"(user_id_low = {_USER_ID} OR user_id_high = {_USER_ID})"),
+        "user_ignores": f"user_id = {_USER_ID}",
+    }
+    for table, predicate in own_row.items():
+        qualified = f"public.{table}"
+        for command in ("SELECT", "INSERT", "DELETE"):
+            clause = "WITH CHECK" if command == "INSERT" else "USING"
+            statements += [
+                f"DROP POLICY IF EXISTS {table}_self_{command.lower()} ON {qualified}",
+                f"CREATE POLICY {table}_self_{command.lower()} ON {qualified} "
+                f'AS PERMISSIVE FOR {command} TO "{base}" '
+                f"{clause} ({predicate})",
+            ]
+    for table in ("user_dm_settings", "contact_grants"):
+        qualified = f"public.{table}"
+        predicate = own_row[table]
+        statements += [
+            f"DROP POLICY IF EXISTS {table}_self_update ON {qualified}",
+            f"CREATE POLICY {table}_self_update ON {qualified} "
+            f'AS PERMISSIVE FOR UPDATE TO "{base}" '
+            f"USING ({predicate}) WITH CHECK ({predicate})",
+        ]
+
+    # The system engine: seeding a new account's policy row, the lifecycle
+    # sweeps, and clearing an erased account off these tables.
+    statements += [
+        "GRANT SELECT, INSERT, DELETE ON TABLE public.user_dm_settings TO app_admin",
+        "GRANT SELECT, DELETE ON TABLE public.user_dm_guild_optouts TO app_admin",
+        "GRANT SELECT, DELETE ON TABLE public.contact_grants TO app_admin",
+        "GRANT SELECT, DELETE ON TABLE public.user_ignores TO app_admin",
+    ]
+
+    # The reader role and the rule it owns.
+    statements += [
+        f"""
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{READER}') THEN
+                CREATE ROLE "{READER}" NOLOGIN;
+            END IF;
+        END $$;
+        """,
+        # Migrations run as ``app_provisioner``, not as a superuser, and handing
+        # an object to a role means being able to become it.
+        f'GRANT "{READER}" TO CURRENT_USER WITH INHERIT TRUE, SET TRUE',
+        f'GRANT USAGE ON SCHEMA public TO "{READER}"',
+    ]
+    statements += [grant.format(r=f'"{READER}"') for grant in _READER_GRANTS]
+    for table, policy in _READER_POLICIES:
+        statements += [
+            f"DROP POLICY IF EXISTS {policy} ON public.{table}",
+            f"CREATE POLICY {policy} ON public.{table} "
+            f'AS PERMISSIVE FOR SELECT TO "{READER}" USING (true)',
+        ]
+    statements += _FUNCTIONS
+    # Ownership can only be handed to a role that may create in the schema.
+    # Given for the assignment and taken straight back: the reader creates
+    # nothing, it only reads.
+    statements.append(f'GRANT CREATE ON SCHEMA public TO "{READER}"')
+    for function, signature in (
+        ("dm_can_ask", "int, int"),
+        ("dm_reachable", "int"),
+        ("dm_mutual_ask", "int, int"),
+        ("dm_apparent_permission", "int"),
+        ("dm_listable_in_guild", "int"),
+    ):
+        statements += [
+            f'ALTER FUNCTION public.{function}({signature}) OWNER TO "{READER}"',
+            f"REVOKE ALL ON FUNCTION public.{function}({signature}) FROM PUBLIC",
+        ]
+    statements.append(f'REVOKE CREATE ON SCHEMA public FROM "{READER}"')
+    # Only the two entry points are callable, and only from the platform path.
+    # The three below them are reached by the pair that owns them.
+    statements += [
+        f'GRANT EXECUTE ON FUNCTION public.dm_apparent_permission(int) TO "{base}"',
+        f'GRANT EXECUTE ON FUNCTION public.dm_listable_in_guild(int) TO "{base}"',
+    ]
+
+    _run(statements)
+
+
+def downgrade() -> None:
+    statements = []
+    for function, signature in (
+        ("dm_listable_in_guild", "int"),
+        ("dm_apparent_permission", "int"),
+        ("dm_mutual_ask", "int, int"),
+        ("dm_reachable", "int"),
+        ("dm_can_ask", "int, int"),
+    ):
+        statements.append(f"DROP FUNCTION IF EXISTS public.{function}({signature})")
+    for table, policy in _READER_POLICIES:
+        statements.append(f"DROP POLICY IF EXISTS {policy} ON public.{table}")
+    statements += [
+        f'REVOKE ALL ON TABLE public.users FROM "{READER}"',
+        f'REVOKE ALL ON TABLE public.guilds FROM "{READER}"',
+        f'REVOKE ALL ON TABLE public.guild_memberships FROM "{READER}"',
+        f'REVOKE ALL ON SCHEMA public FROM "{READER}"',
+    ]
+    for table in _TABLES:
+        qualified = f"public.{table}"
+        for command in ("select", "insert", "delete", "update"):
+            statements.append(
+                f"DROP POLICY IF EXISTS {table}_self_{command} ON {qualified}"
+            )
+        statements.append(f"ALTER TABLE {qualified} DISABLE ROW LEVEL SECURITY")
+    _run(statements)
+
+    op.drop_index("ix_user_ignores_ignored_user", table_name="user_ignores")
+    op.drop_table("user_ignores")
+    op.drop_index("ix_contact_grants_user_high", table_name="contact_grants")
+    op.drop_table("contact_grants")
+    op.drop_table("user_dm_guild_optouts")
+    op.drop_column("app_settings", "default_dm_policy")
+    op.drop_table("user_dm_settings")
+    _run(
+        [
+            "DROP TYPE IF EXISTS contact_grant_state",
+            "DROP TYPE IF EXISTS contact_grant_kind",
+            "DROP TYPE IF EXISTS user_dm_policy",
+            # The role is cluster-global, so another database may still grant to
+            # it; that is somebody else's grant to give up.
+            f"""
+            DO $$
+            BEGIN
+                DROP ROLE IF EXISTS "{READER}";
+            EXCEPTION WHEN dependent_objects_still_exist THEN
+                NULL;
+            END
+            $$
+            """,
+        ]
+    )

--- a/backend/alembic/versions/20260904_0223_direct_messages.py
+++ b/backend/alembic/versions/20260904_0223_direct_messages.py
@@ -27,8 +27,8 @@ construction.
 the order: the rows go in before ``FORCE ROW LEVEL SECURITY``, because the
 policies key on request GUCs a migration has no value for.
 
-Revision ID: 20260904_0222
-Revises: 20260904_0221
+Revision ID: 20260904_0223
+Revises: 20260904_0222
 Create Date: 2026-09-04
 """
 
@@ -39,8 +39,8 @@ from sqlalchemy.dialects import postgresql
 
 from app.core.config import settings
 
-revision = "20260904_0222"
-down_revision = "20260904_0221"
+revision = "20260904_0223"
+down_revision = "20260904_0222"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -102,6 +102,7 @@ from app.services.auth.platform_provider import (
 )
 from app.services.auth.sessions import RefreshOutcome
 from app.services.platform import app_settings as app_settings_service
+from app.services.platform import dm_settings as dm_settings_service
 from app.services import email as email_service
 from app.services.platform import user_tokens
 from app.services.platform import guilds as guilds_service
@@ -272,6 +273,8 @@ async def register_user(
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=exc.code
             ) from exc
+
+        await dm_settings_service.seed_for_new_account(session, user_id=user.id)
 
         if normalized_invite:
             try:

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -67,6 +67,10 @@ from app.models.tenant.upload import Upload
 from app.models.platform.user_decoration import UserDecoration
 from app.models.platform.profile_favorite import ProfileFavorite
 from app.models.platform.user_view_preference import UserViewPreference
+from app.models.platform.user_dm_settings import UserDmSettings
+from app.models.platform.user_dm_guild_optout import UserDmGuildOptout
+from app.models.platform.contact_grant import ContactGrant
+from app.models.platform.user_ignore import UserIgnore
 from app.models.platform.access_grant import AccessGrant
 from app.models.platform.auth_provider import AuthProvider
 from app.models.platform.auth_provider_secret import AuthProviderSecret
@@ -170,6 +174,10 @@ __all__ = [
     "UserDecoration",
     "ProfileFavorite",
     "UserViewPreference",
+    "UserDmSettings",
+    "UserDmGuildOptout",
+    "ContactGrant",
+    "UserIgnore",
     "UserToken",
     "PushToken",
     "AutoDelegationJti",

--- a/backend/app/db/dm_rules_test.py
+++ b/backend/app/db/dm_rules_test.py
@@ -1,0 +1,273 @@
+"""The direct-message rule, exercised through the SQL that is its only copy.
+
+Every case here calls ``public.dm_can_ask`` / ``dm_apparent_permission`` /
+``dm_listable_in_guild`` rather than a Python restatement of them, because the
+functions are the rule: a test that agreed with a mirror would prove nothing
+about what the request path actually gets.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.models.platform.contact_grant import (
+    ContactGrant,
+    ContactGrantKind,
+    ContactGrantState,
+    canonical_pair,
+)
+from app.models.platform.user_dm_settings import DmPolicy, UserDmSettings
+from app.models.platform.user_dm_guild_optout import UserDmGuildOptout
+from app.models.platform.user_ignore import UserIgnore
+from app.testing import create_guild, create_guild_membership, create_user
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _policy(session, user, policy: DmPolicy) -> None:
+    row = await session.get(UserDmSettings, user.id)
+    if row is None:
+        row = UserDmSettings(user_id=user.id)
+        session.add(row)
+    row.dm_policy = policy
+    await session.flush()
+
+
+async def _grant(
+    session, a, b, kind: ContactGrantKind, state=ContactGrantState.accepted
+):
+    low, high = canonical_pair(a.id, b.id)
+    session.add(
+        ContactGrant(
+            user_id_low=low,
+            user_id_high=high,
+            kind=kind,
+            state=state,
+            requested_by=a.id,
+        )
+    )
+    await session.flush()
+
+
+async def _can_ask(session, frm, to) -> bool:
+    return (
+        await session.exec(
+            text("SELECT public.dm_can_ask(:f, :t)").bindparams(f=frm.id, t=to.id)
+        )
+    ).scalar_one()
+
+
+async def _permission(session, actor, target) -> str:
+    await session.exec(
+        text("SELECT set_config('app.current_user_id', :v, true)").bindparams(
+            v=str(actor.id)
+        )
+    )
+    return (
+        await session.exec(
+            text("SELECT public.dm_apparent_permission(:t)").bindparams(t=target.id)
+        )
+    ).scalar_one()
+
+
+async def _listable(session, viewer, guild) -> set[int]:
+    await session.exec(
+        text("SELECT set_config('app.current_user_id', :v, true)").bindparams(
+            v=str(viewer.id)
+        )
+    )
+    rows = await session.exec(
+        text("SELECT public.dm_listable_in_guild(:g)").bindparams(g=guild.id)
+    )
+    return {row[0] for row in rows}
+
+
+# ---------------------------------------------------------------- can_ask ---
+
+
+async def test_public_may_be_asked_by_a_stranger(session):
+    asker = await create_user(session)
+    target = await create_user(session)
+    await _policy(session, target, DmPolicy.public)
+    assert await _can_ask(session, asker, target) is True
+
+
+async def test_private_may_not_be_asked_without_a_connection(session):
+    asker = await create_user(session)
+    target = await create_user(session)
+    await _policy(session, target, DmPolicy.private)
+    assert await _can_ask(session, asker, target) is False
+
+
+async def test_a_connection_satisfies_private(session):
+    asker = await create_user(session)
+    target = await create_user(session)
+    await _policy(session, target, DmPolicy.private)
+    await _grant(session, asker, target, ContactGrantKind.connection)
+    assert await _can_ask(session, asker, target) is True
+
+
+async def test_a_pending_connection_satisfies_nothing(session):
+    asker = await create_user(session)
+    target = await create_user(session)
+    await _policy(session, target, DmPolicy.private)
+    await _grant(
+        session, asker, target, ContactGrantKind.connection, ContactGrantState.pending
+    )
+    assert await _can_ask(session, asker, target) is False
+
+
+async def test_community_needs_a_shared_community(session):
+    guild = await create_guild(session)
+    member = await create_user(session)
+    await create_guild_membership(session, user=member, guild=guild)
+    target = await create_user(session)
+    await create_guild_membership(session, user=target, guild=guild)
+    stranger = await create_user(session)
+    await _policy(session, target, DmPolicy.community)
+
+    assert await _can_ask(session, member, target) is True
+    assert await _can_ask(session, stranger, target) is False
+
+
+async def test_a_switched_off_community_does_not_count(session):
+    guild = await create_guild(session)
+    member = await create_user(session)
+    await create_guild_membership(session, user=member, guild=guild)
+    target = await create_user(session)
+    await create_guild_membership(session, user=target, guild=guild)
+    await _policy(session, target, DmPolicy.community)
+    session.add(UserDmGuildOptout(user_id=target.id, guild_id=guild.id))
+    await session.flush()
+
+    assert await _can_ask(session, member, target) is False
+
+
+async def test_another_shared_community_still_counts(session):
+    off = await create_guild(session)
+    on = await create_guild(session)
+    member = await create_user(session)
+    target = await create_user(session)
+    for guild in (off, on):
+        await create_guild_membership(session, user=member, guild=guild)
+        await create_guild_membership(session, user=target, guild=guild)
+    await _policy(session, target, DmPolicy.community)
+    session.add(UserDmGuildOptout(user_id=target.id, guild_id=off.id))
+    await session.flush()
+
+    assert await _can_ask(session, member, target) is True
+
+
+async def test_a_missing_settings_row_reads_as_private(session):
+    asker = await create_user(session)
+    target = await create_user(session)
+    await session.exec(
+        text("DELETE FROM public.user_dm_settings WHERE user_id = :u").bindparams(
+            u=target.id
+        )
+    )
+    assert await _can_ask(session, asker, target) is False
+
+
+# ------------------------------------------------------------- permission ---
+
+
+async def test_a_connection_alone_is_may_request_not_open(session):
+    a = await create_user(session)
+    b = await create_user(session)
+    await _policy(session, a, DmPolicy.private)
+    await _policy(session, b, DmPolicy.private)
+    await _grant(session, a, b, ContactGrantKind.connection)
+
+    assert await _permission(session, a, b) == "may_request"
+
+
+async def test_an_accepted_message_grant_opens_it(session):
+    a = await create_user(session)
+    b = await create_user(session)
+    await _policy(session, a, DmPolicy.private)
+    await _policy(session, b, DmPolicy.private)
+    await _grant(session, a, b, ContactGrantKind.connection)
+    await _grant(session, a, b, ContactGrantKind.message)
+
+    assert await _permission(session, a, b) == "open"
+
+
+async def test_a_private_account_holds_nothing_without_a_connection(session):
+    """The mutual half: b is public, but a is private and they are not
+    connected, so neither may ask."""
+    a = await create_user(session)
+    b = await create_user(session)
+    await _policy(session, a, DmPolicy.private)
+    await _policy(session, b, DmPolicy.public)
+
+    assert await _can_ask(session, a, b) is True
+    assert await _can_ask(session, b, a) is False
+    assert await _permission(session, a, b) == "denied"
+
+
+async def test_an_unconfirmed_age_denies_in_both_directions(session):
+    a = await create_user(session, age_confirmed_at=None)
+    b = await create_user(session)
+    await _policy(session, a, DmPolicy.public)
+    await _policy(session, b, DmPolicy.public)
+    await _grant(session, a, b, ContactGrantKind.connection)
+    await _grant(session, a, b, ContactGrantKind.message)
+
+    assert await _permission(session, a, b) == "denied"
+    assert await _permission(session, b, a) == "denied"
+
+
+async def test_being_ignored_does_not_change_the_answer(session):
+    """The oracle guard: the same response before and after being ignored."""
+    a = await create_user(session)
+    b = await create_user(session)
+    await _policy(session, a, DmPolicy.public)
+    await _policy(session, b, DmPolicy.public)
+
+    before = await _permission(session, a, b)
+    session.add(UserIgnore(user_id=b.id, ignored_user_id=a.id))
+    await session.flush()
+    after = await _permission(session, a, b)
+
+    assert before == after == "may_request"
+
+
+async def test_the_permission_refuses_to_answer_without_a_caller(session):
+    target = await create_user(session)
+    await session.exec(text("SELECT set_config('app.current_user_id', '', true)"))
+    with pytest.raises(Exception, match="app.current_user_id"):
+        await session.exec(
+            text("SELECT public.dm_apparent_permission(:t)").bindparams(t=target.id)
+        )
+
+
+# --------------------------------------------------------------- listable ---
+
+
+async def test_a_private_viewer_lists_nobody_they_are_not_connected_to(session):
+    guild = await create_guild(session)
+    viewer = await create_user(session)
+    other = await create_user(session)
+    friend = await create_user(session)
+    for user in (viewer, other, friend):
+        await create_guild_membership(session, user=user, guild=guild)
+        await _policy(session, user, DmPolicy.community)
+    await _policy(session, viewer, DmPolicy.private)
+    await _grant(session, viewer, friend, ContactGrantKind.connection)
+
+    assert await _listable(session, viewer, guild) == {friend.id}
+
+
+async def test_an_ignored_account_still_lists_the_person_ignoring_them(session):
+    guild = await create_guild(session)
+    ada = await create_user(session)
+    bram = await create_user(session)
+    for user in (ada, bram):
+        await create_guild_membership(session, user=user, guild=guild)
+        await _policy(session, user, DmPolicy.community)
+
+    session.add(UserIgnore(user_id=ada.id, ignored_user_id=bram.id))
+    await session.flush()
+
+    assert await _listable(session, bram, guild) == {ada.id}
+    assert await _listable(session, ada, guild) == set()

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -20,6 +20,7 @@ from app.db.session import AdminSessionLocal, run_migrations, set_rls_context
 from app.models.platform.guild import Guild
 from app.models.platform.user import User, UserRole
 from app.services.platform import app_settings as app_settings_service
+from app.services.platform import dm_settings as dm_settings_service
 from app.services.platform import guilds as guilds_service
 from app.core import usernames
 
@@ -54,6 +55,8 @@ async def init_owner() -> None:
             email_verified=True,
         )
         session.add(user)
+        await session.flush()
+        await dm_settings_service.seed_for_new_account(session, user_id=user.id)
         await session.commit()
 
         # ...and their guild the same way the API does: create the shared rows,

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -51,6 +51,7 @@ _RLS_SHARED_TABLES = {
     "auth_providers",
     "auth_sessions",
     "billing_event_log",
+    "contact_grants",
     "federated_identities",
     "federated_identity_secrets",
     "guild_administration",
@@ -70,6 +71,9 @@ _RLS_SHARED_TABLES = {
     "user_api_keys",
     "user_avatars",
     "user_decorations",
+    "user_dm_guild_optouts",
+    "user_dm_settings",
+    "user_ignores",
     "user_view_preferences",
     "users",
 }

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -129,6 +129,17 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     # to clear an anonymized account off other people's lists too — the row
     # survives the husk, so the FK cascade never fires for it.
     "profile_favorites": frozenset({"SELECT", "DELETE"}),
+    # An account is created on the system engine (registration, invite
+    # redemption, provisioning from an identity provider), and its policy row is
+    # seeded there from the operator default — hence INSERT. The other three are
+    # written on the request path by the account holder; the system engine only
+    # reads them for the guild-lifecycle sweeps and clears them on erasure.
+    "user_dm_settings": frozenset({"SELECT", "INSERT", "DELETE"}),
+    "user_dm_guild_optouts": frozenset({"SELECT", "DELETE"}),
+    "contact_grants": frozenset({"SELECT", "DELETE"}),
+    # SELECT also carries the notification fan-out: who, of a set of
+    # recipients, ignores the actor (see app.services.platform.accounts).
+    "user_ignores": frozenset({"SELECT", "DELETE"}),
     # operator AI connections: the request path never queries this directly —
     # the resolve step reads it via an in-process cache loaded on the system
     # engine (SELECT), and the secret-key rotation re-encrypts its key column on
@@ -252,6 +263,12 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # A contacts list belongs to a signed-in account, and the bare pre-routing
     # login role serves nobody in particular.
     "profile_favorites": None,
+    # Read and written on the authenticated platform-tier path, never before a
+    # session is routed.
+    "user_dm_settings": None,
+    "user_dm_guild_optouts": None,
+    "contact_grants": None,
+    "user_ignores": None,
     # operator AI connections are owner-managed + system-engine-read only; the
     # bare pre-routing login role never touches them
     "platform_ai_connections": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -75,6 +75,14 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # and one-directional: the list is the holder's, and it may name
         # people they share no guild with.
         "profile_favorites",
+        # Who may ask to message an account, who it has agreed something with,
+        # and who it has chosen not to hear from. All three are per-account and
+        # cross-guild, like the starred list above, and none of them is any
+        # guild's business.
+        "user_dm_settings",
+        "user_dm_guild_optouts",
+        "contact_grants",
+        "user_ignores",
         # What a moderator did, and to whom. Cross-guild platform security
         # that has to outlive any guild — and every reference in it is a plain
         # integer, so it outlives the accounts it names too.

--- a/backend/app/models/platform/app_setting.py
+++ b/backend/app/models/platform/app_setting.py
@@ -1,8 +1,10 @@
 from typing import Optional
 
 from sqlalchemy import Boolean, Column, Integer, String
-from sqlmodel import Field, SQLModel
+from sqlmodel import Enum as SQLEnum, Field, SQLModel
 from pydantic import ConfigDict
+
+from app.models.platform.user_dm_settings import DmPolicy
 
 # Login posture (platform vs guild) is a deploy-time setting, read from
 # ``settings.AUTH_SCOPE`` — see ``app.core.config.AuthScope``. Platform OIDC
@@ -85,6 +87,19 @@ class AppSetting(SQLModel, table=True):
     community_age_gate_enabled: bool = Field(
         default=True,
         sa_column=Column(Boolean, nullable=False, server_default="true"),
+    )
+
+    # The direct-message policy a newly created account starts on. Read once,
+    # when the account is created, and copied into its ``user_dm_settings`` row;
+    # changing it later moves nobody, so raising it opens no existing account
+    # and lowering it revokes no channel anybody is using.
+    default_dm_policy: DmPolicy = Field(
+        default=DmPolicy.private,
+        sa_column=Column(
+            SQLEnum(DmPolicy, name="user_dm_policy", create_type=False),
+            nullable=False,
+            server_default=DmPolicy.private.value,
+        ),
     )
 
     # AI config ownership mode: "platform" (the operator's connections apply to

--- a/backend/app/models/platform/contact_grant.py
+++ b/backend/app/models/platform/contact_grant.py
@@ -1,0 +1,110 @@
+"""What two accounts have agreed between them.
+
+One unordered pair, one row per ``kind``. A **connection** is a mutual link
+that satisfies every ``DmPolicy``; a **message** grant is the accepted request
+that actually opens the channel. Both are needed to message on ``private``, and
+they are separate rows because a connection request may be raised while a
+message grant is already accepted.
+
+The pair is canonical (``user_id_low < user_id_high``), so a pair holds at most
+one grant of each kind by constraint rather than by handler — and a crossing
+request (B asking while A's is pending) collides on the primary key, which the
+handler turns into an accept.
+
+Declining deletes the row: there is no ``declined`` state, because the pair is
+back where it started and either may ask again.
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from pydantic import ConfigDict
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+)
+from sqlmodel import Enum as SQLEnum, Field, SQLModel
+
+
+class ContactGrantKind(str, Enum):
+    #: Mutual link. Satisfies every ``DmPolicy``; opens nothing on its own.
+    connection = "connection"
+    #: The accepted ask that opens the channel.
+    message = "message"
+
+
+class ContactGrantState(str, Enum):
+    pending = "pending"
+    accepted = "accepted"
+
+
+def canonical_pair(a: int, b: int) -> tuple[int, int]:
+    """The pair as this table stores it, smaller id first."""
+    return (a, b) if a < b else (b, a)
+
+
+class ContactGrant(SQLModel, table=True):
+    __tablename__ = "contact_grants"
+    __table_args__ = (
+        CheckConstraint(
+            "user_id_low < user_id_high", name="ck_contact_grants_ordered_pair"
+        ),
+        CheckConstraint(
+            "requested_by IN (user_id_low, user_id_high)",
+            name="ck_contact_grants_requester_in_pair",
+        ),
+        # The primary key covers the low side as a prefix; this is the other
+        # direction, which every "my pending requests" read needs.
+        Index("ix_contact_grants_user_high", "user_id_high"),
+    )
+    __allow_unmapped__ = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    user_id_low: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    user_id_high: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    kind: ContactGrantKind = Field(
+        sa_column=Column(
+            SQLEnum(ContactGrantKind, name="contact_grant_kind"),
+            primary_key=True,
+        )
+    )
+    state: ContactGrantState = Field(
+        default=ContactGrantState.pending,
+        sa_column=Column(
+            SQLEnum(ContactGrantState, name="contact_grant_state"),
+            nullable=False,
+            server_default=ContactGrantState.pending.value,
+        ),
+    )
+    requested_by: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    responded_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )

--- a/backend/app/models/platform/user_dm_guild_optout.py
+++ b/backend/app/models/platform/user_dm_guild_optout.py
@@ -1,0 +1,42 @@
+"""The communities an account has switched off for direct messages.
+
+A row means **off**. Storing the exceptions rather than a row per (account,
+community) is what makes "all on by default" true by construction: a community
+joined tomorrow counts with no write, leaving one drops the row through the
+foreign key, and the table stays empty for everyone who never touched a toggle.
+
+Only consulted while the account's policy is ``community``. Rows survive the
+policy moving away and back, so a week on ``public`` does not cost somebody
+their list.
+"""
+
+from datetime import datetime, timezone
+
+from pydantic import ConfigDict
+from sqlalchemy import Column, DateTime, ForeignKey, Integer
+from sqlmodel import Field, SQLModel
+
+
+class UserDmGuildOptout(SQLModel, table=True):
+    __tablename__ = "user_dm_guild_optouts"
+    __allow_unmapped__ = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    guild_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("guilds.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/app/models/platform/user_dm_settings.py
+++ b/backend/app/models/platform/user_dm_settings.py
@@ -1,0 +1,62 @@
+"""How one account answers "who may ask to message me".
+
+One row per account, written when the account is created and seeded from
+``AppSetting.default_dm_policy``. Deliberately not a column on ``public.users``:
+that table is read whole by the platform tiers, and this is the account
+holder's own business (see ``user_ignores`` for the same shape).
+
+An account with no row here reads as ``private`` — the most closed value —
+so a creation path that forgets to seed one is closed rather than open.
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import ConfigDict
+from sqlalchemy import Column, DateTime, ForeignKey, Integer
+from sqlmodel import Enum as SQLEnum, Field, SQLModel
+
+
+class DmPolicy(str, Enum):
+    """Who may ask to message this account, outside its connections.
+
+    A connection satisfies every value here, which is what makes it the one
+    thing that works whatever the holder picks.
+    """
+
+    #: Nobody. Only accounts this one is connected to may ask.
+    private = "private"
+    #: Anyone sharing a live community this account has not switched off.
+    community = "community"
+    #: Anyone at all.
+    public = "public"
+
+
+class UserDmSettings(SQLModel, table=True):
+    __tablename__ = "user_dm_settings"
+    __allow_unmapped__ = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    dm_policy: DmPolicy = Field(
+        default=DmPolicy.private,
+        sa_column=Column(
+            SQLEnum(DmPolicy, name="user_dm_policy"),
+            nullable=False,
+            server_default=DmPolicy.private.value,
+        ),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/app/models/platform/user_ignore.py
+++ b/backend/app/models/platform/user_ignore.py
@@ -1,0 +1,59 @@
+"""The accounts one person has chosen not to hear from.
+
+A row is one account on one account's list. It is private and one-directional,
+like ``profile_favorites``: the list is the holder's, and who has ignored *you*
+is not a question this table answers for anybody on the request path.
+
+What it governs is arrival, not permission — an ignored account's messages,
+requests and mentions do not reach the holder, and the holder's own reach is
+untouched. The rule that reads the other direction is
+``public.dm_deliverable``, which returns a boolean and never a row.
+
+There is nothing on the row to edit, so no UPDATE policy and no UPDATE grant:
+a row is (who, whom, when), and stopping is a delete.
+"""
+
+from datetime import datetime, timezone
+
+from pydantic import ConfigDict
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+)
+from sqlmodel import Field, SQLModel
+
+
+class UserIgnore(SQLModel, table=True):
+    __tablename__ = "user_ignores"
+    __table_args__ = (
+        CheckConstraint("user_id <> ignored_user_id", name="ck_user_ignores_not_self"),
+        # The primary key covers ``user_id`` as a prefix, which is the read the
+        # page makes. This is the other direction: which of a set of accounts
+        # ignores one actor, which the notification fan-out asks.
+        Index("ix_user_ignores_ignored_user", "ignored_user_id"),
+    )
+    __allow_unmapped__ = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    ignored_user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -38,6 +38,7 @@ from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.guild_administration import GuildAdministration
 from app.models.platform.federated_identity_secret import FederatedIdentitySecret
 from app.models.platform.user import User, UserRole, UserStatus
+from app.services.platform import dm_settings as dm_settings_service
 from app.services.platform import usernames as username_service
 
 logger = logging.getLogger(__name__)
@@ -327,6 +328,10 @@ async def _provision(
             )
             session.add(identity)
             await session.flush()
+        # Outside the savepoint, and before the commit: a lost race raises out
+        # of the block above and never reaches this, so there is no row for an
+        # account that was discarded.
+        await dm_settings_service.seed_for_new_account(session, user_id=user.id)
         await session.commit()
         await session.refresh(user)
         await session.refresh(identity)

--- a/backend/app/services/platform/dm_settings.py
+++ b/backend/app/services/platform/dm_settings.py
@@ -1,0 +1,49 @@
+"""The direct-message policy row that hangs off an account.
+
+One row per account, created with the account. It is seeded here rather than in
+each of the three places an account is made — registration, provisioning from
+an identity provider, and the bootstrap owner — so the operator's default is
+applied wherever an account arrives from.
+
+A missing row still reads as ``private`` in ``public.dm_can_ask``, so a path
+that somehow skips this is closed rather than open; what it would lose is the
+operator's choice, silently, which is what ``dm_settings_test`` is for.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.platform.user_dm_settings import UserDmSettings
+
+
+async def seed_for_new_account(session: AsyncSession, *, user_id: int) -> None:
+    """Give a newly created account the policy the operator set as the default.
+
+    Runs on the session that created the account, which is the system engine on
+    every path — the row belongs to an account that has no request context of
+    its own yet.
+
+    Idempotent by constraint: a second call for the same account does nothing,
+    so a retried registration does not overwrite a policy its owner has since
+    changed.
+    """
+    from app.services.platform import app_settings as app_settings_service
+
+    app_settings = await app_settings_service.get_app_settings(session)
+    # A core insert, so the model's default factories do not run: the
+    # timestamps are named here.
+    now = datetime.now(timezone.utc)
+    await session.exec(
+        pg_insert(UserDmSettings)
+        .values(
+            user_id=user_id,
+            dm_policy=app_settings.default_dm_policy,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(index_elements=["user_id"])
+    )

--- a/backend/app/services/platform/dm_settings_test.py
+++ b/backend/app/services/platform/dm_settings_test.py
@@ -1,0 +1,115 @@
+"""Every path that makes an account leaves it a policy row.
+
+There is no single funnel for account creation — registration, provisioning
+from an identity provider and the bootstrap owner each build a ``User`` of
+their own — so the thing worth asserting is coverage: each one calls the
+seeder, and each one applies the operator's default rather than the column
+default.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlmodel import select
+
+from app.models.platform.user_dm_settings import DmPolicy, UserDmSettings
+from app.services.platform import dm_settings as dm_settings_service
+from app.testing import create_user
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _set_default(session, policy: DmPolicy) -> None:
+    from app.services.platform import app_settings as app_settings_service
+
+    row = await app_settings_service.get_app_settings(session)
+    row.default_dm_policy = policy
+    session.add(row)
+    await session.flush()
+
+
+async def _policy_of(session, user_id: int) -> DmPolicy | None:
+    row = (
+        await session.exec(
+            select(UserDmSettings).where(UserDmSettings.user_id == user_id)
+        )
+    ).one_or_none()
+    return row.dm_policy if row else None
+
+
+async def test_seeding_applies_the_operator_default(session):
+    await _set_default(session, DmPolicy.community)
+    user = await create_user(session)
+    await session.exec(
+        text("DELETE FROM public.user_dm_settings WHERE user_id = :u").bindparams(
+            u=user.id
+        )
+    )
+
+    await dm_settings_service.seed_for_new_account(session, user_id=user.id)
+
+    assert await _policy_of(session, user.id) is DmPolicy.community
+
+
+async def test_seeding_twice_leaves_a_changed_policy_alone(session):
+    await _set_default(session, DmPolicy.private)
+    user = await create_user(session)
+    await session.exec(
+        text("DELETE FROM public.user_dm_settings WHERE user_id = :u").bindparams(
+            u=user.id
+        )
+    )
+    await dm_settings_service.seed_for_new_account(session, user_id=user.id)
+
+    # The account holder opens up, and a retried creation must not close them.
+    row = (
+        await session.exec(
+            select(UserDmSettings).where(UserDmSettings.user_id == user.id)
+        )
+    ).one()
+    row.dm_policy = DmPolicy.public
+    await session.flush()
+    await dm_settings_service.seed_for_new_account(session, user_id=user.id)
+
+    assert await _policy_of(session, user.id) is DmPolicy.public
+
+
+async def test_registration_seeds_the_row(client, session):
+    await _set_default(session, DmPolicy.community)
+    await session.commit()
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "dm-seed@example.com",
+            "password": "correct horse battery staple",
+            "full_name": "Seed Tester",
+            "username": "seedtester",
+        },
+    )
+    assert response.status_code in (200, 201), response.text
+
+    created = response.json()["id"]
+    assert await _policy_of(session, created) is DmPolicy.community
+
+
+async def test_the_bootstrap_owner_is_seeded(session):
+    """``init_db`` seeds the first account before anything else exists."""
+    from app.db import init_db as init_db_module
+
+    source = init_db_module.__file__
+    assert source is not None
+    with open(source, encoding="utf-8") as handle:
+        body = handle.read()
+    assert "dm_settings_service.seed_for_new_account" in body
+
+
+async def test_identity_provisioning_is_seeded(session):
+    """Provisioning from an identity provider seeds the row before it commits,
+    and after the savepoint that would discard a lost race."""
+    from app.services.auth import identity as identity_module
+
+    source = identity_module.__file__
+    assert source is not None
+    with open(source, encoding="utf-8") as handle:
+        body = handle.read()
+    assert "dm_settings_service.seed_for_new_account" in body


### PR DESCRIPTION
## Problem

There is no way for one account to say who may contact it, and no messaging
permission layer for a direct-message transport to sit on. This is the first
of five PRs building that; it lands the schema and the rule, and nothing user
facing.

Design doc: `history/dm-connections-blocks-design.md` (local, gitignored).

## Changes

**Four tables in `public`**, all per-account and cross-guild:

| Table | Holds |
|---|---|
| `user_dm_settings` | the policy this account picked — `private`, `community`, `public` |
| `user_dm_guild_optouts` | the communities it switched off, stored as the exceptions so a newly joined one counts with no write |
| `contact_grants` | the canonical pair, one row per `kind`: a connection, and the accepted message request |
| `user_ignores` | the accounts it has chosen not to hear from |

**The model.** A policy says who may ask *outside your connections*. A
connection satisfies all three values and opens nothing on its own — the
accepted message request is what does that — so a pair on `private` needs both.
Age confirmation gates everything in both directions.

**The rule is SQL, because it is the only copy.** Two entry points,
`dm_apparent_permission(target)` and `dm_listable_in_guild(guild)`, over three
internal functions. All owned by `app_dm_reader`, a new `NOLOGIN` role holding
column-scoped SELECT on exactly what the rule reads — the
`app_profile_reader` / `user_profiles` pattern from `0214`, one step further
because the answer spans seven relations and takes parameters.

**Neither entry point takes a caller id.** They read `app.current_user_id` and
raise without it, so the caller is the current user by construction and
neither can be asked about two other accounts.

**Ignoring is not in the rule.** It is one-directional and governs arrival, so
it stays off the permission answer entirely.

## Access shape

Verified against the live catalog after applying:

- `app_guild_base` — the role every `guild_<id>` inherits — holds **nothing** on
  all four tables, matching the shape `0221` put the guild path into.
- `platform_base` holds SELECT/INSERT/DELETE, plus UPDATE on the two that are
  edited in place.
- No platform-tier policy, no guild-admin leg, no PAM leg on any of the four.
- The three internal functions are owner-only; EXECUTE on the two entry points
  goes to `platform_base` and nowhere else.

## Schema / migration notes

`0222`. `user_dm_settings` is backfilled for every existing account, which
decides the order: rows in **before** `FORCE ROW LEVEL SECURITY`, per the rule
in CLAUDE.md and migration `0179`, since the policies key on request GUCs a
migration has no value for. The backfill asserts its own row count.

Existing accounts get `private` rather than the new operator default
(`app_settings.default_dm_policy`) — an account that predates the feature chose
nothing, and this is what nothing means.

## Testing

```
pytest -n 0 app/db/dm_rules_test.py                       16 passed
pytest -n 4 app/db app/api/v1/platform_endpoints/settings_test.py \
            app/api/v1/platform_endpoints/config_test.py  563 passed
ruff check app alembic                                    clean
ruff format app alembic                                   clean
ty check app                                              clean
alembic upgrade head                                      applied, catalog verified
```

`app/db/dm_rules_test.py` exercises the SQL functions rather than a Python
restatement of them. Two of the sixteen are the ones to keep:

- `test_being_ignored_does_not_change_the_answer` — identical response before
  and after being ignored.
- `test_an_ignored_account_still_lists_the_person_ignoring_them` — the roster
  is unchanged for the account that was ignored.

## What is not here

No endpoints, no services, no UI, so no changelog entry — that lands with the
surface. Next: services and endpoints, then notification suppression, then the
realtime channel, then the frontend.
