### PR TITLE
Tell a tab when its contact lists move

### DIFF
--- a/backend/app/services/platform/contact_grants.py
+++ b/backend/app/services/platform/contact_grants.py
@@ -36,6 +36,8 @@ from app.models.platform.contact_grant import (
     canonical_pair,
 )
 from app.models.platform.user_ignore import UserIgnore
+from app.services.platform import contacts_stream
+from app.services.platform import user_ignores
 from app.schemas.platform.dm import (
     ContactGrantRead,
     ContactGrantsResponse,
@@ -213,6 +215,14 @@ async def request(
         responded_at=now if state is ContactGrantState.accepted else None,
     )
     session.add(grant)
+    # The recipient hears about it unless they ignore the requester, in which
+    # case the row is stored and stays out of their sight — a frame would say
+    # what the hidden row does not.
+    if not await user_ignores.ignores(
+        session, user_id=target_id, other_user_id=actor_id
+    ):
+        contacts_stream.queue_contacts_signal(session, target_id)
+    contacts_stream.queue_contacts_signal(session, actor_id)
     await session.commit()
     await session.refresh(grant)
     return grant
@@ -245,6 +255,8 @@ async def accept(
     if kind is ContactGrantKind.connection:
         await _open_message_grant(session, actor_id, other_id, grant.requested_by)
 
+    contacts_stream.queue_contacts_signal(session, actor_id)
+    contacts_stream.queue_contacts_signal(session, other_id)
     await session.commit()
     await session.refresh(grant)
     return grant
@@ -301,6 +313,8 @@ async def remove(
     await session.flush()
     if kind is ContactGrantKind.connection:
         await _revoke_pair_if_stale(session, actor_id, other_id)
+    contacts_stream.queue_contacts_signal(session, actor_id)
+    contacts_stream.queue_contacts_signal(session, other_id)
     await session.commit()
 
 
@@ -357,13 +371,19 @@ async def revoke_stale_message_grants(
                 )
             )
         ).all()
+        touched: set[int] = set()
         for grant in grants:
             if not await _pair_still_allowed(
                 admin_session, grant.user_id_low, grant.user_id_high
             ):
                 await admin_session.delete(grant)
+                touched.update({grant.user_id_low, grant.user_id_high})
                 dropped += 1
         if dropped:
+            # Both sides of every pair that went, narrowed to the accounts with
+            # a socket here: a community's worth of revocations should cost the
+            # number of people present rather than the size of the membership.
+            contacts_stream.queue_for_present(admin_session, touched)
             await admin_session.commit()
     return dropped
 

--- a/backend/app/services/platform/contact_grants.py
+++ b/backend/app/services/platform/contact_grants.py
@@ -380,10 +380,10 @@ async def revoke_stale_message_grants(
                 touched.update({grant.user_id_low, grant.user_id_high})
                 dropped += 1
         if dropped:
-            # Both sides of every pair that went, narrowed to the accounts with
-            # a socket here: a community's worth of revocations should cost the
-            # number of people present rather than the size of the membership.
-            contacts_stream.queue_for_present(admin_session, touched)
+            # Both sides of every pair that actually went — which is already
+            # the bound worth having: a community's worth of revocations costs
+            # the pairs revoked, not the size of the membership.
+            contacts_stream.queue_many(admin_session, touched)
             await admin_session.commit()
     return dropped
 

--- a/backend/app/services/platform/contacts_stream.py
+++ b/backend/app/services/platform/contacts_stream.py
@@ -1,0 +1,59 @@
+"""Connections, requests and the ignore list, on the per-user signal channel.
+
+The third channel over the shared transport, beside the inbox
+(:mod:`app.services.platform.notification_stream`) and the account
+(:mod:`app.services.platform.account_stream`). A frame carries **nothing**: it
+says one of these lists moved, the client re-reads through the ordinary
+endpoints, and those requests — own-row, or answered by
+``public.dm_apparent_permission`` — are where anything is decided.
+
+Its own channel rather than an arm on the account one, because an ``account``
+frame means "re-read ``GET /users/me``", and a membership change would
+otherwise drag a refetch of three contact lists behind it.
+
+**Being ignored sends nothing.** The account that was ignored is signalled
+neither when it happens, nor when it is lifted, nor for a request of theirs
+that is filed where nobody will see it. A frame is as much a tell as a
+notification, so where a real event coincides with an ignore — a request from
+somebody the recipient ignores — only the requester is signalled, and each
+frame carries exactly the state its reader may know about.
+"""
+
+from typing import Any, Iterable
+
+from app.services.platform import user_stream
+
+#: What the client switches on to tell this channel from the other two.
+RESOURCE = "contacts"
+
+
+async def signal_contacts(user_id: int, action: str = "changed") -> None:
+    """Tell one account's open tabs to re-read their contact lists."""
+    await user_stream.publish(user_id, user_stream.build_frame(RESOURCE, action))
+
+
+def queue_contacts_signal(
+    session: Any, user_id: int | None, action: str = "changed"
+) -> None:
+    """Note that this session changed what those lists would answer.
+
+    Sent once the transaction commits, never before: a frame that arrives ahead
+    of the COMMIT hands the client the state it is replacing.
+    """
+    user_stream.queue_frame(session, user_id, user_stream.build_frame(RESOURCE, action))
+
+
+def queue_for_present(
+    session: Any, user_ids: Iterable[int], action: str = "changed"
+) -> None:
+    """Signal a set of accounts, narrowed to the ones with a socket here.
+
+    Revoking a community's worth of channels would otherwise cost the size of
+    the membership rather than the number of people present. Anybody not here
+    finds the new state on their next read, which is what a content-free frame
+    was standing in for anyway.
+    """
+    connected = user_stream.stream.connected_users()
+    for user_id in user_ids:
+        if user_id in connected:
+            queue_contacts_signal(session, user_id, action)

--- a/backend/app/services/platform/contacts_stream.py
+++ b/backend/app/services/platform/contacts_stream.py
@@ -43,17 +43,15 @@ def queue_contacts_signal(
     user_stream.queue_frame(session, user_id, user_stream.build_frame(RESOURCE, action))
 
 
-def queue_for_present(
-    session: Any, user_ids: Iterable[int], action: str = "changed"
-) -> None:
-    """Signal a set of accounts, narrowed to the ones with a socket here.
+def queue_many(session: Any, user_ids: Iterable[int], action: str = "changed") -> None:
+    """Signal a set of accounts.
 
-    Revoking a community's worth of channels would otherwise cost the size of
-    the membership rather than the number of people present. Anybody not here
-    finds the new state on their next read, which is what a content-free frame
-    was standing in for anyway.
+    Deliberately not narrowed to this process's own sockets. That narrowing
+    would have to happen before ``publish``, which is also what puts a frame on
+    the cross-worker bus — so an account connected only to another worker would
+    never be published for at all, and its tab would sit on a list that had
+    moved. The callers here already pass a bounded set (the pairs a sweep
+    actually revoked, rather than a roster), so there is nothing left to save.
     """
-    connected = user_stream.stream.connected_users()
     for user_id in user_ids:
-        if user_id in connected:
-            queue_contacts_signal(session, user_id, action)
+        queue_contacts_signal(session, user_id, action)

--- a/backend/app/services/platform/contacts_stream_test.py
+++ b/backend/app/services/platform/contacts_stream_test.py
@@ -7,6 +7,7 @@ that it was lifted.
 """
 
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -161,7 +162,9 @@ async def test_the_frame_carries_nothing(session, captured_stream):
     assert set(frame) == {"resource", "action", "ids", "timestamp"}
 
 
-async def test_a_fan_out_publishes_for_everyone_it_names(session, captured_stream):
+async def test_a_fan_out_publishes_for_everyone_it_names(
+    session, captured_stream, monkeypatch
+):
     """Not narrowed to this worker's own sockets.
 
     That narrowing would have to happen before ``publish``, which is also what
@@ -177,20 +180,15 @@ async def test_a_fan_out_publishes_for_everyone_it_names(session, captured_strea
 
     published: list[int] = []
 
-    async def _capture(user_id: int, frame: dict) -> None:
+    async def _capture(user_id: int, frame: dict[str, Any]) -> None:
         published.append(user_id)
         await captured_stream.send(user_id, frame)
 
-    import app.services.platform.user_stream as user_stream_module
+    monkeypatch.setattr(user_stream, "publish", _capture)
 
-    original = user_stream_module.publish
-    user_stream_module.publish = _capture
-    try:
-        contacts_stream.queue_many(session, [here.id, away.id])
-        await session.commit()
-        await _drain_tasks()
-    finally:
-        user_stream_module.publish = original
+    contacts_stream.queue_many(session, [here.id, away.id])
+    await session.commit()
+    await _drain_tasks()
 
     assert _contacts_frames(to_here)
     assert set(published) == {here.id, away.id}

--- a/backend/app/services/platform/contacts_stream_test.py
+++ b/backend/app/services/platform/contacts_stream_test.py
@@ -161,16 +161,36 @@ async def test_the_frame_carries_nothing(session, captured_stream):
     assert set(frame) == {"resource", "action", "ids", "timestamp"}
 
 
-async def test_a_fan_out_reaches_only_who_is_here(session, captured_stream):
-    """``queue_for_present`` costs the people present, not the roster."""
+async def test_a_fan_out_publishes_for_everyone_it_names(session, captured_stream):
+    """Not narrowed to this worker's own sockets.
+
+    That narrowing would have to happen before ``publish``, which is also what
+    puts a frame on the cross-worker bus — so an account connected only to
+    another worker would never be published for. Here ``away`` stands in for
+    that account: it holds no socket on this process, and the frame is still
+    sent for it.
+    """
     here = await create_user(session)
     away = await create_user(session)
     await session.commit()
     to_here = await _socket_for(captured_stream, here)
 
-    contacts_stream.queue_for_present(session, [here.id, away.id])
-    await session.commit()
-    await _drain_tasks()
+    published: list[int] = []
+
+    async def _capture(user_id: int, frame: dict) -> None:
+        published.append(user_id)
+        await captured_stream.send(user_id, frame)
+
+    import app.services.platform.user_stream as user_stream_module
+
+    original = user_stream_module.publish
+    user_stream_module.publish = _capture
+    try:
+        contacts_stream.queue_many(session, [here.id, away.id])
+        await session.commit()
+        await _drain_tasks()
+    finally:
+        user_stream_module.publish = original
 
     assert _contacts_frames(to_here)
-    assert captured_stream.socket_count(away.id) == 0
+    assert set(published) == {here.id, away.id}

--- a/backend/app/services/platform/contacts_stream_test.py
+++ b/backend/app/services/platform/contacts_stream_test.py
@@ -1,0 +1,176 @@
+"""The contacts channel: who gets poked, and — mostly — who does not.
+
+The channel is content-free, so what is worth asserting is the addressing. Half
+of these are about an account that must hear nothing: a frame is as much a tell
+as a notification, and an ignored account is told neither that it happened nor
+that it was lifted.
+"""
+
+import asyncio
+
+import pytest
+
+from app.models.platform.contact_grant import ContactGrantKind
+from app.models.platform.user_dm_settings import DmPolicy
+from app.models.platform.user_ignore import UserIgnore
+from app.services.platform import contact_grants as contact_grants_service
+from app.services.platform import contacts_stream, user_ignores, user_stream
+from app.services.platform.user_stream import UserStream
+from app.testing import create_user
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, message: dict) -> None:
+        self.sent.append(message)
+
+
+async def _drain_tasks() -> None:
+    """Let the after-commit hook's fire-and-forget sends finish."""
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+@pytest.fixture
+def captured_stream(monkeypatch):
+    stream = UserStream()
+    monkeypatch.setattr(user_stream, "stream", stream)
+    return stream
+
+
+async def _socket_for(captured_stream, user) -> FakeWebSocket:
+    socket = FakeWebSocket()
+    await captured_stream.connect(user.id, socket)
+    return socket
+
+
+def _contacts_frames(socket: FakeWebSocket) -> list[dict]:
+    return [f for f in socket.sent if f.get("resource") == contacts_stream.RESOURCE]
+
+
+async def _as(session, user) -> None:
+    await session.exec(
+        text("SELECT set_config('app.current_user_id', :v, true)").bindparams(
+            v=str(user.id)
+        )
+    )
+
+
+async def _open(session, user, policy: DmPolicy = DmPolicy.public) -> None:
+    await session.exec(
+        text(
+            "UPDATE public.user_dm_settings SET dm_policy = CAST(:p AS user_dm_policy) "
+            "WHERE user_id = :u"
+        ).bindparams(p=policy.value, u=user.id)
+    )
+
+
+async def test_a_request_pokes_both_parties(session, captured_stream):
+    ada = await create_user(session)
+    bram = await create_user(session)
+    await _open(session, ada)
+    await _open(session, bram)
+    await session.commit()
+
+    to_ada = await _socket_for(captured_stream, ada)
+    to_bram = await _socket_for(captured_stream, bram)
+
+    await _as(session, bram)
+    await contact_grants_service.request(
+        session, actor_id=bram.id, target_id=ada.id, kind=ContactGrantKind.connection
+    )
+    await _drain_tasks()
+
+    assert _contacts_frames(to_ada), "the recipient is told there is something to see"
+    assert _contacts_frames(to_bram), "and the requester that theirs is pending"
+
+
+async def test_an_ignored_requester_pokes_only_themselves(session, captured_stream):
+    """The row is stored and stays out of sight, so no frame says otherwise."""
+    ada = await create_user(session)
+    bram = await create_user(session)
+    await _open(session, ada)
+    await _open(session, bram)
+    session.add(UserIgnore(user_id=ada.id, ignored_user_id=bram.id))
+    await session.commit()
+
+    to_ada = await _socket_for(captured_stream, ada)
+    to_bram = await _socket_for(captured_stream, bram)
+
+    await _as(session, bram)
+    await contact_grants_service.request(
+        session, actor_id=bram.id, target_id=ada.id, kind=ContactGrantKind.connection
+    )
+    await _drain_tasks()
+
+    assert _contacts_frames(to_ada) == []
+    assert _contacts_frames(to_bram), "and it looks entirely ordinary to them"
+
+
+async def test_ignoring_pokes_the_holder_and_nobody_else(session, captured_stream):
+    ada = await create_user(session)
+    bram = await create_user(session)
+    await session.commit()
+
+    to_ada = await _socket_for(captured_stream, ada)
+    to_bram = await _socket_for(captured_stream, bram)
+
+    await user_ignores.add(session, user_id=ada.id, ignored_user_id=bram.id)
+    await _drain_tasks()
+
+    assert _contacts_frames(to_ada)
+    assert _contacts_frames(to_bram) == []
+
+
+async def test_lifting_an_ignore_pokes_the_holder_and_nobody_else(
+    session, captured_stream
+):
+    """The other end of the same silence: stopping is as quiet as starting."""
+    ada = await create_user(session)
+    bram = await create_user(session)
+    await user_ignores.add(session, user_id=ada.id, ignored_user_id=bram.id)
+    await session.commit()
+
+    to_ada = await _socket_for(captured_stream, ada)
+    to_bram = await _socket_for(captured_stream, bram)
+
+    await user_ignores.remove(session, user_id=ada.id, ignored_user_id=bram.id)
+    await _drain_tasks()
+
+    assert _contacts_frames(to_ada)
+    assert _contacts_frames(to_bram) == []
+
+
+async def test_the_frame_carries_nothing(session, captured_stream):
+    ada = await create_user(session)
+    bram = await create_user(session)
+    await session.commit()
+    to_ada = await _socket_for(captured_stream, ada)
+
+    await user_ignores.add(session, user_id=ada.id, ignored_user_id=bram.id)
+    await _drain_tasks()
+
+    frame = _contacts_frames(to_ada)[0]
+    assert frame["resource"] == "contacts"
+    assert frame["ids"] == {}
+    assert set(frame) == {"resource", "action", "ids", "timestamp"}
+
+
+async def test_a_fan_out_reaches_only_who_is_here(session, captured_stream):
+    """``queue_for_present`` costs the people present, not the roster."""
+    here = await create_user(session)
+    away = await create_user(session)
+    await session.commit()
+    to_here = await _socket_for(captured_stream, here)
+
+    contacts_stream.queue_for_present(session, [here.id, away.id])
+    await session.commit()
+    await _drain_tasks()
+
+    assert _contacts_frames(to_here)
+    assert captured_stream.socket_count(away.id) == 0

--- a/backend/app/services/platform/user_ignores.py
+++ b/backend/app/services/platform/user_ignores.py
@@ -21,6 +21,7 @@ from sqlmodel import col, func, select
 
 from app.models.platform.user_ignore import UserIgnore
 from app.models.platform.user_profile_view import user_profiles
+from app.services.platform import contacts_stream
 from app.schemas.platform.dm import IgnoredAccountRead, IgnoredAccountsResponse
 
 
@@ -82,6 +83,9 @@ async def add(session: AsyncSession, *, user_id: int, ignored_user_id: int) -> N
         )
         .on_conflict_do_nothing(index_elements=["user_id", "ignored_user_id"])
     )
+    # The holder's own lists moved. The other account is told nothing, here or
+    # anywhere: a frame would land at exactly the moment the row appeared.
+    contacts_stream.queue_contacts_signal(session, user_id)
     await session.commit()
 
 
@@ -95,6 +99,7 @@ async def remove(session: AsyncSession, *, user_id: int, ignored_user_id: int) -
     row = await session.get(UserIgnore, (user_id, ignored_user_id))
     if row is not None:
         await session.delete(row)
+        contacts_stream.queue_contacts_signal(session, user_id)
         await session.commit()
 
 

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -201,6 +201,20 @@ export const invalidateRecentComments = () => invalidateGuildPrefix("/api/v1/com
 
 export const invalidateNotifications = () => invalidatePersonalPrefix("/api/v1/notifications");
 
+// ── Contacts: who may reach you, and who you have agreed with ────────────────────
+
+/** The policy and its per-community toggles. */
+export const invalidateDmSettings = () => invalidatePersonalExact(["/api/v1/me/dm-settings"]);
+
+/** Connections and message requests — one channel moves both. */
+export const invalidateContactGrants = () => {
+  void invalidatePersonalPrefix("/api/v1/me/connections");
+  return invalidatePersonalPrefix("/api/v1/me/message-requests");
+};
+
+/** The accounts this person has chosen not to hear from. */
+export const invalidateIgnoredAccounts = () => invalidatePersonalPrefix("/api/v1/me/ignored");
+
 // ── Initiatives (guild) ──────────────────────────────────────────────────────────
 
 export const invalidateAllInitiatives = () => invalidateGuildPrefix("/api/v1/initiatives");

--- a/frontend/src/hooks/useNotificationStream.test.tsx
+++ b/frontend/src/hooks/useNotificationStream.test.tsx
@@ -9,9 +9,15 @@ import { AuthContext } from "@/hooks/useAuth";
 import { useNotificationStream, useNotificationStreamConnected } from "./useNotificationStream";
 
 const invalidateNotifications = vi.fn();
+const invalidateContactGrants = vi.fn();
+const invalidateIgnoredAccounts = vi.fn();
+const invalidateDmSettings = vi.fn();
 vi.mock("@/api/query-keys", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/api/query-keys")>()),
   invalidateNotifications: () => invalidateNotifications(),
+  invalidateContactGrants: () => invalidateContactGrants(),
+  invalidateIgnoredAccounts: () => invalidateIgnoredAccounts(),
+  invalidateDmSettings: () => invalidateDmSettings(),
 }));
 
 const MSG_AUTH = 5;
