### PR TITLE
An ignored account is not a recipient

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -1703,7 +1703,8 @@ async def notify_mentions(
     # Who to tell is a question about their account, so it is asked where an
     # account may be read.
     recipients = await accounts_service.load(
-        user_id for user_id in mentioned_user_ids if user_id in member_ids
+        (user_id for user_id in mentioned_user_ids if user_id in member_ids),
+        excluding_ignorers_of=current_user.id,
     )
     for user_id in mentioned_user_ids:
         mentioned_user = recipients.get(user_id)

--- a/backend/app/services/platform/accounts.py
+++ b/backend/app/services/platform/accounts.py
@@ -16,6 +16,11 @@ needs their account to do so.
 Those reads happen here, on the system engine, the way
 ``authenticate_api_key`` resolves a credential before a session exists.
 
+It is also where a recipient stops being one. An account that ignores the actor
+does not hear from them — no notification row, so no email, no push, no unread
+count and no realtime frame — and because that is decided here, no fan-out
+carries a rule of its own.
+
 The rows come back **detached**. Every column is loaded, so callers read them
 exactly as they read a request-loaded row; what a detached row cannot do is
 lazy-load a relationship or be written back, which is right for something the
@@ -33,12 +38,23 @@ from app.models.platform.user import User
 __all__ = ["load", "load_one", "load_all", "load_event_reminder_optins"]
 
 
-async def load(user_ids: Iterable[int | None]) -> dict[int, User]:
+async def load(
+    user_ids: Iterable[int | None],
+    *,
+    excluding_ignorers_of: int | None = None,
+) -> dict[int, User]:
     """The accounts behind ``user_ids``, keyed by id, detached.
 
     Ids with no account behind them are simply absent — an account can be
     erased between the content write and the notification, and having nobody to
     tell is not an error.
+
+    ``excluding_ignorers_of`` drops the accounts that ignore that actor. It
+    belongs here because this is the one place a *recipient* is resolved, so a
+    person who has stopped hearing from somebody is not a recipient of theirs —
+    and every caller already handles an id coming back empty, for the erasure
+    case above. Left out, nothing is filtered: the export worker re-runs a job
+    as the person who asked for it and is not telling anybody anything.
     """
     wanted = {user_id for user_id in user_ids if user_id is not None}
     if not wanted:
@@ -47,28 +63,42 @@ async def load(user_ids: Iterable[int | None]) -> dict[int, User]:
     # Imported here: this module is pulled in by request-path services, and the
     # session module reaches back into configuration at import time.
     from app.db.session import AdminSessionLocal
+    from app.models.platform.user_ignore import UserIgnore
+
+    statement = select(User).where(User.id.in_(tuple(wanted)))
+    if excluding_ignorers_of is not None:
+        statement = statement.where(
+            ~select(UserIgnore.user_id)
+            .where(
+                UserIgnore.user_id == User.id,
+                UserIgnore.ignored_user_id == excluding_ignorers_of,
+            )
+            .exists()
+        )
 
     async with AdminSessionLocal() as admin_session:
-        rows = list(
-            (
-                await admin_session.exec(select(User).where(User.id.in_(tuple(wanted))))
-            ).all()
-        )
+        rows = list((await admin_session.exec(statement)).all())
         for row in rows:
             admin_session.expunge(row)
     return {row.id: row for row in rows if row.id is not None}
 
 
-async def load_one(user_id: int | None) -> User | None:
+async def load_one(
+    user_id: int | None, *, excluding_ignorers_of: int | None = None
+) -> User | None:
     """One recipient, or ``None`` if there is nobody to tell."""
     if user_id is None:
         return None
-    return (await load([user_id])).get(user_id)
+    return (await load([user_id], excluding_ignorers_of=excluding_ignorers_of)).get(
+        user_id
+    )
 
 
-async def load_all(user_ids: Sequence[int | None]) -> list[User]:
+async def load_all(
+    user_ids: Sequence[int | None], *, excluding_ignorers_of: int | None = None
+) -> list[User]:
     """Recipients in the order asked for, skipping any that are gone."""
-    targets = await load(user_ids)
+    targets = await load(user_ids, excluding_ignorers_of=excluding_ignorers_of)
     seen: set[int] = set()
     ordered: list[User] = []
     for user_id in user_ids:

--- a/backend/app/services/platform/accounts_ignore_test.py
+++ b/backend/app/services/platform/accounts_ignore_test.py
@@ -1,0 +1,180 @@
+"""An ignored account is not a recipient.
+
+The filter lives at the one place a recipient is resolved, so these tests are
+about ``accounts.load`` and one fan-out that goes through it end to end. The
+seam is what makes the other five fan-outs true without a rule each.
+"""
+
+import pytest
+from sqlmodel import select
+
+from app.models.platform.notification import Notification, NotificationType
+from app.models.platform.user_ignore import UserIgnore
+from app.services.platform import accounts as accounts_service
+from app.testing import create_user
+
+pytestmark = pytest.mark.asyncio
+
+
+def _mentions(rows: list[Notification]) -> list[Notification]:
+    """``Notification.type`` is a string column, so a row reads back as ``str``
+    rather than the enum — comparing identity against ``NotificationType``
+    would match nothing and pass every assertion."""
+    return [row for row in rows if str(row.type) == NotificationType.mention.value]
+
+
+async def _inbox(session, user_id: int) -> list[Notification]:
+    """Read the inbox on a connection of its own.
+
+    The endpoint commits on its own session, so this asks the database rather
+    than the test session's snapshot.
+    """
+    from app.db.session import AdminSessionLocal
+
+    async with AdminSessionLocal() as admin_session:
+        return list(
+            (
+                await admin_session.exec(
+                    select(Notification).where(Notification.user_id == user_id)
+                )
+            ).all()
+        )
+
+
+async def test_an_account_that_ignores_the_actor_is_not_returned(session):
+    ada = await create_user(session)
+    bram = await create_user(session)
+    session.add(UserIgnore(user_id=ada.id, ignored_user_id=bram.id))
+    await session.commit()
+
+    everyone = await accounts_service.load([ada.id])
+    assert set(everyone) == {ada.id}
+
+    from_bram = await accounts_service.load([ada.id], excluding_ignorers_of=bram.id)
+    assert from_bram == {}
+
+
+async def test_the_other_direction_is_untouched(session):
+    """Ada ignoring Bram silences Bram towards Ada, and nothing else.
+
+    Ada still hears from everyone, and Bram still hears from Ada — ignoring
+    governs arrival at the person who did it.
+    """
+    ada = await create_user(session)
+    bram = await create_user(session)
+    session.add(UserIgnore(user_id=ada.id, ignored_user_id=bram.id))
+    await session.commit()
+
+    # Bram is told about what Ada does: Ada switched off her own inbox, not his.
+    to_bram = await accounts_service.load([bram.id], excluding_ignorers_of=ada.id)
+    assert set(to_bram) == {bram.id}
+
+    # And Ada is told about everyone except Bram.
+    cleo = await create_user(session)
+    to_ada = await accounts_service.load([ada.id], excluding_ignorers_of=cleo.id)
+    assert set(to_ada) == {ada.id}
+
+
+async def test_only_the_ignoring_recipient_drops_out(session):
+    """One person's ignore does not cost anybody else their notice."""
+    ada = await create_user(session)
+    cleo = await create_user(session)
+    bram = await create_user(session)
+    session.add(UserIgnore(user_id=ada.id, ignored_user_id=bram.id))
+    await session.commit()
+
+    recipients = await accounts_service.load(
+        [ada.id, cleo.id], excluding_ignorers_of=bram.id
+    )
+    assert set(recipients) == {cleo.id}
+
+
+async def test_omitting_the_actor_filters_nothing(session):
+    """The export worker re-runs a job as the person who asked for it, and is
+    not telling anybody anything."""
+    ada = await create_user(session)
+    bram = await create_user(session)
+    session.add(UserIgnore(user_id=ada.id, ignored_user_id=bram.id))
+    await session.commit()
+
+    assert set(await accounts_service.load([ada.id])) == {ada.id}
+
+
+async def test_stopping_lets_the_next_one_through(session):
+    """Nothing from the quiet period is reconstructed — none of it was written
+    — but everything after it arrives."""
+    ada = await create_user(session)
+    bram = await create_user(session)
+    row = UserIgnore(user_id=ada.id, ignored_user_id=bram.id)
+    session.add(row)
+    await session.commit()
+    assert await accounts_service.load([ada.id], excluding_ignorers_of=bram.id) == {}
+
+    await session.delete(row)
+    await session.commit()
+
+    assert set(
+        await accounts_service.load([ada.id], excluding_ignorers_of=bram.id)
+    ) == {ada.id}
+
+
+async def test_a_mention_from_an_ignored_account_writes_no_notification(
+    client, session, acting_user
+):
+    """End to end through a comment: the mention is written and rendered, and
+    the person who is ignoring hears nothing about it."""
+    from app.models.platform.guild import GuildRole
+
+    bram = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
+    ada = await acting_user(
+        guild_role=GuildRole.member,
+        guild=bram.guild,
+        initiative=bram.initiative,
+        initiative_role="member",
+    )
+    session.add(UserIgnore(user_id=ada.user.id, ignored_user_id=bram.user.id))
+    await session.commit()
+
+    task = await _a_task(session, bram)
+    before = len(await _inbox(session, ada.user.id))
+
+    posted = await client.post(
+        bram.g("/comments/"),
+        json={
+            "task_id": task.id,
+            "content": f"hello @[{ada.user.username}]({ada.user.id})",
+        },
+        headers=bram.headers,
+    )
+    assert posted.status_code in (200, 201), posted.text
+
+    after = await _inbox(session, ada.user.id)
+    assert len(after) == before
+    assert not _mentions(after)
+
+    # The control, without which the assertion above passes even if mentions
+    # notify nobody: the same comment from the same person, once Ada is no
+    # longer ignoring them, does arrive.
+    ignore = await session.get(UserIgnore, (ada.user.id, bram.user.id))
+    await session.delete(ignore)
+    await session.commit()
+
+    again = await client.post(
+        bram.g("/comments/"),
+        json={
+            "task_id": task.id,
+            "content": f"still here @[{ada.user.username}]({ada.user.id})",
+        },
+        headers=bram.headers,
+    )
+    assert again.status_code in (200, 201), again.text
+
+    assert len(_mentions(await _inbox(session, ada.user.id))) == 1
+
+
+async def _a_task(session, actor):
+    from app.testing import create_task
+
+    task = await create_task(session, actor.project)
+    await session.commit()
+    return task

--- a/backend/app/services/tenant/comments.py
+++ b/backend/app/services/tenant/comments.py
@@ -588,17 +588,22 @@ async def create_comment(
     return comment
 
 
-async def _notify_target(user_id: int | None) -> User | None:
+async def _notify_target(
+    user_id: int | None, *, actor_id: int | None = None
+) -> User | None:
     """Who to tell, with the preferences and address a notice needs.
 
     On the system engine: an account's notification settings and address are
-    not a guild's to read."""
-    return await accounts_service.load_one(user_id)
+    not a guild's to read. ``actor_id`` drops anybody who ignores whoever is
+    doing this, so they are simply not a recipient."""
+    return await accounts_service.load_one(user_id, excluding_ignorers_of=actor_id)
 
 
-async def _notify_targets(user_ids: list[int]) -> list[User]:
+async def _notify_targets(
+    user_ids: list[int], *, actor_id: int | None = None
+) -> list[User]:
     """The same, for the several people one comment can reach."""
-    return await accounts_service.load_all(user_ids)
+    return await accounts_service.load_all(user_ids, excluding_ignorers_of=actor_id)
 
 
 async def _load_task_with_assignees(
@@ -652,7 +657,9 @@ async def _process_comment_notifications(
 
     # 1. Reply to comment → notify parent comment author
     if parent_comment and parent_comment.created_by != author.id:
-        parent_author = await _notify_target(parent_comment.created_by)
+        parent_author = await _notify_target(
+            parent_comment.created_by, actor_id=author.id
+        )
         if parent_author:
             await notifications.notify_comment_reply(
                 session,
@@ -675,7 +682,7 @@ async def _process_comment_notifications(
             continue
         if user_id in notified_user_ids:
             continue
-        mentioned_user = await _notify_target(user_id)
+        mentioned_user = await _notify_target(user_id, actor_id=author.id)
         if not mentioned_user:
             continue
         await notifications.notify_comment_mention(
@@ -706,7 +713,7 @@ async def _process_comment_notifications(
             for assignee in assignees
             if assignee.id != author.id and assignee.id not in notified_user_ids
         ]
-        for assignee in await _notify_targets(wanted):
+        for assignee in await _notify_targets(wanted, actor_id=author.id):
             await notifications.notify_task_mentioned_in_comment(
                 session,
                 assignee=assignee,
@@ -735,7 +742,7 @@ async def _process_comment_notifications(
                 for assignee in assignees
                 if assignee.id != author.id and assignee.id not in notified_user_ids
             ]
-            for assignee in await _notify_targets(wanted):
+            for assignee in await _notify_targets(wanted, actor_id=author.id):
                 await notifications.notify_comment_on_task(
                     session,
                     assignee=assignee,
@@ -750,7 +757,7 @@ async def _process_comment_notifications(
 
     # 5. Tool comment → notify the entity's creator (if not already notified)
     if ctx.resource is not None:
-        owner = await _notify_target(ctx.resource.created_by)
+        owner = await _notify_target(ctx.resource.created_by, actor_id=author.id)
         if owner and owner.id != author.id and owner.id not in notified_user_ids:
             await notifications.notify_comment_on_resource(
                 session,

--- a/backend/app/services/tenant/reactions.py
+++ b/backend/app/services/tenant/reactions.py
@@ -359,7 +359,9 @@ async def _queue_reaction_notification(
         return
     # On the system engine: whether they want to hear about this, and where to
     # write to, are facts about their account rather than about this guild.
-    author = await accounts_service.load_one(ctx.author_id)
+    author = await accounts_service.load_one(
+        ctx.author_id, excluding_ignorers_of=reactor.id
+    )
     if author is None:
         return
     await notifications.enqueue_reaction_event(


### PR DESCRIPTION
## Problem

Ignoring already refused contact — no messages, no requests — but it did not
yet stop a notification. Somebody you had stopped hearing from could still
reach your inbox by mentioning you. This is the fourth of five PRs.

Design doc: `history/dm-connections-blocks-design.md` (local, gitignored).

## Changes

One place, because there is only one place a *recipient* is resolved.
`accounts.load` — the system-engine read every fan-out goes through since
#1368 took the guild path off `public.users` — takes
`excluding_ignorers_of`, and an account that ignores the actor does not come
back from it.

**No `notify_*` function changed.** Every call site already handled an id
resolving to nobody, because an account can be erased between the content write
and the notification, so an ignored recipient is simply not a recipient. Three
call sites pass the actor:

| Site | Covers |
|---|---|
| `comments.py` — `_notify_target` / `_notify_targets` | mentions, replies, comment-on-task, comment-on-tool, task-mentioned-in-comment |
| `documents.py` | document mentions |
| `reactions.py` | the reaction roll-up |

Seven notices, no rule in any of them. Nothing is written, so nothing is
resurrected on stopping — and no email, push, unread count or realtime frame
goes out either, since they all hang off the row.

**Work carries on.** An assignment or an event invitation from somebody you
ignore still arrives: ignoring is about contact between two people, not about
what you are asked to do. Somebody who ignores a colleague and is then assigned
a task by them would otherwise think it had not worked.

**The export worker passes no actor** and filters nothing — it re-runs a job as
the person who asked for it and is not telling anybody anything.

## Notes for review

Three of the six tests exist because the first versions passed while asserting
nothing, and it is worth knowing which:

- The end-to-end test used `@[Name](user:id)`; the real syntax is
  `@[Name](id)`, so no mention was ever parsed.
- `Notification.type` is a `String` column, so a row reads back as `str` — the
  original `n.type is NotificationType.mention` matched nothing and made both
  the suppression assertion *and* its control vacuous. There is now a named
  helper that compares the string and says why.
- Only adding the control — *without the ignore, this same comment does
  notify* — surfaced either of those.

`test_the_other_direction_is_untouched` had me briefly convinced the code was
wrong when the test was: ignoring governs arrival at the person who did it, so
recipient-ignores-actor is exactly the case that should suppress.

## Testing

```
pytest -n 2 app/services/platform app/services/tenant/comments_test.py \
            app/api/v1/tenant_endpoints/comments_test.py \
            app/api/v1/tenant_endpoints/documents_test.py   363 passed
ruff check app && ruff format app                           clean
ty check app                                                clean
```

## Related

`549e2288` went straight to `dev`: #1374 added four notification types without
a push channel, leaving `test_every_pushed_notification_type_has_a_channel`
failing. They are declared in-app only — they belong in the inbox beside the
contacts page that answers them, and a channel of their own would mean a native
release, so they should arrive with the one that ships direct messages.

## What is not here

No changelog entry: there is still no way to ignore anyone, so the entry lands
with the UI that offers it. Next and last: the frontend.
