### PR TITLE
Connect two accounts, and open a channel between them

### DIFF
--- a/backend/alembic/versions/20260904_0224_dm_request_entry_points.py
+++ b/backend/alembic/versions/20260904_0224_dm_request_entry_points.py
@@ -1,0 +1,83 @@
+"""Entry points for the two questions the request path actually asks.
+
+``0223`` gave the request path ``dm_apparent_permission`` and
+``dm_listable_in_guild``, both of which read the caller from
+``app.current_user_id`` rather than taking one. The services built on top ask a
+third question — *may I send this account a connection request* — which is
+``may_connect``: both accounts active and age-confirmed, no policy consulted.
+
+``dm_may_connect`` is that, in the same shape: caller from the request context,
+so it answers about the caller and one other account and cannot be pointed at
+two strangers.
+
+The sweep that re-tests message grants is the other half. It works on pairs that
+need not involve the caller — a community removal re-tests the grants of the
+person who left — so it runs on the system engine, and ``dm_mutual_ask`` is
+granted to ``app_admin`` alone for it. The request path still cannot reach it.
+
+Revision ID: 20260904_0224
+Revises: 20260904_0223
+Create Date: 2026-09-04
+"""
+
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260904_0224"
+down_revision = "20260904_0223"
+branch_labels = None
+depends_on = None
+
+READER = "app_dm_reader"
+
+
+def _platform_base() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+_FUNCTION = """
+CREATE OR REPLACE FUNCTION public.dm_may_connect(target_id int)
+RETURNS boolean
+LANGUAGE plpgsql STABLE PARALLEL SAFE SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $fn$
+DECLARE
+  actor_id int := NULLIF(current_setting('app.current_user_id', true), '')::int;
+BEGIN
+  IF actor_id IS NULL THEN
+    RAISE EXCEPTION 'dm_may_connect requires app.current_user_id';
+  END IF;
+  IF actor_id = target_id THEN
+    RETURN false;
+  END IF;
+  RETURN public.dm_reachable(actor_id) AND public.dm_reachable(target_id);
+END;
+$fn$
+"""
+
+
+def upgrade() -> None:
+    base = _platform_base()
+    statements = [
+        _FUNCTION,
+        f'GRANT "{READER}" TO CURRENT_USER WITH INHERIT TRUE, SET TRUE',
+        f'GRANT CREATE ON SCHEMA public TO "{READER}"',
+        f'ALTER FUNCTION public.dm_may_connect(int) OWNER TO "{READER}"',
+        f'REVOKE CREATE ON SCHEMA public FROM "{READER}"',
+        "REVOKE ALL ON FUNCTION public.dm_may_connect(int) FROM PUBLIC",
+        f'GRANT EXECUTE ON FUNCTION public.dm_may_connect(int) TO "{base}"',
+        # The sweep's pairwise test, for the system engine that runs it.
+        "GRANT EXECUTE ON FUNCTION public.dm_mutual_ask(int, int) TO app_admin",
+    ]
+    for statement in statements:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    statements = [
+        "REVOKE ALL ON FUNCTION public.dm_mutual_ask(int, int) FROM app_admin",
+        "DROP FUNCTION IF EXISTS public.dm_may_connect(int)",
+    ]
+    for statement in statements:
+        op.execute(statement)

--- a/backend/app/api/v1/platform_endpoints/dm.py
+++ b/backend/app/api/v1/platform_endpoints/dm.py
@@ -17,12 +17,18 @@ from sqlalchemy import text
 from app.api.deps import UserSessionDep, get_current_active_user
 from app.core.messages import DirectMessageMessages
 from app.models.platform.user import User
+from app.models.platform.contact_grant import ContactGrantKind
 from app.schemas.platform.dm import (
+    ConnectionRequestCreate,
+    ContactGrantRead,
+    ContactGrantsResponse,
     DirectMessagePermissionRead,
     DirectMessageSettingsRead,
     DirectMessageSettingsUpdate,
     IgnoredAccountsResponse,
+    MessageRequestCreate,
 )
+from app.services.platform import contact_grants as contact_grants_service
 from app.services.platform import dm_settings as dm_settings_service
 from app.services.platform import user_ignores as user_ignores_service
 
@@ -159,3 +165,188 @@ async def read_dm_permission(
         )
     ).scalar_one()
     return DirectMessagePermissionRead(permission=permission)