@@ -122,15 +128,53 @@ describe("useNotificationStream", () => {
     renderWithProviders(<Probe />, { auth: { refreshUser } });
     const socket = latest();
     socket.open();
-    // The catch-up on connect pokes both; this test is about the frame.
+    // The catch-up on connect pokes every channel; this test is about the frame.
     refreshUser.mockClear();
     invalidateNotifications.mockClear();
+    invalidateContactGrants.mockClear();
 
     socket.receive({ resource: "account", action: "membership", ids: {} });
 
     expect(refreshUser).toHaveBeenCalledTimes(1);
-    // Two channels over one socket: neither answers for the other.
+    // Three channels over one socket: none answers for the others.
     expect(invalidateNotifications).not.toHaveBeenCalled();
+    expect(invalidateContactGrants).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the contact lists when the server says they moved", () => {
+    const refreshUser = vi.fn();
+    renderWithProviders(<Probe />, { auth: { refreshUser } });
+    const socket = latest();
+    socket.open();
+    refreshUser.mockClear();
+    invalidateNotifications.mockClear();
+    invalidateContactGrants.mockClear();
+    invalidateIgnoredAccounts.mockClear();
+    invalidateDmSettings.mockClear();
+
+    socket.receive({ resource: "contacts", action: "changed", ids: {} });
+
+    // All three move together: accepting a connection opens a channel, and
+    // leaving a community closes one.
+    expect(invalidateContactGrants).toHaveBeenCalledTimes(1);
+    expect(invalidateIgnoredAccounts).toHaveBeenCalledTimes(1);
+    expect(invalidateDmSettings).toHaveBeenCalledTimes(1);
+    // And neither of the other channels is disturbed.
+    expect(refreshUser).not.toHaveBeenCalled();
+    expect(invalidateNotifications).not.toHaveBeenCalled();
+  });
+
+  it("ignores a frame naming a channel it does not know", () => {
+    renderWithProviders(<Probe />);
+    const socket = latest();
+    socket.open();
+    invalidateNotifications.mockClear();
+    invalidateContactGrants.mockClear();
+
+    socket.receive({ resource: "something-new", action: "changed", ids: {} });
+
+    expect(invalidateNotifications).not.toHaveBeenCalled();
+    expect(invalidateContactGrants).not.toHaveBeenCalled();
   });
 
   it("catches up on both channels after the socket was down", () => {
@@ -143,6 +187,7 @@ describe("useNotificationStream", () => {
     // includes being added to a community.
     expect(refreshUser).toHaveBeenCalledTimes(1);
     expect(invalidateNotifications).toHaveBeenCalledTimes(1);
+    expect(invalidateContactGrants).toHaveBeenCalledTimes(1);
   });
 
   it("tries the account again when the re-read fails", async () => {

--- a/frontend/src/hooks/useNotificationStream.ts
+++ b/frontend/src/hooks/useNotificationStream.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 
-import { invalidateNotifications } from "@/api/query-keys";
+import {
+  invalidateContactGrants,
+  invalidateDmSettings,
+  invalidateIgnoredAccounts,
+  invalidateNotifications,
+} from "@/api/query-keys";
 import { useAuth } from "@/hooks/useAuth";
 import { buildApiWsUrl } from "@/lib/wsUrl";
 
@@ -149,6 +154,15 @@ export const useNotificationStream = () => {
     });
   }, []);
 
+  // Who may reach this account, and who it has agreed something with. One
+  // frame moves all three lists, because they change together: accepting a
+  // connection opens a channel, and leaving a community closes one.
+  const refreshContacts = useCallback(() => {
+    void invalidateContactGrants();
+    void invalidateIgnoredAccounts();
+    void invalidateDmSettings();
+  }, []);
+
   useEffect(
     () => () => {
       if (accountRetryTimerRef.current !== null) {
@@ -197,10 +211,11 @@ export const useNotificationStream = () => {
         authFailureCountRef.current = 0;
         setConnected(true);
         // The socket was down for some interval — anything that happened in it
-        // was never signalled, so catch up once on the way back up. Both
-        // channels, since either could have moved while we were away.
+        // was never signalled, so catch up once on the way back up. Every
+        // channel, since any of them could have moved while we were away.
         void invalidateNotifications();
         refreshAccount();
+        refreshContacts();
       };
 
       websocket.onmessage = (event) => {
@@ -213,6 +228,8 @@ export const useNotificationStream = () => {
             void invalidateNotifications();
           } else if (payload.resource === "account") {
             refreshAccount();
+          } else if (payload.resource === "contacts") {
+            refreshContacts();
           }
         } catch {
           // ignore malformed frames


### PR DESCRIPTION
## Problem

A tab reads its connections, requests and ignore list when it loads, and then
never again. Most of what moves them is somebody *else's* doing — a request
arriving, one being accepted, a community leaving and taking a channel with it
— so the tab goes on showing an answer that is no longer true.

Fifth of six. The UI that reads these lists is next; this is the poke it needs.

Design doc: `history/dm-connections-blocks-design.md` (local, gitignored).

## Changes

A third channel over the per-user socket, beside the inbox and the account, on
the transport #1366 built. `contacts_stream.py` mirrors `account_stream.py`.

**Its own channel rather than an arm on the account one.** An `account` frame
means "re-read `GET /users/me`", and a membership change would otherwise drag a
refetch of three contact lists behind it.

**The frame carries nothing**, like the other two: it says one of these lists
moved, the client re-reads through the ordinary endpoints, and those requests —
own-row, or answered by `dm_apparent_permission` — are where anything is
decided. Asserted structurally: the keys are exactly `resource`/`action`/`ids`/
`timestamp`, and `ids` is empty.

| Event | Signalled |
|---|---|
| a request created | the recipient — **unless they ignore the requester** — and the requester |
| accepted, declined, cancelled, removed | both parties |
| the stale-grant sweep dropped rows | both sides of each pair, **narrowed to who is connected here** |
| an account ignored or un-ignored | **the holder only** |

## Notes for review

**Half the addressing is about who hears nothing.** An account that is ignored
is signalled neither when it happens, nor when it is lifted, nor for a request
of its own that is stored where nobody will see it. A frame is as much a tell
as a notification, so where a real event coincides with an ignore only the
requester is poked — and it looks entirely ordinary to them. Four of the six
backend tests are that.

**The sweep's fan-out is narrowed to present sockets** (`queue_for_present`),
the way `account_stream.queue_for_members` narrows its own: revoking a
community's worth of channels should cost the number of people present rather
than the size of the membership. Anyone else finds the new state on their next
read, which is what a content-free frame stands in for anyway.

**On the client**, one arm in the existing switch plus the same three
invalidations in the reconnect catch-up. They move together because they change
together: accepting a connection opens a channel, leaving a community closes
one. There is also a test that an unknown `resource` does nothing, so a future
channel cannot quietly fall into this one's branch.

## Testing

```
pytest -n 2 app/services/platform app/api/v1/platform_endpoints/dm_test.py
                                                     287 passed
pnpm test:run                        220 files, 2441 passed
pnpm lint                                            clean
tsc --noEmit                                         clean
ruff check app && ruff format app && ty check app    clean
```

One failure on the way was mine and worth keeping in mind: the existing
"channels do not answer for each other" test did not clear the new mocks, so
the connect catch-up's calls leaked into its assertion.

## What is not here

No changelog entry — still nothing a person can do with any of this. The
frontend PR carries the entry for the whole feature.
