### PR TITLE
Stop the age screen looping on account reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The age question no longer hammers the server.** Answering how old you are re-reads your account, and re-reading it rebuilt the connection that had just asked for the re-read — a loop that ran until the API started refusing requests. The connection now belongs to the person rather than to a particular reading of them, and a re-read that says nothing new changes nothing.
+
+- **The date of birth is picked with the app's own date picker**, so a birthday is a year off a dropdown rather than forty years of paging back through the browser's calendar.
+
 - **The community calendar shows its calendars** and offers to add one, instead of opening straight onto a grid of events.
 
 - **A task description with a code block no longer stretches its board card** out of the column — code fences, tables, images and long strings stay inside it.

--- a/frontend/public/locales/de/auth.json
+++ b/frontend/public/locales/de/auth.json
@@ -145,6 +145,7 @@
     "title": "Wie alt bist du?",
     "subtitle": "Du gehörst zu einer Community, die jede angemeldete Person finden kann. Solche Communitys stehen auch Menschen offen, die du nicht kennst – deshalb fragen wir einmal nach deinem Alter.",
     "birthdateLabel": "Geburtsdatum",
+    "birthdatePlaceholder": "Wähle dein Geburtsdatum",
     "privacyNote": "Wir prüfen damit nur, ob du alt genug bist, und verwerfen es danach. Dein Konto hält fest, dass du geantwortet hast – nie das Datum. Es wird nicht verkauft, weitergegeben oder gespeichert.",
     "scopeNote": "Danach fragen nur die Bereiche von Initiative, die Menschen außerhalb deiner eigenen Communitys offenstehen. Private Communitys fragen nie.",
     "required": "Gib zum Fortfahren dein Geburtsdatum ein.",

--- a/frontend/public/locales/en/auth.json
+++ b/frontend/public/locales/en/auth.json
@@ -145,6 +145,7 @@
     "title": "How old are you?",
     "subtitle": "You belong to a community anyone signed in can find. Communities like that are open to people you have not met, so we ask your age once before you carry on.",
     "birthdateLabel": "Date of birth",
+    "birthdatePlaceholder": "Pick your date of birth",
     "privacyNote": "We use this to work out whether you are old enough, and then discard it. Your account records that you answered, never the date. It is not sold, shared, or kept.",
     "scopeNote": "Only the parts of Initiative that are open to people outside your own communities ask for this. Private communities never do.",
     "required": "Enter your date of birth to continue.",

--- a/frontend/public/locales/es/auth.json
+++ b/frontend/public/locales/es/auth.json
@@ -145,6 +145,7 @@
     "title": "¿Qué edad tienes?",
     "subtitle": "Perteneces a una comunidad que puede encontrar cualquier persona con sesión iniciada. Esas comunidades están abiertas a gente que no conoces, así que te preguntamos la edad una vez antes de continuar.",
     "birthdateLabel": "Fecha de nacimiento",
+    "birthdatePlaceholder": "Elige tu fecha de nacimiento",
     "privacyNote": "La usamos para comprobar si tienes edad suficiente y después la descartamos. Tu cuenta guarda que respondiste, nunca la fecha. No se vende, no se comparte y no se conserva.",
     "scopeNote": "Solo lo piden las partes de Initiative abiertas a personas ajenas a tus propias comunidades. Las comunidades privadas nunca lo piden.",
     "required": "Introduce tu fecha de nacimiento para continuar.",

--- a/frontend/public/locales/fr/auth.json
+++ b/frontend/public/locales/fr/auth.json
@@ -145,6 +145,7 @@
     "title": "Quel âge avez-vous ?",
     "subtitle": "Vous appartenez à une communauté que toute personne connectée peut trouver. Ces communautés sont ouvertes à des gens que vous ne connaissez pas : nous demandons donc votre âge une fois avant de continuer.",
     "birthdateLabel": "Date de naissance",