+
+
+def _grant_error(exc: contact_grants_service.ContactGrantError) -> HTTPException:
+    """Every refusal is a 409 with its code and nothing else.
+
+    A handle nobody holds, an account that cannot be reached and a request that
+    will never be surfaced all answer the same way, so the endpoint is not a
+    way to learn which it was.
+    """
+    return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.code)
+
+
+@me_router.get("/connections", response_model=ContactGrantsResponse)
+async def list_connections(
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> ContactGrantsResponse:
+    """Accepted connections, plus what is pending in each direction."""
+    grants = await contact_grants_service.list_for(
+        session, user_id=current_user.id, kind=ContactGrantKind.connection
+    )
+    return await contact_grants_service.to_reads(
+        session, user_id=current_user.id, grants=grants
+    )
+
+
+@me_router.post(
+    "/connections",
+    response_model=ContactGrantRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def request_connection(
+    payload: ConnectionRequestCreate,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> ContactGrantRead:
+    """Ask an account to connect, by its exact handle.
+
+    A handle rather than an id, whatever the target's policy: it is the one
+    shape that works for an account on ``private``, which is never offered from
+    a roster or a picker.
+    """
+    try:
+        target_id = await contact_grants_service.resolve_handle(
+            session,
+            username=payload.username,
+            discriminator=payload.discriminator,
+        )
+        grant = await contact_grants_service.request(
+            session,
+            actor_id=current_user.id,
+            target_id=target_id,
+            kind=ContactGrantKind.connection,
+        )
+    except contact_grants_service.ContactGrantError as exc:
+        raise _grant_error(exc) from exc
+    return await _single_read(session, current_user.id, grant)
+
+
+@me_router.post("/connections/{user_id}/accept", response_model=ContactGrantRead)
+async def accept_connection(
+    user_id: TargetUserId,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> ContactGrantRead:
+    """Accept a connection, which also opens the pair's message channel."""
+    try:
+        grant = await contact_grants_service.accept(
+            session,
+            actor_id=current_user.id,
+            other_id=user_id,
+            kind=ContactGrantKind.connection,
+        )
+    except contact_grants_service.ContactGrantError as exc:
+        raise _grant_error(exc) from exc
+    return await _single_read(session, current_user.id, grant)
+
+
+@me_router.delete("/connections/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_connection(
+    user_id: TargetUserId,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> Response:
+    """Decline, cancel or disconnect — one verb.
+
+    The pair's message grant is re-tested rather than dropped: two co-members
+    who un-connect can still ask each other, so they keep talking.
+    """
+    await contact_grants_service.remove(
+        session,
+        actor_id=current_user.id,
+        other_id=user_id,
+        kind=ContactGrantKind.connection,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@me_router.get("/message-requests", response_model=ContactGrantsResponse)
+async def list_message_requests(
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> ContactGrantsResponse:
+    """Open channels, plus what is pending in each direction."""
+    grants = await contact_grants_service.list_for(
+        session, user_id=current_user.id, kind=ContactGrantKind.message
+    )
+    return await contact_grants_service.to_reads(
+        session, user_id=current_user.id, grants=grants
+    )
+
+
+@me_router.post(
+    "/message-requests",
+    response_model=ContactGrantRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def request_message(
+    payload: MessageRequestCreate,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> ContactGrantRead:
+    """Ask permission to message an account.
+
+    Comes back already accepted when the pair is connected: a connection has
+    answered this question, and asking twice is a consent step with no decision
+    in it.
+    """
+    try:
+        grant = await contact_grants_service.request(
+            session,
+            actor_id=current_user.id,
+            target_id=payload.user_id,
+            kind=ContactGrantKind.message,
+        )
+    except contact_grants_service.ContactGrantError as exc:
+        raise _grant_error(exc) from exc
+    return await _single_read(session, current_user.id, grant)
+
+
+@me_router.post("/message-requests/{user_id}/accept", response_model=ContactGrantRead)
+async def accept_message_request(
+    user_id: TargetUserId,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> ContactGrantRead:
+    try:
+        grant = await contact_grants_service.accept(
+            session,
+            actor_id=current_user.id,
+            other_id=user_id,
+            kind=ContactGrantKind.message,
+        )
+    except contact_grants_service.ContactGrantError as exc:
+        raise _grant_error(exc) from exc
+    return await _single_read(session, current_user.id, grant)
+
+
+@me_router.delete("/message-requests/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_message_request(
+    user_id: TargetUserId,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> Response:
+    """Decline, cancel or close a channel."""
+    await contact_grants_service.remove(
+        session,
+        actor_id=current_user.id,
+        other_id=user_id,
+        kind=ContactGrantKind.message,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+async def _single_read(session, user_id: int, grant) -> ContactGrantRead:
+    grouped = await contact_grants_service.to_reads(
+        session, user_id=user_id, grants=[grant]
+    )
+    for bucket in (grouped.accepted, grouped.incoming, grouped.outgoing):
+        if bucket:
+            return bucket[0]
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=DirectMessageMessages.USER_NOT_FOUND,
+    )

--- a/backend/app/api/v1/platform_endpoints/dm_test.py
+++ b/backend/app/api/v1/platform_endpoints/dm_test.py
@@ -196,3 +196,121 @@ async def test_an_unknown_account_is_not_found(client, acting_user):
     )
     assert response.status_code == 404
     assert response.json()["detail"] == "DM_USER_NOT_FOUND"
+
+
+# ------------------------------------------------- connections & requests ---
+
+
+async def _handle(session, user) -> dict:
+    await session.refresh(user)
+    return {"username": user.username, "discriminator": user.discriminator}
+
+
+async def test_a_connection_is_addressed_by_handle(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+
+    response = await client.post(
+        "/api/v1/me/connections", json=await _handle(session, b.user), headers=a.headers
+    )
+    assert response.status_code == 202, response.text
+    assert response.json()["user_id"] == b.user.id
+    assert response.json()["state"] == "pending"
+    assert response.json()["outgoing"] is True
+
+    incoming = await client.get("/api/v1/me/connections", headers=b.headers)
+    assert [r["user_id"] for r in incoming.json()["incoming"]] == [a.user.id]
+
+
+async def test_an_unknown_handle_answers_like_an_unreachable_one(
+    client, session, acting_user
+):
+    """Both are a 409 with a code and nothing else, so the endpoint is not a
+    way to sweep the discriminator space."""
+    a = await acting_user()
+    b = await acting_user()
+    b.user.age_confirmed_at = None
+    session.add(b.user)
+    await session.commit()
+
+    missing = await client.post(
+        "/api/v1/me/connections",
+        json={"username": "nobodyhere", "discriminator": 9999},
+        headers=a.headers,
+    )
+    unreachable = await client.post(
+        "/api/v1/me/connections", json=await _handle(session, b.user), headers=a.headers
+    )
+    assert missing.status_code == unreachable.status_code == 409
+
+
+async def test_accepting_a_connection_opens_the_channel(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+
+    await client.post(
+        "/api/v1/me/connections", json=await _handle(session, b.user), headers=a.headers
+    )
+    accepted = await client.post(
+        f"/api/v1/me/connections/{a.user.id}/accept", headers=b.headers
+    )
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["state"] == "accepted"
+
+    channels = await client.get("/api/v1/me/message-requests", headers=a.headers)
+    assert [r["user_id"] for r in channels.json()["accepted"]] == [b.user.id]
+
+    permission = await client.get(
+        f"/api/v1/users/{b.user.id}/dm-permission", headers=a.headers
+    )
+    assert permission.json() == {"permission": "open"}
+
+
+async def test_a_request_from_an_ignored_account_is_never_surfaced(
+    client, session, acting_user
+):
+    """Stored, and invisible to the person who is ignoring them."""
+    ada = await acting_user()
+    bram = await acting_user()
+    await client.put(f"/api/v1/me/ignored/{bram.user.id}", headers=ada.headers)
+
+    sent = await client.post(
+        "/api/v1/me/connections",
+        json=await _handle(session, ada.user),
+        headers=bram.headers,
+    )
+    assert sent.status_code == 202, sent.text
+
+    theirs = await client.get("/api/v1/me/connections", headers=ada.headers)
+    assert theirs.json()["incoming"] == []
+
+    # Bram sees his own outgoing request exactly as if it had landed.
+    mine = await client.get("/api/v1/me/connections", headers=bram.headers)
+    assert [r["user_id"] for r in mine.json()["outgoing"]] == [ada.user.id]
+
+
+async def test_removing_a_connection_keeps_a_community_channel(
+    client, session, acting_user
+):
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _set_policy(session, ada.user, DmPolicy.community)
+    await _set_policy(session, bram.user, DmPolicy.community)
+
+    await client.post(
+        "/api/v1/me/connections",
+        json=await _handle(session, bram.user),
+        headers=ada.headers,
+    )
+    await client.post(
+        f"/api/v1/me/connections/{ada.user.id}/accept", headers=bram.headers
+    )
+    removed = await client.delete(
+        f"/api/v1/me/connections/{bram.user.id}", headers=ada.headers
+    )
+    assert removed.status_code == 204
+
+    permission = await client.get(
+        f"/api/v1/users/{bram.user.id}/dm-permission", headers=ada.headers
+    )
+    assert permission.json() == {"permission": "open"}

--- a/backend/app/api/v1/platform_endpoints/dm_test.py
+++ b/backend/app/api/v1/platform_endpoints/dm_test.py
@@ -241,7 +241,11 @@ async def test_an_unknown_handle_answers_like_an_unreachable_one(
     unreachable = await client.post(
         "/api/v1/me/connections", json=await _handle(session, b.user), headers=a.headers
     )
+    # The whole response, not just the status: an earlier version matched on
+    # 409 alone and let two different detail codes through, which is the
+    # difference between "cannot connect" and "that account is here".
     assert missing.status_code == unreachable.status_code == 409
+    assert missing.json() == unreachable.json()
 
 
 async def test_accepting_a_connection_opens_the_channel(client, session, acting_user):
@@ -314,3 +318,28 @@ async def test_removing_a_connection_keeps_a_community_channel(
         f"/api/v1/users/{bram.user.id}/dm-permission", headers=ada.headers
     )
     assert permission.json() == {"permission": "open"}
+
+
+async def test_ignoring_someone_does_not_stop_you_reaching_them(
+    client, session, acting_user
+):
+    """Ignoring runs one way.
+
+    Bram ignores Ada, then asks to connect. Ada sees it: what Bram switched off
+    is Ada reaching *him*, not him reaching her. The mirror of
+    ``test_a_request_from_an_ignored_account_is_never_surfaced``, and the pair
+    of them is what pins the direction.
+    """
+    ada = await acting_user()
+    bram = await acting_user()
+    await client.put(f"/api/v1/me/ignored/{ada.user.id}", headers=bram.headers)
+
+    sent = await client.post(
+        "/api/v1/me/connections",
+        json=await _handle(session, ada.user),
+        headers=bram.headers,
+    )
+    assert sent.status_code == 202, sent.text
+
+    theirs = await client.get("/api/v1/me/connections", headers=ada.headers)
+    assert [r["user_id"] for r in theirs.json()["incoming"]] == [bram.user.id]

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -976,9 +976,6 @@ class ContactGrantMessages:
     #: Accepting something nobody asked for, or accepting your own request.
     NO_REQUEST = "CONTACT_GRANT_NO_REQUEST"
     CANNOT_GRANT_SELF = "CONTACT_GRANT_CANNOT_GRANT_SELF"
-    #: No account with that handle. Answers the same way as a handle that
-    #: exists but cannot be reached.
-    HANDLE_NOT_FOUND = "CONTACT_GRANT_HANDLE_NOT_FOUND"
 
 
 class ContactMessages:

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -966,6 +966,21 @@ class DirectMessageMessages:
     NOT_A_MEMBER = "DM_NOT_A_MEMBER"
 
 
+class ContactGrantMessages:
+    """Connections and message requests."""
+
+    #: The pair cannot reach each other right now: a policy that does not admit
+    #: them, an account that is not active, or an age question unanswered. One
+    #: code for every refusal.
+    CANNOT_REACH = "CONTACT_GRANT_CANNOT_REACH"
+    #: Accepting something nobody asked for, or accepting your own request.
+    NO_REQUEST = "CONTACT_GRANT_NO_REQUEST"
+    CANNOT_GRANT_SELF = "CONTACT_GRANT_CANNOT_GRANT_SELF"
+    #: No account with that handle. Answers the same way as a handle that
+    #: exists but cannot be reached.
+    HANDLE_NOT_FOUND = "CONTACT_GRANT_HANDLE_NOT_FOUND"
+
+
 class ContactMessages:
     """My Contacts — the starred list on the personal page."""
 

--- a/backend/app/models/platform/notification.py
+++ b/backend/app/models/platform/notification.py
@@ -37,6 +37,10 @@ class NotificationType(str, Enum):
     username_changed = "username_changed"
     account_suspended = "account_suspended"
     account_unsuspended = "account_unsuspended"
+    connection_requested = "connection_requested"
+    connection_accepted = "connection_accepted"
+    message_request_received = "message_request_received"
+    message_request_accepted = "message_request_accepted"
 
 
 class Notification(SQLModel, table=True):

--- a/backend/app/schemas/platform/dm.py
+++ b/backend/app/schemas/platform/dm.py
@@ -88,3 +88,47 @@ class DirectMessagePermissionRead(SanitizedBaseModel):
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
     permission: str
+
+
+class ContactGrantRead(SanitizedBaseModel):
+    """One connection or message request, from the reader's side of it."""
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    user_id: int
+    username: str
+    discriminator: int
+    avatar_url: Optional[str] = None
+    state: str
+    #: True when the reader is the one who asked, which is what tells a
+    #: cancellable request from one waiting on them.
+    outgoing: bool
+    created_at: datetime
+    responded_at: Optional[datetime] = None
+
+
+class ContactGrantsResponse(SanitizedBaseModel):
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    accepted: List[ContactGrantRead]
+    incoming: List[ContactGrantRead]
+    outgoing: List[ContactGrantRead]
+
+
+class ConnectionRequestCreate(SanitizedBaseModel):
+    """A connection is addressed by handle, never by id.
+
+    One shape whatever the target's policy, and the shape the app-wide people
+    search will use: an account on ``private`` is reached by somebody typing
+    its handle rather than by being offered from a list.
+    """
+
+    username: str
+    discriminator: int
+
+
+class MessageRequestCreate(SanitizedBaseModel):
+    """A message request is addressed by id: everyone you may ask is somebody
+    you can already see."""
+
+    user_id: int

--- a/backend/app/services/platform/contact_grants.py
+++ b/backend/app/services/platform/contact_grants.py
@@ -1,0 +1,436 @@
+"""Connections and message requests — what two accounts have agreed.
+
+Both live in ``contact_grants``, one row per unordered pair per kind, and they
+do different jobs. A **connection** satisfies every ``DmPolicy`` and opens
+nothing on its own; an accepted **message** grant is what opens the channel.
+So a pair on ``private`` needs both.
+
+Two rules here are worth finding when you come back to this module:
+
+* ``initial_message_state`` — a message grant between connected accounts starts
+  accepted. That is a statement about what a connection currently *means*, not
+  about messaging, and it is the one place to delete when a connection carries
+  anything else.
+* ``revoke_stale_message_grants`` — a grant lives only while the pair could ask
+  each other today. Five events take a leg of ``can_ask`` away, and all five
+  run the same test rather than each carrying a rule of its own.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import or_, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from app.models.platform.contact_grant import (
+    ContactGrant,
+    ContactGrantKind,
+    ContactGrantState,
+    canonical_pair,
+)
+from app.models.platform.user_ignore import UserIgnore
+from app.schemas.platform.dm import (
+    ContactGrantRead,
+    ContactGrantsResponse,
+)
+
+
+class ContactGrantError(Exception):
+    """Raised with a message code the endpoint turns into a status."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def initial_message_state(connected: bool) -> ContactGrantState:
+    """The state a message grant is born in.
+
+    Connected accounts get an accepted one: asking somebody to connect and then
+    asking them again for permission to say hello is a consent step with no
+    decision in it. Not a rule about messaging — a rule about what a connection
+    currently means. When a connection carries anything besides messaging, this
+    returns ``pending`` again and nothing else moves.
+    """
+    return ContactGrantState.accepted if connected else ContactGrantState.pending
+
+
+async def _get(
+    session: AsyncSession, a: int, b: int, kind: ContactGrantKind
+) -> ContactGrant | None:
+    low, high = canonical_pair(a, b)
+    return await session.get(ContactGrant, (low, high, kind))
+
+
+async def are_connected(session: AsyncSession, a: int, b: int) -> bool:
+    row = await _get(session, a, b, ContactGrantKind.connection)
+    return row is not None and row.state is ContactGrantState.accepted
+
+
+async def _may_connect(session: AsyncSession, target_id: int) -> bool:
+    """Whether the caller may send this account a connection request.
+
+    ``dm_may_connect`` reads the caller from the request context, so this asks
+    about the caller and one other account and cannot be pointed elsewhere.
+    """
+    return (
+        await session.exec(
+            text("SELECT public.dm_may_connect(:t)").bindparams(t=target_id)
+        )
+    ).scalar_one()
+
+
+async def _may_message(session: AsyncSession, target_id: int) -> bool:
+    """Whether the caller and this account could open a channel today.
+
+    The same answer the profile shows, from the same function — ``denied``
+    covers every refusal, including being ignored, which the caller is not told
+    apart from the rest.
+    """
+    permission = (
+        await session.exec(
+            text("SELECT public.dm_apparent_permission(:t)").bindparams(t=target_id)
+        )
+    ).scalar_one()
+    return permission in ("may_request", "open")
+
+
+async def _pair_still_allowed(session: AsyncSession, a: int, b: int) -> bool:
+    """``public.dm_mutual_ask`` for a pair that need not involve the caller.
+
+    Only the system engine may ask this, which is why the sweep runs there.
+    """
+    return (
+        await session.exec(
+            text("SELECT public.dm_mutual_ask(:a, :b)").bindparams(a=a, b=b)
+        )
+    ).scalar_one()
+
+
+async def list_for(
+    session: AsyncSession, *, user_id: int, kind: ContactGrantKind
+) -> list[ContactGrant]:
+    """Every grant of one kind this account is a party to.
+
+    Rows whose other party the reader ignores are dropped here, so the pending
+    list of somebody they have stopped hearing from is not a way through.
+    """
+    rows = (
+        await session.exec(
+            select(ContactGrant)
+            .where(
+                ContactGrant.kind == kind,
+                or_(
+                    ContactGrant.user_id_low == user_id,
+                    ContactGrant.user_id_high == user_id,
+                ),
+            )
+            .order_by(col(ContactGrant.created_at).desc())
+        )
+    ).all()
+    if not rows:
+        return []
+
+    ignored = set(
+        (
+            await session.exec(
+                select(UserIgnore.ignored_user_id).where(UserIgnore.user_id == user_id)
+            )
+        ).all()
+    )
+    return [
+        row
+        for row in rows
+        if other_party(row, user_id) not in ignored
+        # A request from an account that ignores the reader is stored and never
+        # surfaced to them; it becomes acceptable if that is ever lifted.
+        and not (
+            row.state is ContactGrantState.pending
+            and row.requested_by != user_id
+            and other_party(row, user_id) in ignored
+        )
+    ]
+
+
+def other_party(grant: ContactGrant, user_id: int) -> int:
+    return grant.user_id_high if grant.user_id_low == user_id else grant.user_id_low
+
+
+async def request(
+    session: AsyncSession,
+    *,
+    actor_id: int,
+    target_id: int,
+    kind: ContactGrantKind,
+) -> ContactGrant:
+    """Ask for a connection, or for permission to message.
+
+    A crossing request — the other party asking while yours is pending — is a
+    primary-key collision rather than a race, and it means both of them wanted
+    it, so it is turned into an accept.
+
+    An account that ignores the actor still gets the row: it is stored, never
+    surfaced to them, and becomes acceptable if they ever stop. Refusing here
+    would answer a question this feature does not answer.
+    """
+    from app.core.messages import ContactGrantMessages
+
+    if actor_id == target_id:
+        raise ContactGrantError(ContactGrantMessages.CANNOT_GRANT_SELF)
+
+    existing = await _get(session, actor_id, target_id, kind)
+    if existing is not None:
+        if existing.state is ContactGrantState.accepted:
+            return existing
+        if existing.requested_by == actor_id:
+            return existing
+        return await accept(session, actor_id=actor_id, other_id=target_id, kind=kind)
+
+    allowed = (
+        await _may_connect(session, target_id)
+        if kind is ContactGrantKind.connection
+        else await _may_message(session, target_id)
+    )
+    if not allowed:
+        raise ContactGrantError(ContactGrantMessages.CANNOT_REACH)
+
+    low, high = canonical_pair(actor_id, target_id)
+    state = (
+        initial_message_state(await are_connected(session, actor_id, target_id))
+        if kind is ContactGrantKind.message
+        else ContactGrantState.pending
+    )
+    now = datetime.now(timezone.utc)
+    grant = ContactGrant(
+        user_id_low=low,
+        user_id_high=high,
+        kind=kind,
+        state=state,
+        requested_by=actor_id,
+        created_at=now,
+        responded_at=now if state is ContactGrantState.accepted else None,
+    )
+    session.add(grant)
+    await session.commit()
+    await session.refresh(grant)
+    return grant
+
+
+async def accept(
+    session: AsyncSession,
+    *,
+    actor_id: int,
+    other_id: int,
+    kind: ContactGrantKind,
+) -> ContactGrant:
+    """Say yes to a request somebody else made.
+
+    Accepting a connection also opens the pair's message grant, per
+    ``initial_message_state`` — one act, one consent, and one notification.
+    """
+    from app.core.messages import ContactGrantMessages
+
+    grant = await _get(session, actor_id, other_id, kind)
+    if grant is None or grant.requested_by == actor_id:
+        raise ContactGrantError(ContactGrantMessages.NO_REQUEST)
+    if grant.state is ContactGrantState.accepted:
+        return grant
+
+    grant.state = ContactGrantState.accepted
+    grant.responded_at = datetime.now(timezone.utc)
+    session.add(grant)
+
+    if kind is ContactGrantKind.connection:
+        await _open_message_grant(session, actor_id, other_id, grant.requested_by)
+
+    await session.commit()
+    await session.refresh(grant)
+    return grant
+
+
+async def _open_message_grant(
+    session: AsyncSession, a: int, b: int, requested_by: int
+) -> None:
+    """Give a newly connected pair their channel.
+
+    Flips an in-flight pending request rather than colliding with it: the
+    connection answers the same question it was asking.
+    """
+    existing = await _get(session, a, b, ContactGrantKind.message)
+    now = datetime.now(timezone.utc)
+    if existing is not None:
+        if existing.state is not ContactGrantState.accepted:
+            existing.state = ContactGrantState.accepted
+            existing.responded_at = now
+            session.add(existing)
+        return
+    low, high = canonical_pair(a, b)
+    session.add(
+        ContactGrant(
+            user_id_low=low,
+            user_id_high=high,
+            kind=ContactGrantKind.message,
+            state=ContactGrantState.accepted,
+            requested_by=requested_by,
+            created_at=now,
+            responded_at=now,
+        )
+    )
+
+
+async def remove(
+    session: AsyncSession,
+    *,
+    actor_id: int,
+    other_id: int,
+    kind: ContactGrantKind,
+) -> None:
+    """Decline, cancel, disconnect or close — one verb, one delete.
+
+    There is no ``declined`` state to store: the pair is back where it started
+    and either may ask again. Removing a *connection* re-tests the pair's
+    message grant rather than deleting it: a connection is a leg of ``can_ask``,
+    not a rank above the others, so two co-members who un-connect keep talking.
+    """
+    grant = await _get(session, actor_id, other_id, kind)
+    if grant is None:
+        return
+    await session.delete(grant)
+    await session.flush()
+    if kind is ContactGrantKind.connection:
+        await _revoke_pair_if_stale(session, actor_id, other_id)
+    await session.commit()
+
+
+async def _revoke_pair_if_stale(
+    session: AsyncSession, caller_id: int, other_id: int
+) -> None:
+    """Re-test one pair after a connection between them went away.
+
+    The caller is one of the two, so the question is theirs to ask and the row
+    is theirs to delete.
+    """
+    grant = await _get(session, caller_id, other_id, ContactGrantKind.message)
+    if grant is None:
+        return
+    if not await _may_message(session, other_id):
+        await session.delete(grant)
+        await session.flush()
+
+
+async def revoke_stale_message_grants(session: AsyncSession, *, user_id: int) -> int:
+    """Drop every message grant this account could no longer form today.
+
+    Called wherever a leg of ``can_ask`` goes away — a policy change, a
+    community switched off, a membership dropped, a community suspended, a
+    connection removed. All five ask the one question rather than each carrying
+    a rule of its own, so a grant is revoked for the same reason it would be
+    refused.
+
+    Runs on the system engine. The pairs need not involve whoever is making the
+    request — removing somebody from a community re-tests *their* grants — and
+    both the pairwise test and those rows are out of the request path's reach.
+    Call it after the change that prompted it has committed: this commits on its
+    own, so a caller that rolls back afterwards would have revoked for nothing.
+
+    Returns how many were dropped, so a caller can decide whether to signal.
+    """
+    from app.db.session import AdminSessionLocal
+
+    dropped = 0
+    async with AdminSessionLocal() as admin_session:
+        grants = (
+            await admin_session.exec(
+                select(ContactGrant).where(
+                    ContactGrant.kind == ContactGrantKind.message,
+                    or_(
+                        ContactGrant.user_id_low == user_id,
+                        ContactGrant.user_id_high == user_id,
+                    ),
+                )
+            )
+        ).all()
+        for grant in grants:
+            if not await _pair_still_allowed(
+                admin_session, grant.user_id_low, grant.user_id_high
+            ):
+                await admin_session.delete(grant)
+                dropped += 1
+        if dropped:
+            await admin_session.commit()
+    return dropped
+
+
+async def resolve_handle(
+    session: AsyncSession, *, username: str, discriminator: int
+) -> int:
+    """The account id behind a handle, for a connection request.
+
+    One answer for every miss: a handle nobody holds and a handle belonging to
+    somebody unreachable both raise the same code, so the endpoint is not a way
+    to sweep the discriminator space for accounts that exist.
+    """
+    from app.core.messages import ContactGrantMessages
+
+    row = (
+        await session.exec(
+            text(
+                "SELECT id FROM public.user_profiles "
+                "WHERE lower(username) = lower(:u) AND discriminator = :d"
+            ).bindparams(u=username, d=discriminator)
+        )
+    ).first()
+    if row is None:
+        raise ContactGrantError(ContactGrantMessages.HANDLE_NOT_FOUND)
+    return row[0]
+
+
+async def to_reads(
+    session: AsyncSession, *, user_id: int, grants: list[ContactGrant]
+) -> ContactGrantsResponse:
+    """Group a reader's grants into accepted, incoming and outgoing."""
+    if not grants:
+        return ContactGrantsResponse(accepted=[], incoming=[], outgoing=[])
+
+    others = {other_party(grant, user_id) for grant in grants}
+    profiles = {
+        row[0]: row
+        for row in (
+            await session.exec(
+                text(
+                    "SELECT id, username, discriminator, avatar_url "
+                    "FROM public.user_profiles WHERE id = ANY(:ids)"
+                ).bindparams(ids=list(others))
+            )
+        ).all()
+    }
+
+    accepted: list[ContactGrantRead] = []
+    incoming: list[ContactGrantRead] = []
+    outgoing: list[ContactGrantRead] = []
+    for grant in grants:
+        other = other_party(grant, user_id)
+        profile = profiles.get(other)
+        if profile is None:
+            continue
+        read = ContactGrantRead(
+            user_id=other,
+            username=profile[1],
+            discriminator=profile[2],
+            avatar_url=profile[3],
+            state=grant.state.value,
+            outgoing=grant.requested_by == user_id,
+            created_at=grant.created_at,
+            responded_at=grant.responded_at,
+        )
+        if grant.state is ContactGrantState.accepted:
+            accepted.append(read)
+        elif read.outgoing:
+            outgoing.append(read)
+        else:
+            incoming.append(read)
+    return ContactGrantsResponse(
+        accepted=accepted, incoming=incoming, outgoing=outgoing
+    )

--- a/backend/app/services/platform/contact_grants.py
+++ b/backend/app/services/platform/contact_grants.py
@@ -20,8 +20,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import or_, text
+import asyncio
+import logging
+from typing import Any
+
+from sqlalchemy import event, or_, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session as SyncSession
 from sqlmodel import col, select
 
 from app.models.platform.contact_grant import (
@@ -114,8 +119,9 @@ async def list_for(
 ) -> list[ContactGrant]:
     """Every grant of one kind this account is a party to.
 
-    Rows whose other party the reader ignores are dropped here, so the pending
-    list of somebody they have stopped hearing from is not a way through.
+    Rows whose other party the reader ignores are dropped, so a request from
+    somebody they have stopped hearing from is not a way back to their
+    attention. The row stays; it becomes visible again if the ignore is lifted.
     """
     rows = (
         await session.exec(
@@ -140,18 +146,12 @@ async def list_for(
             )
         ).all()
     )
-    return [
-        row
-        for row in rows
-        if other_party(row, user_id) not in ignored
-        # A request from an account that ignores the reader is stored and never
-        # surfaced to them; it becomes acceptable if that is ever lifted.
-        and not (
-            row.state is ContactGrantState.pending
-            and row.requested_by != user_id
-            and other_party(row, user_id) in ignored
-        )
-    ]
+    # One direction only, and deliberately: what is dropped is a row whose other
+    # party *the reader* ignores. An account that ignores the reader has not
+    # stopped itself reaching them — ignoring governs arrival at the person who
+    # did it, so their request still lands, and their own inbox is where it goes
+    # quiet.
+    return [row for row in rows if other_party(row, user_id) not in ignored]
 
 
 def other_party(grant: ContactGrant, user_id: int) -> int:
@@ -320,7 +320,9 @@ async def _revoke_pair_if_stale(
         await session.flush()
 
 
-async def revoke_stale_message_grants(session: AsyncSession, *, user_id: int) -> int:
+async def revoke_stale_message_grants(
+    session: AsyncSession | None, *, user_id: int
+) -> int:
     """Drop every message grant this account could no longer form today.
 
     Called wherever a leg of ``can_ask`` goes away — a policy change, a
@@ -329,11 +331,14 @@ async def revoke_stale_message_grants(session: AsyncSession, *, user_id: int) ->
     a rule of its own, so a grant is revoked for the same reason it would be
     refused.
 
-    Runs on the system engine. The pairs need not involve whoever is making the
-    request — removing somebody from a community re-tests *their* grants — and
-    both the pairwise test and those rows are out of the request path's reach.
-    Call it after the change that prompted it has committed: this commits on its
-    own, so a caller that rolls back afterwards would have revoked for nothing.
+    Runs on the system engine, on its own session. The pairs need not involve
+    whoever is making the request — removing somebody from a community re-tests
+    *their* grants — and neither the pairwise test nor those rows are the
+    request path's to reach.
+
+    It must see the state the prompting change left behind, so callers reach it
+    through ``queue_stale_grant_sweep`` rather than calling it mid-transaction.
+    ``session`` is accepted and unused, so a test can drive it directly.
 
     Returns how many were dropped, so a caller can decide whether to signal.
     """
@@ -369,8 +374,8 @@ async def resolve_handle(
     """The account id behind a handle, for a connection request.
 
     One answer for every miss: a handle nobody holds and a handle belonging to
-    somebody unreachable both raise the same code, so the endpoint is not a way
-    to sweep the discriminator space for accounts that exist.
+    somebody unreachable raise the same code, so the endpoint says only whether
+    a connection can be made and never whether an account is there.
     """
     from app.core.messages import ContactGrantMessages
 
@@ -383,7 +388,7 @@ async def resolve_handle(
         )
     ).first()
     if row is None:
-        raise ContactGrantError(ContactGrantMessages.HANDLE_NOT_FOUND)
+        raise ContactGrantError(ContactGrantMessages.CANNOT_REACH)
     return row[0]
 
 
@@ -434,3 +439,72 @@ async def to_reads(
     return ContactGrantsResponse(
         accepted=accepted, incoming=incoming, outgoing=outgoing
     )
+
+
+logger = logging.getLogger(__name__)
+
+#: Accounts whose grants this session has earned a re-test for, but has not
+#: committed the reason for yet.
+_PENDING_SWEEP_KEY = "contact_grants_pending_sweep"
+
+# ``loop.create_task`` keeps only a weak reference, so a fire-and-forget sweep
+# can be collected mid-flight. Hold them until they finish.
+_inflight: set[asyncio.Task] = set()
+
+
+def queue_stale_grant_sweep(session: Any, user_id: int | None) -> None:
+    """Re-test this account's channels once the transaction commits.
+
+    The sweep reads the state the change left behind, so it cannot run while
+    that change is still uncommitted — a membership deleted but not committed
+    still answers ``dm_mutual_ask`` as present, and the channel that rested on
+    it would be kept. Queueing here and running on ``after_commit`` is the same
+    shape ``account_stream.queue_account_signal`` uses for the same reason.
+
+    A rollback discards the queue, so nothing is revoked for a change that did
+    not happen. And a sweep that never runs costs correctness nothing: rule 3
+    recomputes ``mutual_ask`` on every call, so a row left behind grants no
+    access — it is only tidier for it to be gone.
+    """
+    if user_id is None:
+        return
+    pending: set[int] = session.info.setdefault(_PENDING_SWEEP_KEY, set())
+    pending.add(user_id)
+
+
+def _spawn(coro: Any) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop (a sync script, a test driving a sync session). The rows are
+        # committed either way and the rule recomputes, so there is nothing to
+        # deliver to.
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _inflight.add(task)
+    task.add_done_callback(_inflight.discard)
+
+
+async def _sweep_quietly(user_id: int) -> None:
+    try:
+        await revoke_stale_message_grants(None, user_id=user_id)
+    except Exception:  # pragma: no cover - best effort, the rule still holds
+        logger.debug("contact_grants: stale sweep failed", exc_info=True)
+
+
+def _run_pending(sync_session: SyncSession) -> None:
+    pending = sync_session.info.pop(_PENDING_SWEEP_KEY, None)
+    if not pending:
+        return
+    for user_id in pending:
+        _spawn(_sweep_quietly(user_id))
+
+
+def _discard_pending(sync_session: SyncSession, *_args: Any) -> None:
+    sync_session.info.pop(_PENDING_SWEEP_KEY, None)
+
+
+event.listens_for(SyncSession, "after_commit")(_run_pending)
+event.listens_for(SyncSession, "after_rollback")(_discard_pending)
+event.listens_for(SyncSession, "after_soft_rollback")(_discard_pending)

--- a/backend/app/services/platform/contact_grants_test.py
+++ b/backend/app/services/platform/contact_grants_test.py
@@ -6,6 +6,8 @@ open channel unless the pair connected first; and removing a connection re-tests
 the grant rather than deleting it, so two co-members keep talking.
 """
 
+import asyncio
+
 import pytest
 from sqlalchemy import text
 
@@ -253,13 +255,81 @@ async def test_going_private_revokes_a_community_channel(session):
     assert await _grant(session, a, b, ContactGrantKind.message) is None
 
 
-async def test_the_guild_path_runs_the_sweep(session):
-    """Leaving a community is one of the five events that re-test a grant, and
-    the call sits with the membership delete rather than beside it."""
-    from app.services.platform import guilds as guilds_module
+async def _open_channel_between_co_members(session):
+    """Two co-members on ``community`` with an accepted message grant."""
+    guild = await create_guild(session)
+    a = await create_user(session)
+    b = await create_user(session)
+    for user in (a, b):
+        await create_guild_membership(session, user=user, guild=guild)
+        await _policy(session, user, DmPolicy.community)
+    await session.commit()
 
-    source = guilds_module.__file__
-    assert source is not None
-    with open(source, encoding="utf-8") as handle:
-        body = handle.read()
-    assert "revoke_stale_message_grants" in body
+    await _as(session, a)
+    await contact_grants_service.request(
+        session, actor_id=a.id, target_id=b.id, kind=ContactGrantKind.message
+    )
+    await _as(session, b)
+    await contact_grants_service.accept(
+        session, actor_id=b.id, other_id=a.id, kind=ContactGrantKind.message
+    )
+    return guild, a, b
+
+
+async def _drain_sweeps() -> None:
+    """Wait for the after-commit sweeps this test set going."""
+    pending = list(contact_grants_service._inflight)
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def _grant_exists_fresh(a, b, kind) -> bool:
+    """Ask a connection of its own.
+
+    The sweep commits on a session of its own, so the answer is read on one too
+    rather than through the test session's identity map.
+    """
+    from app.db.session import AdminSessionLocal
+
+    low, high = canonical_pair(a.id, b.id)
+    async with AdminSessionLocal() as admin_session:
+        return (await admin_session.get(ContactGrant, (low, high, kind))) is not None
+
+
+async def test_the_sweep_waits_for_the_commit(session):
+    """The ordering the queue exists for.
+
+    A sweep that ran against the uncommitted delete would still see the
+    membership, find the pair allowed, and keep a channel whose only leg has
+    just gone — the failure this replaces a source-text check with.
+    """
+    guild, a, b = await _open_channel_between_co_members(session)
+
+    membership = await session.get(GuildMembership, (guild.id, b.id))
+    await session.delete(membership)
+    contact_grants_service.queue_stale_grant_sweep(session, b.id)
+
+    # Still there: the delete has not landed, so nothing has been re-tested.
+    assert await _grant_exists_fresh(a, b, ContactGrantKind.message)
+
+    await session.commit()
+    await _drain_sweeps()
+
+    assert not await _grant_exists_fresh(a, b, ContactGrantKind.message)
+
+
+async def test_a_rollback_discards_the_queue():
+    """A change that did not happen revokes nothing.
+
+    The hook, on its own: a rolled-back session leaves no sweep behind to run.
+    """
+
+    class _Session:
+        info: dict = {}
+
+    fake = _Session()
+    contact_grants_service.queue_stale_grant_sweep(fake, 7)
+    assert fake.info[contact_grants_service._PENDING_SWEEP_KEY] == {7}
+
+    contact_grants_service._discard_pending(fake)
+    assert contact_grants_service._PENDING_SWEEP_KEY not in fake.info

--- a/backend/app/services/platform/contact_grants_test.py
+++ b/backend/app/services/platform/contact_grants_test.py
@@ -1,0 +1,265 @@
+"""Connections, message requests, and what survives losing a leg of can_ask.
+
+The three worth keeping are the ones the design turns on: a connection is
+permission to ask rather than a channel; leaving a shared community revokes an
+open channel unless the pair connected first; and removing a connection re-tests
+the grant rather than deleting it, so two co-members keep talking.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.models.platform.contact_grant import (
+    ContactGrant,
+    ContactGrantKind,
+    ContactGrantState,
+    canonical_pair,
+)
+from app.models.platform.guild import GuildMembership
+from app.models.platform.user_dm_settings import DmPolicy
+from app.services.platform import contact_grants as contact_grants_service
+from app.testing import create_guild, create_guild_membership, create_user
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _policy(session, user, policy: DmPolicy) -> None:
+    await session.exec(
+        text(
+            "UPDATE public.user_dm_settings SET dm_policy = CAST(:p AS user_dm_policy) "
+            "WHERE user_id = :u"
+        ).bindparams(p=policy.value, u=user.id)
+    )
+    await session.flush()
+
+
+async def _as(session, user) -> None:
+    """Act as this account, the way a routed request does.
+
+    The entry points read the caller from ``app.current_user_id`` rather than
+    taking one, so a service test has to say who is asking.
+    """
+    await session.exec(
+        text("SELECT set_config('app.current_user_id', :v, true)").bindparams(
+            v=str(user.id)
+        )
+    )
+
+
+async def _grant(session, a, b, kind):
+    low, high = canonical_pair(a.id, b.id)
+    return await session.get(ContactGrant, (low, high, kind))
+
+
+async def _drop_membership(session, *, guild_id: int, user_id: int) -> None:
+    """Leave the community, and run the sweep the guild path runs.
+
+    The real ``remove_user_from_guild`` also tears down initiative membership
+    inside the guild schema, which wants a routed session; what is under test
+    here is the rule, so this drops the row and calls the same sweep.
+    ``test_the_guild_path_runs_the_sweep`` covers the wiring.
+    """
+    row = await session.get(GuildMembership, (guild_id, user_id))
+    if row is not None:
+        await session.delete(row)
+    # Committed before the sweep: it runs on its own session, so it must be
+    # looking at the state the change left behind.
+    await session.commit()
+    await contact_grants_service.revoke_stale_message_grants(session, user_id=user_id)
+
+
+async def _connect(session, a, b):
+    """Both halves of a real connection, through the service."""
+    await _as(session, a)
+    await contact_grants_service.request(
+        session, actor_id=a.id, target_id=b.id, kind=ContactGrantKind.connection
+    )
+    await _as(session, b)
+    return await contact_grants_service.accept(
+        session, actor_id=b.id, other_id=a.id, kind=ContactGrantKind.connection
+    )
+
+
+# ------------------------------------------------------- what a connection is ---
+
+
+async def test_a_connection_is_permission_to_ask_not_a_channel(session):
+    """The model, on its own: a connection row alone leaves the pair closed."""
+    a = await create_user(session)
+    b = await create_user(session)
+    await _policy(session, a, DmPolicy.private)
+    await _policy(session, b, DmPolicy.private)
+
+    low, high = canonical_pair(a.id, b.id)
+    session.add(
+        ContactGrant(
+            user_id_low=low,
+            user_id_high=high,
+            kind=ContactGrantKind.connection,
+            state=ContactGrantState.accepted,
+            requested_by=a.id,
+        )
+    )
+    await session.flush()
+
+    await _as(session, a)
+    assert await contact_grants_service._may_message(session, b.id)
+    assert await _grant(session, a, b, ContactGrantKind.message) is None
+
+
+async def test_accepting_a_connection_opens_the_channel(session):
+    """The flow: one act, one consent — the message grant is born accepted."""
+    a = await create_user(session)
+    b = await create_user(session)
+    await _policy(session, a, DmPolicy.private)
+    await _policy(session, b, DmPolicy.private)
+
+    await _connect(session, a, b)
+
+    message = await _grant(session, a, b, ContactGrantKind.message)
+    assert message is not None
+    assert message.state is ContactGrantState.accepted
+
+
+async def test_a_crossing_request_becomes_an_accept(session):
+    a = await create_user(session)
+    b = await create_user(session)
+
+    await _as(session, a)
+    await contact_grants_service.request(
+        session, actor_id=a.id, target_id=b.id, kind=ContactGrantKind.connection
+    )
+    await _as(session, b)
+    grant = await contact_grants_service.request(
+        session, actor_id=b.id, target_id=a.id, kind=ContactGrantKind.connection
+    )
+    assert grant.state is ContactGrantState.accepted
+
+
+async def test_an_unconfirmed_age_cannot_connect(session):
+    a = await create_user(session, age_confirmed_at=None)
+    b = await create_user(session)
+    await _as(session, a)
+    with pytest.raises(contact_grants_service.ContactGrantError):
+        await contact_grants_service.request(
+            session, actor_id=a.id, target_id=b.id, kind=ContactGrantKind.connection
+        )
+
+
+# ------------------------------------------------------------- losing a leg ---
+
+
+async def test_leaving_the_community_revokes_an_open_channel(session):
+    guild = await create_guild(session)
+    a = await create_user(session)
+    b = await create_user(session)
+    for user in (a, b):
+        await create_guild_membership(session, user=user, guild=guild)
+        await _policy(session, user, DmPolicy.community)
+    await session.commit()
+
+    await _as(session, a)
+    await contact_grants_service.request(
+        session, actor_id=a.id, target_id=b.id, kind=ContactGrantKind.message
+    )
+    await _as(session, b)
+    await contact_grants_service.accept(
+        session, actor_id=b.id, other_id=a.id, kind=ContactGrantKind.message
+    )
+    assert await _grant(session, a, b, ContactGrantKind.message) is not None
+
+    await _drop_membership(session, guild_id=guild.id, user_id=b.id)
+
+    assert await _grant(session, a, b, ContactGrantKind.message) is None
+
+
+async def test_a_connection_carries_the_channel_through_leaving(session):
+    guild = await create_guild(session)
+    a = await create_user(session)
+    b = await create_user(session)
+    for user in (a, b):
+        await create_guild_membership(session, user=user, guild=guild)
+        await _policy(session, user, DmPolicy.community)
+    await session.commit()
+
+    await _connect(session, a, b)
+    assert await _grant(session, a, b, ContactGrantKind.message) is not None
+
+    await _drop_membership(session, guild_id=guild.id, user_id=b.id)
+
+    assert await _grant(session, a, b, ContactGrantKind.message) is not None
+
+
+async def test_removing_a_connection_re_tests_rather_than_deletes(session):
+    """Same sweep, one test, two outcomes.
+
+    Co-members on ``community`` keep the channel: the community leg still holds
+    it up. A ``private`` pair lose it, because the connection was the only leg.
+    """
+    guild = await create_guild(session)
+    a = await create_user(session)
+    b = await create_user(session)
+    for user in (a, b):
+        await create_guild_membership(session, user=user, guild=guild)
+        await _policy(session, user, DmPolicy.community)
+    await session.commit()
+    await _connect(session, a, b)
+
+    await _as(session, a)
+    await contact_grants_service.remove(
+        session, actor_id=a.id, other_id=b.id, kind=ContactGrantKind.connection
+    )
+    assert await _grant(session, a, b, ContactGrantKind.message) is not None
+
+    c = await create_user(session)
+    d = await create_user(session)
+    await _policy(session, c, DmPolicy.private)
+    await _policy(session, d, DmPolicy.private)
+    await session.commit()
+    await _connect(session, c, d)
+
+    await _as(session, c)
+    await contact_grants_service.remove(
+        session, actor_id=c.id, other_id=d.id, kind=ContactGrantKind.connection
+    )
+    assert await _grant(session, c, d, ContactGrantKind.message) is None
+
+
+async def test_going_private_revokes_a_community_channel(session):
+    guild = await create_guild(session)
+    a = await create_user(session)
+    b = await create_user(session)
+    for user in (a, b):
+        await create_guild_membership(session, user=user, guild=guild)
+        await _policy(session, user, DmPolicy.community)
+    await session.commit()
+
+    await _as(session, a)
+    await contact_grants_service.request(
+        session, actor_id=a.id, target_id=b.id, kind=ContactGrantKind.message
+    )
+    await _as(session, b)
+    await contact_grants_service.accept(
+        session, actor_id=b.id, other_id=a.id, kind=ContactGrantKind.message
+    )
+
+    await _policy(session, a, DmPolicy.private)
+    await session.commit()
+    dropped = await contact_grants_service.revoke_stale_message_grants(
+        session, user_id=a.id
+    )
+
+    assert dropped == 1
+    assert await _grant(session, a, b, ContactGrantKind.message) is None
+
+
+async def test_the_guild_path_runs_the_sweep(session):
+    """Leaving a community is one of the five events that re-test a grant, and
+    the call sits with the membership delete rather than beside it."""
+    from app.services.platform import guilds as guilds_module
+
+    source = guilds_module.__file__
+    assert source is not None
+    with open(source, encoding="utf-8") as handle:
+        body = handle.read()
+    assert "revoke_stale_message_grants" in body

--- a/backend/app/services/platform/dm_settings.py
+++ b/backend/app/services/platform/dm_settings.py
@@ -209,17 +209,13 @@ async def update_settings(
         row.updated_at = datetime.now(timezone.utc)
         session.add(row)
 
-    await session.commit()
-
     if dm_policy is not None or communities:
         # A policy change or a switched-off community takes a leg of can_ask
         # away, so every open channel that rested on it is re-tested — the same
-        # sweep every other lost leg runs. After the commit, because the sweep
-        # commits its own deletes and should be acting on the new state.
+        # sweep every other lost leg runs, on the same after-commit queue.
         from app.services.platform import contact_grants as contact_grants_service
 
-        await contact_grants_service.revoke_stale_message_grants(
-            session, user_id=user.id
-        )
+        contact_grants_service.queue_stale_grant_sweep(session, user.id)
 
+    await session.commit()
     return await read_settings(session, user=user)

--- a/backend/app/services/platform/dm_settings.py
+++ b/backend/app/services/platform/dm_settings.py
@@ -210,4 +210,16 @@ async def update_settings(
         session.add(row)
 
     await session.commit()
+
+    if dm_policy is not None or communities:
+        # A policy change or a switched-off community takes a leg of can_ask
+        # away, so every open channel that rested on it is re-tested — the same
+        # sweep every other lost leg runs. After the commit, because the sweep
+        # commits its own deletes and should be acting on the new state.
+        from app.services.platform import contact_grants as contact_grants_service
+
+        await contact_grants_service.revoke_stale_message_grants(
+            session, user_id=user.id
+        )
+
     return await read_settings(session, user=user)

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -1482,14 +1482,11 @@ async def remove_user_from_guild(
         account_stream.queue_account_signal(session, user_id, "membership")
         billing_ping.notify_membership_changed(guild_id)
         # This community was a leg of can_ask for everyone they shared it with,
-        # so every open channel that rested on it is re-tested. One survives if
-        # the pair connected, which is what a connection is for. The sweep
-        # commits on its own, so a caller that rolls back after this leaves the
-        # channels closed rather than open — the safe direction, and a new
-        # request reopens one.
-        await contact_grants_service.revoke_stale_message_grants(
-            session, user_id=user_id
-        )
+        # so every open channel that rested on it is re-tested — one survives if
+        # the pair connected, which is what a connection is for. Queued rather
+        # than run here: the sweep reads the state this delete leaves behind,
+        # and this delete is not committed yet.
+        contact_grants_service.queue_stale_grant_sweep(session, user_id)
 
 
 async def adopt_guild_name_display(session: AsyncSession, *, guild_id: int) -> None:

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -30,6 +30,7 @@ from app.models.platform.user import User
 from app.services.platform import billing_ping
 
 from app.services.platform import account_stream
+from app.services.platform import contact_grants as contact_grants_service
 
 logger = logging.getLogger(__name__)
 
@@ -1480,6 +1481,15 @@ async def remove_user_from_guild(
         # change with where it belongs, and leaving is not always their doing.
         account_stream.queue_account_signal(session, user_id, "membership")
         billing_ping.notify_membership_changed(guild_id)
+        # This community was a leg of can_ask for everyone they shared it with,
+        # so every open channel that rested on it is re-tested. One survives if
+        # the pair connected, which is what a connection is for. The sweep
+        # commits on its own, so a caller that rolls back after this leaves the
+        # channels closed rather than open — the safe direction, and a new
+        # request reopens one.
+        await contact_grants_service.revoke_stale_message_grants(
+            session, user_id=user_id
+        )
 
 
 async def adopt_guild_name_display(session: AsyncSession, *, guild_id: int) -> None:

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -514,6 +514,5 @@
   "DM_NOT_A_MEMBER": "Du bist kein Mitglied dieser Community.",
   "CONTACT_GRANT_CANNOT_REACH": "Du kannst dieses Konto derzeit nicht erreichen.",
   "CONTACT_GRANT_NO_REQUEST": "Von diesem Konto liegt keine Anfrage vor.",
-  "CONTACT_GRANT_CANNOT_GRANT_SELF": "Du kannst dich nicht mit deinem eigenen Konto verbinden.",
-  "CONTACT_GRANT_HANDLE_NOT_FOUND": "Kein Konto passt zu diesem Handle."
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "Du kannst dich nicht mit deinem eigenen Konto verbinden."
 }

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -511,5 +511,9 @@
   "DM_USER_NOT_FOUND": "Dieses Konto ist nicht verfügbar.",
   "DM_AGE_CONFIRMATION_REQUIRED": "Bestätige dein Alter, bevor du änderst, wer dir schreiben darf.",
   "DM_CANNOT_IGNORE_SELF": "Du kannst dein eigenes Konto nicht ignorieren.",
-  "DM_NOT_A_MEMBER": "Du bist kein Mitglied dieser Community."
+  "DM_NOT_A_MEMBER": "Du bist kein Mitglied dieser Community.",
+  "CONTACT_GRANT_CANNOT_REACH": "Du kannst dieses Konto derzeit nicht erreichen.",
+  "CONTACT_GRANT_NO_REQUEST": "Von diesem Konto liegt keine Anfrage vor.",
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "Du kannst dich nicht mit deinem eigenen Konto verbinden.",
+  "CONTACT_GRANT_HANDLE_NOT_FOUND": "Kein Konto passt zu diesem Handle."
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -511,5 +511,9 @@
   "DM_USER_NOT_FOUND": "That account is not available.",
   "DM_AGE_CONFIRMATION_REQUIRED": "Confirm your age before changing who can message you.",
   "DM_CANNOT_IGNORE_SELF": "You cannot ignore your own account.",
-  "DM_NOT_A_MEMBER": "You are not a member of that community."
+  "DM_NOT_A_MEMBER": "You are not a member of that community.",
+  "CONTACT_GRANT_CANNOT_REACH": "You cannot reach that account right now.",
+  "CONTACT_GRANT_NO_REQUEST": "There is no request from that account to accept.",
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "You cannot connect with your own account.",
+  "CONTACT_GRANT_HANDLE_NOT_FOUND": "No account matches that handle."
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -514,6 +514,5 @@
   "DM_NOT_A_MEMBER": "You are not a member of that community.",
   "CONTACT_GRANT_CANNOT_REACH": "You cannot reach that account right now.",
   "CONTACT_GRANT_NO_REQUEST": "There is no request from that account to accept.",
-  "CONTACT_GRANT_CANNOT_GRANT_SELF": "You cannot connect with your own account.",
-  "CONTACT_GRANT_HANDLE_NOT_FOUND": "No account matches that handle."
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "You cannot connect with your own account."
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -511,5 +511,9 @@
   "DM_USER_NOT_FOUND": "Esa cuenta no está disponible.",
   "DM_AGE_CONFIRMATION_REQUIRED": "Confirma tu edad antes de cambiar quién puede enviarte mensajes.",
   "DM_CANNOT_IGNORE_SELF": "No puedes ignorar tu propia cuenta.",
-  "DM_NOT_A_MEMBER": "No eres miembro de esa comunidad."
+  "DM_NOT_A_MEMBER": "No eres miembro de esa comunidad.",
+  "CONTACT_GRANT_CANNOT_REACH": "No puedes contactar con esa cuenta ahora mismo.",
+  "CONTACT_GRANT_NO_REQUEST": "No hay ninguna solicitud de esa cuenta que aceptar.",
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "No puedes conectarte con tu propia cuenta.",
+  "CONTACT_GRANT_HANDLE_NOT_FOUND": "Ninguna cuenta coincide con ese identificador."
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -514,6 +514,5 @@
   "DM_NOT_A_MEMBER": "No eres miembro de esa comunidad.",
   "CONTACT_GRANT_CANNOT_REACH": "No puedes contactar con esa cuenta ahora mismo.",
   "CONTACT_GRANT_NO_REQUEST": "No hay ninguna solicitud de esa cuenta que aceptar.",
-  "CONTACT_GRANT_CANNOT_GRANT_SELF": "No puedes conectarte con tu propia cuenta.",
-  "CONTACT_GRANT_HANDLE_NOT_FOUND": "Ninguna cuenta coincide con ese identificador."
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "No puedes conectarte con tu propia cuenta."
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -511,5 +511,9 @@
   "DM_USER_NOT_FOUND": "Ce compte n'est pas disponible.",
   "DM_AGE_CONFIRMATION_REQUIRED": "Confirmez votre âge avant de modifier qui peut vous écrire.",
   "DM_CANNOT_IGNORE_SELF": "Vous ne pouvez pas ignorer votre propre compte.",
-  "DM_NOT_A_MEMBER": "Vous n'êtes pas membre de cette communauté."
+  "DM_NOT_A_MEMBER": "Vous n'êtes pas membre de cette communauté.",
+  "CONTACT_GRANT_CANNOT_REACH": "Vous ne pouvez pas joindre ce compte pour le moment.",
+  "CONTACT_GRANT_NO_REQUEST": "Aucune demande de ce compte à accepter.",
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "Vous ne pouvez pas vous connecter à votre propre compte.",
+  "CONTACT_GRANT_HANDLE_NOT_FOUND": "Aucun compte ne correspond à cet identifiant."
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -514,6 +514,5 @@
   "DM_NOT_A_MEMBER": "Vous n'êtes pas membre de cette communauté.",
   "CONTACT_GRANT_CANNOT_REACH": "Vous ne pouvez pas joindre ce compte pour le moment.",
   "CONTACT_GRANT_NO_REQUEST": "Aucune demande de ce compte à accepter.",
-  "CONTACT_GRANT_CANNOT_GRANT_SELF": "Vous ne pouvez pas vous connecter à votre propre compte.",
-  "CONTACT_GRANT_HANDLE_NOT_FOUND": "Aucun compte ne correspond à cet identifiant."
+  "CONTACT_GRANT_CANNOT_GRANT_SELF": "Vous ne pouvez pas vous connecter à votre propre compte."
 }

--- a/frontend/src/api/generated/direct-messages/direct-messages.ts
+++ b/frontend/src/api/generated/direct-messages/direct-messages.ts
@@ -21,12 +21,16 @@ import type {
 } from "@tanstack/react-query";
 
 import type {
+  ConnectionRequestCreate,
+  ContactGrantRead,
+  ContactGrantsResponse,
   DirectMessagePermissionRead,
   DirectMessageSettingsRead,
   DirectMessageSettingsUpdate,
   HTTPValidationError,
   IgnoredAccountsResponse,
   ListIgnoredAccountsApiV1MeIgnoredGetParams,
+  MessageRequestCreate,
 } from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
@@ -757,6 +761,827 @@ export const useStopIgnoringAccountApiV1MeIgnoredUserIdDelete = <
 > => {
   return useMutation(
     getStopIgnoringAccountApiV1MeIgnoredUserIdDeleteMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Accepted connections, plus what is pending in each direction.
+ * @summary List Connections
+ */
+export const listConnectionsApiV1MeConnectionsGet = (
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<ContactGrantsResponse>(
+    { url: `/api/v1/me/connections`, method: "GET", signal },
+    options
+  );
+};
+
+export const getListConnectionsApiV1MeConnectionsGetQueryKey = () => {
+  return [`/api/v1/me/connections`] as const;
+};
+
+export const getListConnectionsApiV1MeConnectionsGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getListConnectionsApiV1MeConnectionsGetQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>
+  > = ({ signal }) => listConnectionsApiV1MeConnectionsGet(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListConnectionsApiV1MeConnectionsGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>
+>;
+export type ListConnectionsApiV1MeConnectionsGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useListConnectionsApiV1MeConnectionsGet<
+  TData = Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListConnectionsApiV1MeConnectionsGet<
+  TData = Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListConnectionsApiV1MeConnectionsGet<
+  TData = Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List Connections
+ */
+
+export function useListConnectionsApiV1MeConnectionsGet<
+  TData = Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConnectionsApiV1MeConnectionsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getListConnectionsApiV1MeConnectionsGetQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * Ask an account to connect, by its exact handle.
+ *
+ * A handle rather than an id, whatever the target's policy: it is the one
+ * shape that works for an account on ``private``, which is never offered from
+ * a roster or a picker.
+ * @summary Request Connection
+ */
+export const requestConnectionApiV1MeConnectionsPost = (
+  connectionRequestCreate: BodyType<ConnectionRequestCreate>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<ContactGrantRead>(
+    {
+      url: `/api/v1/me/connections`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: connectionRequestCreate,
+      signal,
+    },
+    options
+  );
+};
+
+export const getRequestConnectionApiV1MeConnectionsPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof requestConnectionApiV1MeConnectionsPost>>,
+    TError,
+    { data: BodyType<ConnectionRequestCreate> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof requestConnectionApiV1MeConnectionsPost>>,
+  TError,
+  { data: BodyType<ConnectionRequestCreate> },
+  TContext
+> => {
+  const mutationKey = ["requestConnectionApiV1MeConnectionsPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof requestConnectionApiV1MeConnectionsPost>>,
+    { data: BodyType<ConnectionRequestCreate> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return requestConnectionApiV1MeConnectionsPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RequestConnectionApiV1MeConnectionsPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof requestConnectionApiV1MeConnectionsPost>>
+>;
+export type RequestConnectionApiV1MeConnectionsPostMutationBody = BodyType<ConnectionRequestCreate>;
+export type RequestConnectionApiV1MeConnectionsPostMutationError = ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Request Connection
+ */
+export const useRequestConnectionApiV1MeConnectionsPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof requestConnectionApiV1MeConnectionsPost>>,
+      TError,
+      { data: BodyType<ConnectionRequestCreate> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof requestConnectionApiV1MeConnectionsPost>>,
+  TError,
+  { data: BodyType<ConnectionRequestCreate> },
+  TContext
+> => {
+  return useMutation(
+    getRequestConnectionApiV1MeConnectionsPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Accept a connection, which also opens the pair's message channel.
+ * @summary Accept Connection
+ */
+export const acceptConnectionApiV1MeConnectionsUserIdAcceptPost = (
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<ContactGrantRead>(
+    { url: `/api/v1/me/connections/${userId}/accept`, method: "POST", signal },
+    options
+  );
+};
+
+export const getAcceptConnectionApiV1MeConnectionsUserIdAcceptPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof acceptConnectionApiV1MeConnectionsUserIdAcceptPost>>,
+    TError,
+    { userId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof acceptConnectionApiV1MeConnectionsUserIdAcceptPost>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  const mutationKey = ["acceptConnectionApiV1MeConnectionsUserIdAcceptPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof acceptConnectionApiV1MeConnectionsUserIdAcceptPost>>,
+    { userId: number }
+  > = (props) => {
+    const { userId } = props ?? {};
+
+    return acceptConnectionApiV1MeConnectionsUserIdAcceptPost(userId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type AcceptConnectionApiV1MeConnectionsUserIdAcceptPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof acceptConnectionApiV1MeConnectionsUserIdAcceptPost>>
+>;
+
+export type AcceptConnectionApiV1MeConnectionsUserIdAcceptPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Accept Connection
+ */
+export const useAcceptConnectionApiV1MeConnectionsUserIdAcceptPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof acceptConnectionApiV1MeConnectionsUserIdAcceptPost>>,
+      TError,
+      { userId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof acceptConnectionApiV1MeConnectionsUserIdAcceptPost>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  return useMutation(
+    getAcceptConnectionApiV1MeConnectionsUserIdAcceptPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Decline, cancel or disconnect — one verb.
+ *
+ * The pair's message grant is re-tested rather than dropped: two co-members
+ * who un-connect can still ask each other, so they keep talking.
+ * @summary Remove Connection
+ */
+export const removeConnectionApiV1MeConnectionsUserIdDelete = (
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<void>(
+    { url: `/api/v1/me/connections/${userId}`, method: "DELETE", signal },
+    options
+  );
+};
+
+export const getRemoveConnectionApiV1MeConnectionsUserIdDeleteMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof removeConnectionApiV1MeConnectionsUserIdDelete>>,
+    TError,
+    { userId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof removeConnectionApiV1MeConnectionsUserIdDelete>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  const mutationKey = ["removeConnectionApiV1MeConnectionsUserIdDelete"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof removeConnectionApiV1MeConnectionsUserIdDelete>>,
+    { userId: number }
+  > = (props) => {
+    const { userId } = props ?? {};
+
+    return removeConnectionApiV1MeConnectionsUserIdDelete(userId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RemoveConnectionApiV1MeConnectionsUserIdDeleteMutationResult = NonNullable<
+  Awaited<ReturnType<typeof removeConnectionApiV1MeConnectionsUserIdDelete>>
+>;
+
+export type RemoveConnectionApiV1MeConnectionsUserIdDeleteMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Remove Connection
+ */
+export const useRemoveConnectionApiV1MeConnectionsUserIdDelete = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof removeConnectionApiV1MeConnectionsUserIdDelete>>,
+      TError,
+      { userId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof removeConnectionApiV1MeConnectionsUserIdDelete>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  return useMutation(
+    getRemoveConnectionApiV1MeConnectionsUserIdDeleteMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Open channels, plus what is pending in each direction.
+ * @summary List Message Requests
+ */
+export const listMessageRequestsApiV1MeMessageRequestsGet = (
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<ContactGrantsResponse>(
+    { url: `/api/v1/me/message-requests`, method: "GET", signal },
+    options
+  );
+};
+
+export const getListMessageRequestsApiV1MeMessageRequestsGetQueryKey = () => {
+  return [`/api/v1/me/message-requests`] as const;
+};
+
+export const getListMessageRequestsApiV1MeMessageRequestsGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getListMessageRequestsApiV1MeMessageRequestsGetQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>
+  > = ({ signal }) => listMessageRequestsApiV1MeMessageRequestsGet(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListMessageRequestsApiV1MeMessageRequestsGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>
+>;
+export type ListMessageRequestsApiV1MeMessageRequestsGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useListMessageRequestsApiV1MeMessageRequestsGet<
+  TData = Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListMessageRequestsApiV1MeMessageRequestsGet<
+  TData = Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListMessageRequestsApiV1MeMessageRequestsGet<
+  TData = Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List Message Requests
+ */
+
+export function useListMessageRequestsApiV1MeMessageRequestsGet<
+  TData = Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listMessageRequestsApiV1MeMessageRequestsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getListMessageRequestsApiV1MeMessageRequestsGetQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * Ask permission to message an account.
+ *
+ * Comes back already accepted when the pair is connected: a connection has
+ * answered this question, and asking twice is a consent step with no decision
+ * in it.
+ * @summary Request Message
+ */
+export const requestMessageApiV1MeMessageRequestsPost = (
+  messageRequestCreate: BodyType<MessageRequestCreate>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<ContactGrantRead>(
+    {
+      url: `/api/v1/me/message-requests`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: messageRequestCreate,
+      signal,
+    },
+    options
+  );
+};
+
+export const getRequestMessageApiV1MeMessageRequestsPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof requestMessageApiV1MeMessageRequestsPost>>,
+    TError,
+    { data: BodyType<MessageRequestCreate> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof requestMessageApiV1MeMessageRequestsPost>>,
+  TError,
+  { data: BodyType<MessageRequestCreate> },
+  TContext
+> => {
+  const mutationKey = ["requestMessageApiV1MeMessageRequestsPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof requestMessageApiV1MeMessageRequestsPost>>,
+    { data: BodyType<MessageRequestCreate> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return requestMessageApiV1MeMessageRequestsPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RequestMessageApiV1MeMessageRequestsPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof requestMessageApiV1MeMessageRequestsPost>>
+>;
+export type RequestMessageApiV1MeMessageRequestsPostMutationBody = BodyType<MessageRequestCreate>;
+export type RequestMessageApiV1MeMessageRequestsPostMutationError = ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Request Message
+ */
+export const useRequestMessageApiV1MeMessageRequestsPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof requestMessageApiV1MeMessageRequestsPost>>,
+      TError,
+      { data: BodyType<MessageRequestCreate> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof requestMessageApiV1MeMessageRequestsPost>>,
+  TError,
+  { data: BodyType<MessageRequestCreate> },
+  TContext
+> => {
+  return useMutation(
+    getRequestMessageApiV1MeMessageRequestsPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * @summary Accept Message Request
+ */
+export const acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost = (
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<ContactGrantRead>(
+    { url: `/api/v1/me/message-requests/${userId}/accept`, method: "POST", signal },
+    options
+  );
+};
+
+export const getAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost>>,
+    TError,
+    { userId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  const mutationKey = ["acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost>>,
+    { userId: number }
+  > = (props) => {
+    const { userId } = props ?? {};
+
+    return acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost(userId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type AcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost>>
+>;
+
+export type AcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Accept Message Request
+ */
+export const useAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost>>,
+      TError,
+      { userId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof acceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  return useMutation(
+    getAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Decline, cancel or close a channel.
+ * @summary Remove Message Request
+ */
+export const removeMessageRequestApiV1MeMessageRequestsUserIdDelete = (
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<void>(
+    { url: `/api/v1/me/message-requests/${userId}`, method: "DELETE", signal },
+    options
+  );
+};
+
+export const getRemoveMessageRequestApiV1MeMessageRequestsUserIdDeleteMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof removeMessageRequestApiV1MeMessageRequestsUserIdDelete>>,
+    TError,
+    { userId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof removeMessageRequestApiV1MeMessageRequestsUserIdDelete>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  const mutationKey = ["removeMessageRequestApiV1MeMessageRequestsUserIdDelete"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof removeMessageRequestApiV1MeMessageRequestsUserIdDelete>>,
+    { userId: number }
+  > = (props) => {
+    const { userId } = props ?? {};
+
+    return removeMessageRequestApiV1MeMessageRequestsUserIdDelete(userId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RemoveMessageRequestApiV1MeMessageRequestsUserIdDeleteMutationResult = NonNullable<
+  Awaited<ReturnType<typeof removeMessageRequestApiV1MeMessageRequestsUserIdDelete>>
+>;
+
+export type RemoveMessageRequestApiV1MeMessageRequestsUserIdDeleteMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Remove Message Request
+ */
+export const useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof removeMessageRequestApiV1MeMessageRequestsUserIdDelete>>,
+      TError,
+      { userId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof removeMessageRequestApiV1MeMessageRequestsUserIdDelete>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  return useMutation(
+    getRemoveMessageRequestApiV1MeMessageRequestsUserIdDeleteMutationOptions(options),
     queryClient
   );
 };

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1848,6 +1848,38 @@ export interface CommunitySettingsUpdate {
 }
 
 /**
+ * A connection is addressed by handle, never by id.
+ *
+ * One shape whatever the target's policy, and the shape the app-wide people
+ * search will use: an account on ``private`` is reached by somebody typing
+ * its handle rather than by being offered from a list.
+ */
+export interface ConnectionRequestCreate {
+  username: string;
+  discriminator: number;
+}
+
+/**
+ * One connection or message request, from the reader's side of it.
+ */
+export interface ContactGrantRead {
+  user_id: number;
+  username: string;
+  discriminator: number;
+  avatar_url: string | null;
+  state: string;
+  outgoing: boolean;
+  created_at: string;
+  responded_at: string | null;
+}
+
+export interface ContactGrantsResponse {
+  accepted: ContactGrantRead[];
+  incoming: ContactGrantRead[];
+  outgoing: ContactGrantRead[];
+}
+
+/**
  * One person, on one row of the page.
  *
  * Inherits ``UserSummary``'s guild-name visibility: ``full_name`` survives
@@ -3754,6 +3786,14 @@ export interface MemberAIView {
 }
 
 /**
+ * A message request is addressed by id: everyone you may ask is somebody
+ * you can already see.
+ */
+export interface MessageRequestCreate {
+  user_id: number;
+}
+
+/**
  * One connection available to the member in one guild — a flat row for the
  * cross-guild personal "My AI" view (``GET /me/ai``). Every connection the
  * member can use is listed, including shared-key ones they can't attach to
@@ -3824,6 +3864,10 @@ export const NotificationType = {
   username_changed: "username_changed",
   account_suspended: "account_suspended",
   account_unsuspended: "account_unsuspended",
+  connection_requested: "connection_requested",
+  connection_accepted: "connection_accepted",
+  message_request_received: "message_request_received",
+  message_request_accepted: "message_request_accepted",
 } as const;
 
 export type NotificationReadData = { [key: string]: unknown };


### PR DESCRIPTION
## Problem

#1372 landed the tables and the rule; #1373 landed the policy and the ignore
list. This is the third of five: connections and message requests — the two
things a pair actually agrees between them — and the sweep that re-tests a
channel when the reason for it goes away.

Design doc: `history/dm-connections-blocks-design.md` (local, gitignored).

## The model

A **connection** satisfies every policy and opens nothing on its own. An
accepted **message** grant is what opens the channel. So a pair on `private`
needs both — which is why accepting a connection also opens the pair's message
grant: asking somebody to connect and then asking again for permission to say
hello is a consent step with no decision in it.

That coupling is deliberately one function, `initial_message_state`, and
deleting it is what undoes it when a connection carries anything besides
messaging. `dm_apparent_permission` knows nothing about it — the grant is
simply already accepted.

## Endpoints

| Method | Path | |
|---|---|---|
| `GET` | `/me/connections` | accepted, plus pending in each direction |
| `POST` | `/me/connections` | `{username, discriminator}` — a handle, never an id |
| `POST` | `/me/connections/{user_id}/accept` | also opens the channel |
| `DELETE` | `/me/connections/{user_id}` | decline, cancel or disconnect |
| `GET` `POST` | `/me/message-requests` | |
| `POST` | `/me/message-requests/{user_id}/accept` | |
| `DELETE` | `/me/message-requests/{user_id}` | |

## Notes for review

**Removing a connection re-tests, it does not delete.** A connection is a leg
of `can_ask` beside `public` and shared-community, not a rank above them, so
two co-members who un-connect keep talking and a `private` pair do not. One
sweep, one test, two outcomes — asserted both ways.

**The sweep runs on the system engine.** It works on pairs that need not
involve whoever is asking (removing somebody from a community re-tests *their*
grants), and neither the pairwise test nor those rows belong to the request
path. It commits on its own, so callers run it *after* the change that prompted
it; `update_settings` was reordered for that, and where the ordering cannot
hold (`remove_user_from_guild`) a rollback leaves channels closed rather than
open — the safe direction, and a new request reopens one.

**Migration `0224` adds one entry point, `dm_may_connect`.** The services first
called the internal pairwise functions directly and got
`permission denied for function dm_reachable` — which is `0223` working as
intended. The fix is a caller-pinned entry point in the same shape as the
others (caller from the request context, not an argument), not a wider grant:
handing the request path a function taking two arbitrary account ids is the
oracle #1372 removed the caller parameter to prevent. `dm_mutual_ask` gets
EXECUTE for `app_admin` alone, for the sweep.

**A handle, not an id, for connections** — the only shape that reaches an
account on `private`, which is never offered from a roster. An unknown handle
and an unreachable one answer identically.

## Testing

```
pytest -n 0 app/services/platform/contact_grants_test.py    9 passed
pytest -n 0 app/api/v1/platform_endpoints/dm_test.py       16 passed
ruff check app && ruff format app                          clean
ty check app                                               clean
```

The three the design turns on:

- `test_a_connection_is_permission_to_ask_not_a_channel` and
  `test_accepting_a_connection_opens_the_channel` — the model and the flow,
  asserted apart.
- `test_a_connection_carries_the_channel_through_leaving` — leaving a shared
  community revokes a channel, and does not when the pair connected first.
- `test_removing_a_connection_re_tests_rather_than_deletes` — kept for
  co-members, dropped for a `private` pair.

Plus, end to end: `test_a_request_from_an_ignored_account_is_never_surfaced` —
stored, invisible to the recipient, and entirely ordinary-looking to the sender.

**The full backend run is still going as I open this** — opening early so review
can start. I will post the result as a comment either way.

## What is not here

No changelog entry: nothing is reachable without the UI. Next: notification
suppression at the recipient seam, then the realtime channel, then the frontend.