+    "birthdatePlaceholder": "Choisissez votre date de naissance",
     "privacyNote": "Nous l'utilisons pour vérifier que vous avez l'âge requis, puis nous l'effaçons. Votre compte retient que vous avez répondu, jamais la date. Elle n'est ni vendue, ni partagée, ni conservée.",
     "scopeNote": "Seules les parties d'Initiative ouvertes à des personnes extérieures à vos propres communautés le demandent. Les communautés privées ne le demandent jamais.",
     "required": "Saisissez votre date de naissance pour continuer.",

--- a/frontend/src/components/auth/AgeConfirmation.test.tsx
+++ b/frontend/src/components/auth/AgeConfirmation.test.tsx
@@ -55,7 +55,8 @@ describe("ConfirmAge", () => {
       .getAllByRole("option")
       .map((option) => option.textContent);
 
-    const thisYear = new Date().getFullYear();
+    // The server compares against the UTC date, so the window is that one.
+    const thisYear = new Date().getUTCFullYear();
     expect(offered.at(-1)).toBe(String(thisYear));
     expect(offered[0]).toBe(String(thisYear - 120));
   });

--- a/frontend/src/components/auth/AgeConfirmation.test.tsx
+++ b/frontend/src/components/auth/AgeConfirmation.test.tsx
@@ -25,11 +25,22 @@ describe("ConfirmAge", () => {
     post.mockReset().mockResolvedValue({ data: {} });
   });
 
+  /** Reach the date through the app's picker: open it, type the date, commit. */
+  const enterBirthdate = async (date: string) => {
+    await userEvent.click(await screen.findByLabelText("Date of birth"));
+    const entry = await screen.findByLabelText("Type or pick a date");
+    await userEvent.type(entry, `${date}{Enter}`);
+    await userEvent.keyboard("{Escape}");
+  };
+
   it("asks for a date of birth rather than offering a box to tick", async () => {
     renderWithProviders(<ConfirmAge />);
 
-    const field = await screen.findByLabelText("Date of birth");
-    expect(field).toHaveAttribute("type", "date");
+    await userEvent.click(await screen.findByLabelText("Date of birth"));
+
+    // The app's own picker, not the browser's: a birthday is decades back, and
+    // the year dropdown is how you get there.
+    expect(await screen.findByLabelText("Type or pick a date")).toBeInTheDocument();
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
 
@@ -51,7 +62,7 @@ describe("ConfirmAge", () => {
   it("sends the date and nothing else", async () => {
     renderWithProviders(<ConfirmAge />);
 
-    await userEvent.type(await screen.findByLabelText("Date of birth"), "1990-05-04");
+    await enterBirthdate("1990-05-04");
     await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
@@ -95,7 +106,7 @@ describe("ConfirmAge", () => {
     });
     renderWithProviders(<ConfirmAge />);
 
-    await userEvent.type(await screen.findByLabelText("Date of birth"), "2020-01-01");
+    await enterBirthdate("2020-01-01");
     await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(

--- a/frontend/src/components/auth/AgeConfirmation.test.tsx
+++ b/frontend/src/components/auth/AgeConfirmation.test.tsx
@@ -5,7 +5,7 @@
  * compared and is not kept — so the screen has to say so, and must not hold on
  * to it either.
  */
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -42,6 +42,22 @@ describe("ConfirmAge", () => {
     // the year dropdown is how you get there.
     expect(await screen.findByLabelText("Type or pick a date")).toBeInTheDocument();
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("offers a lifetime of years to reach, and none the server would refuse", async () => {
+    // Everything the calendar offers has to be a date the server accepts: born
+    // by today, and no longer ago than the oldest person alive.
+    renderWithProviders(<ConfirmAge />);
+
+    await userEvent.click(await screen.findByLabelText("Date of birth"));
+    const years = await screen.findByRole("combobox", { name: /year/i });
+    const offered = within(years)
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+
+    const thisYear = new Date().getFullYear();
+    expect(offered.at(-1)).toBe(String(thisYear));
+    expect(offered[0]).toBe(String(thisYear - 120));
   });
 
   it("says what happens to the date, beside the field asking for it", async () => {

--- a/frontend/src/components/auth/BirthdateField.tsx
+++ b/frontend/src/components/auth/BirthdateField.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 
-import { Input } from "@/components/ui/input";
+import { DateTimePicker } from "@/components/ui/date-time-picker";
 import { Label } from "@/components/ui/label";
 
 /**
@@ -10,6 +10,11 @@ import { Label } from "@/components/ui/label";
  * birthday deserves to be told, in the same breath, that it is being used to
  * work out one thing and then dropped. It sits with the field rather than in
  * each caller so no surface can ask without saying so.
+ *
+ * The date is picked with the same control as every other date in the app —
+ * type it or reach it through the year dropdown — rather than the browser's
+ * own, which differs on every platform and, on a birthday, means paging back
+ * decades a month at a time.
  */
 export const BirthdateField = ({
   id,
@@ -23,20 +28,24 @@ export const BirthdateField = ({
   disabled?: boolean;
 }) => {
   const { t } = useTranslation(["auth"]);
+  const today = new Date();
   return (
     <div className="space-y-2">
       <Label htmlFor={id}>{t("auth:confirmAge.birthdateLabel")}</Label>
-      <Input
+      <DateTimePicker
         id={id}
-        type="date"
         value={value}
-        onChange={(event) => onChange(event.target.value)}
+        onChange={onChange}
         disabled={disabled}
-        required
-        // A birthday is nobody's business to complete for them, and the field
-        // is asked once.
-        autoComplete="off"
-        max={new Date().toISOString().slice(0, 10)}
+        includeTime={false}
+        placeholder={t("auth:confirmAge.birthdatePlaceholder")}
+        calendarProps={{
+          // A lifetime of years to choose from, and nothing ahead of today:
+          // nobody was born tomorrow.
+          startMonth: new Date(today.getFullYear() - 120, 0),
+          endMonth: new Date(today.getFullYear(), today.getMonth()),
+          hidden: { after: today },
+        }}
       />
       <p className="text-muted-foreground text-xs">{t("auth:confirmAge.privacyNote")}</p>
     </div>

--- a/frontend/src/components/auth/BirthdateField.tsx
+++ b/frontend/src/components/auth/BirthdateField.tsx
@@ -28,7 +28,11 @@ export const BirthdateField = ({
   disabled?: boolean;
 }) => {
   const { t } = useTranslation(["auth"]);
+  // The window the server will accept: born by today, and no more than a
+  // lifetime ago. Matched here so nothing the calendar offers is a date the
+  // server then refuses.
   const today = new Date();
+  const earliest = new Date(today.getFullYear() - 120, today.getMonth(), today.getDate());
   return (
     <div className="space-y-2">
       <Label htmlFor={id}>{t("auth:confirmAge.birthdateLabel")}</Label>
@@ -40,11 +44,11 @@ export const BirthdateField = ({
         includeTime={false}
         placeholder={t("auth:confirmAge.birthdatePlaceholder")}
         calendarProps={{
-          // A lifetime of years to choose from, and nothing ahead of today:
-          // nobody was born tomorrow.
-          startMonth: new Date(today.getFullYear() - 120, 0),
-          endMonth: new Date(today.getFullYear(), today.getMonth()),
-          hidden: { after: today },
+          // A lifetime of years to choose from, and nothing outside the window:
+          // nobody was born tomorrow, or before the oldest person alive.
+          startMonth: earliest,
+          endMonth: today,
+          hidden: { before: earliest, after: today },
         }}
       />
       <p className="text-muted-foreground text-xs">{t("auth:confirmAge.privacyNote")}</p>

--- a/frontend/src/components/auth/BirthdateField.tsx
+++ b/frontend/src/components/auth/BirthdateField.tsx
@@ -30,9 +30,13 @@ export const BirthdateField = ({
   const { t } = useTranslation(["auth"]);
   // The window the server will accept: born by today, and no more than a
   // lifetime ago. Matched here so nothing the calendar offers is a date the
-  // server then refuses.
-  const today = new Date();
-  const earliest = new Date(today.getFullYear() - 120, today.getMonth(), today.getDate());
+  // server then refuses — including the day at each edge, which is why the
+  // bounds are built from today's *UTC* date, the one the server compares
+  // against. A reader far enough east or west has a different local date, and
+  // taking theirs would offer an edge day the server does not accept.
+  const now = new Date();
+  const today = new Date(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const earliest = new Date(now.getUTCFullYear() - 120, now.getUTCMonth(), now.getUTCDate());
   return (
     <div className="space-y-2">
       <Label htmlFor={id}>{t("auth:confirmAge.birthdateLabel")}</Label>

--- a/frontend/src/hooks/useAuth.test.tsx
+++ b/frontend/src/hooks/useAuth.test.tsx
@@ -123,6 +123,39 @@ describe("useAuth identity ordering", () => {
     expect(auth.user?.full_name).toBe("Newer");
   });
 
+  it("hands back the same account object when the re-read says nothing new", async () => {
+    // The account is re-read whenever the server says it might have moved, and
+    // most of those answers are identical. A fresh object for one of them
+    // re-runs every effect keyed on the user — including the socket that asked
+    // for the read, which would then ask again, forever.
+    const account = buildUser({ full_name: "Unchanged" });
+    get.mockResolvedValue({ data: account });
+    renderAuth();
+    await waitFor(() => expect(auth.user?.full_name).toBe("Unchanged"));
+    const before = auth.user;
+
+    await act(async () => {
+      await auth.refreshUser();
+    });
+
+    expect(auth.user).toBe(before);
+  });
+
+  it("still swaps the object when the account actually moved", async () => {
+    get.mockResolvedValueOnce({ data: buildUser({ full_name: "Before" }) });
+    renderAuth();
+    await waitFor(() => expect(auth.user?.full_name).toBe("Before"));
+    const before = auth.user;
+
+    get.mockResolvedValueOnce({ data: buildUser({ full_name: "After" }) });
+    await act(async () => {
+      await auth.refreshUser();
+    });
+
+    expect(auth.user).not.toBe(before);
+    expect(auth.user?.full_name).toBe("After");
+  });
+
   it("does not let a read in flight undo a sign-out", async () => {
     get.mockResolvedValueOnce({ data: buildUser({ full_name: "Signed in" }) });
     renderAuth();

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -104,6 +104,20 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setHasActiveSession(nextUser !== null);
   }, []);
 
+  /** Apply a re-read of the same person, keeping the object when nothing moved.
+   *
+   *  The account is re-read whenever the server says it might have changed, and
+   *  most of those answers are identical to what is already held. Handing back a
+   *  fresh object for one of those re-runs every effect keyed on the user —
+   *  including the socket that asked for the re-read — so an answer that says
+   *  nothing new has to be indistinguishable from no answer at all. */
+  const applyRead = useCallback((nextUser: UserRead) => {
+    setUserState((current) =>
+      current && JSON.stringify(current) === JSON.stringify(nextUser) ? current : nextUser
+    );
+    setHasActiveSession(true);
+  }, []);
+
   /** Sign-in / sign-out: a new person, so every read in flight is stale. */
   const replaceIdentity = useCallback(
     (nextUser: UserRead | null) => {
@@ -145,8 +159,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
     appliedReadRef.current = readId;
-    setUser(response.data);
-  }, [setUser, replaceIdentity]);
+    applyRead(response.data);
+  }, [applyRead]);
 
   // Bootstrap user on mount — always attempt /users/me.
   // Web: cookie is sent automatically (withCredentials). Native: token was loaded by the effect above.

--- a/frontend/src/hooks/useNotificationStream.test.tsx
+++ b/frontend/src/hooks/useNotificationStream.test.tsx
@@ -1,7 +1,10 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { buildUser } from "@/__tests__/factories";
 import { renderWithProviders } from "@/__tests__/helpers/render";
+import type { UserRead } from "@/api/generated/initiativeAPI.schemas";
+import { AuthContext } from "@/hooks/useAuth";
 
 import { useNotificationStream, useNotificationStreamConnected } from "./useNotificationStream";
 
@@ -229,6 +232,35 @@ describe("useNotificationStream", () => {
     socket.onmessage?.({ data: "not json" });
 
     expect(invalidateNotifications).not.toHaveBeenCalled();
+  });
+
+  it("stays up across an account re-read rather than rebuilding for it", () => {
+    // Connecting asks for a re-read, and a re-read that replaced the socket
+    // would connect again — a loop that hammers the API until it rate-limits.
+    // The socket belongs to a person, not to a particular reading of them.
+    const account = buildUser();
+    const authValue = (user: UserRead) =>
+      ({
+        user,
+        token: "test-token",
+        loading: false,
+        refreshUser: vi.fn(),
+      }) as unknown as React.ComponentProps<typeof AuthContext.Provider>["value"];
+    const tree = (user: UserRead) => (
+      <AuthContext.Provider value={authValue(user)}>
+        <Probe />
+      </AuthContext.Provider>
+    );
+
+    const { rerender } = render(tree(account));
+    latest().open();
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    // A fresh object for the same person, which is what every re-read returns.
+    rerender(tree({ ...account }));
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(latest().closed).toBe(false);
   });
 
   it("closes the socket when the hook unmounts", () => {

--- a/frontend/src/hooks/useNotificationStream.ts
+++ b/frontend/src/hooks/useNotificationStream.ts
@@ -111,6 +111,12 @@ const sendAuthMessage = (websocket: WebSocket, token: string | null) => {
  */
 export const useNotificationStream = () => {
   const { token, user, refreshUser } = useAuth();
+  // The socket belongs to a person, not to a particular reading of them. Every
+  // account re-read hands back a fresh object, and this socket asks for one on
+  // every connect — so keying the connection on the object would have it tear
+  // itself down and rebuild in a loop, each rebuild asking for the re-read that
+  // ends it. Who they are is the id.
+  const userId = user?.id ?? null;
   const websocketRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<number | null>(null);
   const authFailureCountRef = useRef(0);
@@ -154,7 +160,7 @@ export const useNotificationStream = () => {
   );
 
   useEffect(() => {
-    if (!user) {
+    if (userId === null) {
       return;
     }
 
@@ -282,5 +288,5 @@ export const useNotificationStream = () => {
         websocketRef.current = null;
       }
     };
-  }, [token, user, refreshAccount]);
+  }, [token, userId, refreshAccount]);
 };

--- a/frontend/src/hooks/useRealtimeUpdates.tsx
+++ b/frontend/src/hooks/useRealtimeUpdates.tsx
@@ -80,6 +80,10 @@ const handleCommentEvent = (data?: Record<string, unknown>) => {
 
 export const useRealtimeUpdates = () => {
   const { token, user, logout } = useAuth();
+  // Keyed on the id, not the object: an account re-read replaces the object
+  // without changing who is signed in, and rebuilding the socket for that would
+  // drop every subscription over a no-op.
+  const userId = user?.id ?? null;
   // Key the socket off THIS tab's URL guild (the /c/{guildId} route param), so
   // each tab streams its own guild. On personal routes (/, /me/*) there's no
   // param → null → no socket. The backend authorizes the socket from the same
@@ -93,7 +97,7 @@ export const useRealtimeUpdates = () => {
   useEffect(() => {
     // The socket is scoped to a single guild — in personal mode there's
     // nothing to subscribe to, and the backend would reject the auth payload.
-    if (!user || routeGuildId === null) {
+    if (userId === null || routeGuildId === null) {
       if (websocketRef.current) {
         websocketRef.current.close();
         websocketRef.current = null;
@@ -236,5 +240,5 @@ export const useRealtimeUpdates = () => {
         websocketRef.current = null;
       }
     };
-  }, [token, user, routeGuildId, logout]);
+  }, [token, userId, routeGuildId, logout]);
 };

--- a/frontend/src/pages/communities/CommunitiesPage.test.tsx
+++ b/frontend/src/pages/communities/CommunitiesPage.test.tsx
@@ -285,14 +285,17 @@ describe("CommunitiesPage", () => {
     await screen.findByText("Riverside Players");
 
     await userEvent.click(screen.getByRole("button", { name: "Join" }));
-    const field = await screen.findByLabelText("Date of birth");
-    await userEvent.type(field, "1990-05-04");
-    expect(field).toHaveValue("1990-05-04");
+    await userEvent.click(await screen.findByLabelText("Date of birth"));
+    await userEvent.type(await screen.findByLabelText("Type or pick a date"), "1990-05-04{Enter}");
+    await userEvent.keyboard("{Escape}");
+    expect(await screen.findByLabelText("Date of birth")).toHaveTextContent("May 4, 1990");
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     await userEvent.click(screen.getByRole("button", { name: "Join" }));
 
-    expect(await screen.findByLabelText("Date of birth")).toHaveValue("");
+    expect(await screen.findByLabelText("Date of birth")).toHaveTextContent(
+      "Pick your date of birth"
+    );
     expect(join).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Problem

On the age-verification screen the API was being hammered until it rate-limited:

```
GET /api/v1/users/me            200
GET /api/v1/notifications/      200
WebSocket /api/v1/notifications/stream  [accepted]
GET /api/v1/users/me            200
...
GET /api/v1/users/me            429 Too Many Requests
```

The cause is a self-sustaining reconnect cycle, not anything specific to that screen — it was simply the only traffic in the log, so it stood out:

1. `useNotificationStream` opens the socket, and `onopen` catches up: `invalidateNotifications()` (→ `GET /notifications/`) plus `refreshAccount()` (→ `GET /users/me`).
2. `refreshUser` always called `setUser(response.data)` — a brand-new object on every read, even when the account had not moved.
3. The socket effect listed the `user` **object** in its deps, so the new identity tore the socket down and rebuilt it, and the rebuild asked for the re-read that ends it. At network speed, until the limiter stepped in.

`useRealtimeUpdates` carried the same `user`-object dependency and was being dragged along, dropping its guild subscriptions on every account read.

## Changes

- [useNotificationStream.ts](frontend/src/hooks/useNotificationStream.ts) — the socket is keyed on `user?.id`, not the object. A connection belongs to a person, not to a particular reading of them.
- [useRealtimeUpdates.tsx](frontend/src/hooks/useRealtimeUpdates.tsx) — same change to the guild events socket.
- [useAuth.tsx](frontend/src/hooks/useAuth.tsx) — a re-read is applied through `applyRead`, which keeps the object it already holds when the payload is unchanged, so an answer that says nothing new re-runs no effects anywhere. The read-ordering and sign-out guards are untouched.
- [BirthdateField.tsx](frontend/src/components/auth/BirthdateField.tsx) — the date of birth is picked with the app's own `DateTimePicker` (`includeTime={false}`) rather than `<input type="date">`, bounded to 120 years back and nothing after today. Both surfaces get it: the blocking [ConfirmAge](frontend/src/components/ConfirmAge.tsx) screen and the directory's [AgeConfirmationDialog](frontend/src/components/guilds/AgeConfirmationDialog.tsx). New `confirmAge.birthdatePlaceholder` key added to en/de/es/fr.

Regression tests: "stays up across an account re-read rather than rebuilding for it" in [useNotificationStream.test.tsx](frontend/src/hooks/useNotificationStream.test.tsx), plus two in [useAuth.test.tsx](frontend/src/hooks/useAuth.test.tsx) pinning that an unchanged re-read keeps object identity while a real change still swaps it.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm lint` — clean (1329 files)
- `cd frontend && pnpm test:run` — 220 files / 2438 tests passing

Backend untouched.

Worth a manual look: the picker's popover inside the join dialog. `CreateEventDialog` already nests a `DateTimePicker` in a `Dialog` so the pattern is proven in-app, but jsdom does not really prove that interaction.