### PR TITLE
Show only the tab you are on in the palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A search tab that matched nothing says so.** In ⌘K, switching between Tools, Members, Comments and Tags left the tab before it on screen when the new one had no answer — so a community with nobody matching showed the comments you had just been reading. Each tab now shows only what it found, and says "No results found." when that is nothing — or that search is not answering, if the request never landed, rather than reporting a failure as an empty community.
+
 ## [0.65.0] - 2026-09-02
 
 ### Added

--- a/frontend/public/locales/de/search.json
+++ b/frontend/public/locales/de/search.json
@@ -11,6 +11,10 @@
     "title": "Keine Ergebnisse für „{{query}}“",
     "description": "Prüfe die Schreibweise oder versuche ein anderes Wort."
   },
+  "failed": {
+    "title": "Die Suche antwortet nicht",
+    "description": "Beim Abrufen ist etwas schiefgelaufen. Versuche es gleich noch einmal."
+  },
   "tabs": {
     "tool": "Werkzeuge",
     "member": "Mitglieder",

--- a/frontend/public/locales/en/search.json
+++ b/frontend/public/locales/en/search.json
@@ -11,6 +11,10 @@
     "title": "No results for “{{query}}”",
     "description": "Check the spelling, or try a different word."
   },
+  "failed": {
+    "title": "Search is not answering",
+    "description": "Something went wrong reaching it. Try again in a moment."
+  },
   "tabs": {
     "tool": "Tools",
     "member": "Members",

--- a/frontend/public/locales/es/search.json
+++ b/frontend/public/locales/es/search.json
@@ -11,6 +11,10 @@
     "title": "Sin resultados para «{{query}}»",
     "description": "Revisa la ortografía o prueba con otra palabra."
   },
+  "failed": {
+    "title": "La búsqueda no responde",
+    "description": "Algo salió mal al conectar. Inténtalo de nuevo en un momento."
+  },
   "tabs": {
     "tool": "Herramientas",
     "member": "Miembros",

--- a/frontend/public/locales/fr/search.json
+++ b/frontend/public/locales/fr/search.json
@@ -11,6 +11,10 @@
     "title": "Aucun résultat pour « {{query}} »",
     "description": "Vérifiez l’orthographe ou essayez un autre mot."
   },
+  "failed": {
+    "title": "La recherche ne répond pas",
+    "description": "Un problème est survenu. Réessayez dans un instant."
+  },
   "tabs": {
     "tool": "Outils",
     "member": "Membres",

--- a/frontend/src/__tests__/guildSearchRoute.test.tsx
+++ b/frontend/src/__tests__/guildSearchRoute.test.tsx
@@ -58,6 +58,7 @@ const withHits = (tools: SearchHit[], tags: SearchHit[], comments: SearchHit[] =
       }),
       isLoading: false,
       isFetched: true,
+      isSuccess: true,
     };
   });
 };
@@ -135,11 +136,12 @@ const tag = () =>
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.suggest.mockReturnValue({ data: [], isLoading: false });
+  mocks.suggest.mockReturnValue({ data: [], isLoading: false, isFetched: true, isSuccess: true });
   mocks.members.mockReturnValue({
     data: { items: [], total_count: 0, page: 1, page_size: 20, has_next: false, has_prev: false },
     isLoading: false,
     isFetched: true,
+    isSuccess: true,
   });
   withHits([], []);
 });
@@ -286,6 +288,7 @@ describe("the guild search page", () => {
       },
       isLoading: false,
       isFetched: true,
+      isSuccess: true,
     });
     await renderSearch({ q: "irnforge", tab: "member" });
 
@@ -316,7 +319,7 @@ describe("the guild search page", () => {
 
 describe("the command palette", () => {
   it("carries the same three slices, and narrows to the one it is on", async () => {
-    mocks.suggest.mockReturnValue({ data: [], isLoading: false });
+    mocks.suggest.mockReturnValue({ data: [], isLoading: false, isFetched: true, isSuccess: true });
     renderPage(CommandCenter, {
       initialRoute: "/g/$guildId",
       routeParams: { guildId: "1" },
@@ -400,6 +403,78 @@ describe("the command palette", () => {
     expect(pageRouter.state.location.searchStr).toContain("q=riverside");
   });
 
+  it("shows only the slice being read, and says when it holds nothing", async () => {
+    // Members come from the roster and everything else from the index, so each
+    // slice switches the other question off — and a switched-off question keeps
+    // the answer it was last given. Only the slice being read may put rows on
+    // screen, and a slice that matched nobody says so.
+    mocks.suggest.mockReturnValue({
+      data: [
+        buildSearchSuggestion({
+          entity_type: "comment",
+          entity_id: 31,
+          title: "the riverside stage is booked",
+          tool: Tool.project,
+          tool_id: 7,
+        }),
+      ],
+      isLoading: false,
+      isFetched: true,
+      isSuccess: true,
+    });
+
+    renderPage(CommandCenter, {
+      initialRoute: "/g/$guildId",
+      routeParams: { guildId: "1" },
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    fireEvent.keyDown(document, { key: "k", metaKey: true });
+    await userEvent.type(await screen.findByRole("combobox"), "riverside");
+
+    expect(
+      await screen.findByText("the riverside stage is booked", undefined, { timeout: 2000 })
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Tab" });
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Members" })).toHaveAttribute("aria-selected", "true")
+    );
+
+    expect(screen.queryByText("the riverside stage is booked")).not.toBeInTheDocument();
+    expect(screen.getByText("No results found.")).toBeInTheDocument();
+  });
+
+  it("does not report a search that failed as nobody matching", async () => {
+    // A request that never landed says nothing about who is in the community.
+    mocks.members.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetched: true,
+      isSuccess: false,
+      isError: true,
+    });
+
+    renderPage(CommandCenter, {
+      initialRoute: "/g/$guildId",
+      routeParams: { guildId: "1" },
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    fireEvent.keyDown(document, { key: "k", metaKey: true });
+    await userEvent.type(await screen.findByRole("combobox"), "riverside");
+    await screen.findByRole("tab", { name: "Members" }, { timeout: 2000 });
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Tab" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Members" })).toHaveAttribute("aria-selected", "true")
+    );
+    expect(screen.getByText("Search is not answering")).toBeInTheDocument();
+    expect(screen.queryByText("No results found.")).not.toBeInTheDocument();
+  });
+
   it("finds a person from the palette and opens their profile", async () => {
     // Profiles are public and belong to the person, so this leaves the
     // community tree rather than routing under /c/{guild}.
@@ -423,8 +498,9 @@ describe("the command palette", () => {
       },
       isLoading: false,
       isFetched: true,
+      isSuccess: true,
     });
-    mocks.suggest.mockReturnValue({ data: [] });
+    mocks.suggest.mockReturnValue({ data: [], isFetched: true, isSuccess: true });
 
     renderPage(CommandCenter, {
       initialRoute: "/g/$guildId",

--- a/frontend/src/components/CommandCenter.tsx
+++ b/frontend/src/components/CommandCenter.tsx
@@ -172,16 +172,22 @@ export function CommandCenter() {
   // communities while the index is per-community, so they are read from the
   // roster — the same split the results page makes.
   const scopeTypes = categoryEntityTypes(scope);
+  const isMemberScope = scopeTypes === null;
   const suggestQuery = useGuildSearchSuggest(effectiveSearch, {
-    enabled: open && !!user && isSearching && scopeTypes !== null,
+    enabled: open && !!user && isSearching && !isMemberScope,
     types: scopeTypes ?? undefined,
     staleTime: 30_000,
   });
   const membersQuery = useUserSearch({
     search: effectiveSearch,
     pageSize: PALETTE_MEMBER_LIMIT,
-    enabled: open && !!user && isSearching && scopeTypes === null,
+    enabled: open && !!user && isSearching && isMemberScope,
   });
+  // Whichever of the two the reader is on — the other is switched off, and a
+  // switched-off question keeps the answer it was last given, which belongs to
+  // the tab before this one. Only the scope being read may put rows on screen
+  // or say there are none.
+  const scopeQuery = isMemberScope ? membersQuery : suggestQuery;
   // Browsing (palette just opened): the user's own not-done tasks, most
   // recently updated — surfacing what they're actively working on. Fired once
   // on open, so the full list row is fine.
@@ -222,13 +228,25 @@ export function CommandCenter() {
   // one that isn't offered.
   const suggestions = useMemo(
     () =>
-      (suggestQuery.data ?? [])
-        .map((hit) => ({ hit, path: searchHitPath(hit) }))
-        .filter((row): row is { hit: SearchSuggestion; path: string } => row.path !== null),
-    [suggestQuery.data]
+      isMemberScope
+        ? []
+        : (suggestQuery.data ?? [])
+            .map((hit) => ({ hit, path: searchHitPath(hit) }))
+            .filter((row): row is { hit: SearchSuggestion; path: string } => row.path !== null),
+    [suggestQuery.data, isMemberScope]
   );
 
-  const members = membersQuery.data?.items ?? [];
+  const members = isMemberScope ? (membersQuery.data?.items ?? []) : [];
+  // Nothing is here, and that is this scope's own answer rather than a gap
+  // before it arrives: a tab that found nobody says so instead of leaving the
+  // rows before it standing. A question that never got an answer is a third
+  // thing again — "nobody matched" would be a claim about a community nothing
+  // has been read from.
+  const scopeIsEmpty =
+    members.length === 0 &&
+    suggestions.length === 0 &&
+    scopeQuery.isSuccess &&
+    !scopeQuery.isPlaceholderData;
 
   const isGuildAdmin = activeGuild?.role === "admin";
   const showPlatformSettings = canManagePlatformConfig(user);
@@ -376,6 +394,11 @@ export function CommandCenter() {
                 </CommandItem>
               );
             })}
+            {(scopeQuery.isError || scopeIsEmpty) && (
+              <div className="py-3 text-center text-muted-foreground text-sm">
+                {scopeQuery.isError ? t("search:failed.title") : t("noResults")}
+              </div>
+            )}
             {activeGuildId !== null && (
               <CommandItem
                 value="result-see-all"

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { Loader2, Search, SearchX } from "lucide-react";
+import { Loader2, Search, SearchX, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -224,6 +224,8 @@ export function SearchPage() {
                 />
               ) : results.isLoading || outOfRange ? (
                 <Loading />
+              ) : results.isError ? (
+                <SearchFailed />
               ) : items.length === 0 ? (
                 <NoResults query={query} />
               ) : (
@@ -267,6 +269,24 @@ function Loading() {
     <div className="flex h-40 items-center justify-center">
       <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
     </div>
+  );
+}
+
+/**
+ * The question never got an answer.
+ *
+ * Distinct from nothing having matched: that is something the index said, and
+ * this is the index not having been reached. Told apart so the page does not
+ * report a community as empty on the strength of a request that failed.
+ */
+function SearchFailed() {
+  const { t } = useTranslation("search");
+  return (
+    <StatusMessage
+      icon={<TriangleAlert />}
+      title={t("failed.title")}
+      description={t("failed.description")}
+    />
   );
 }
 
@@ -349,6 +369,7 @@ function MemberResults({
 }) {
   const items = members.data?.items ?? [];
   if (members.isLoading || outOfRange) return <Loading />;
+  if (members.isError) return <SearchFailed />;
   if (items.length === 0) return <NoResults query={query} />;
   return (
     <>


### PR DESCRIPTION
## Problem

In ⌘K, switching to Members in a community where nobody matches showed the results from the tab before it — the comments you had just been reading, under a Members heading. Nothing ever said "no results found" either: `CommandEmpty` only fires when the whole list is empty, and Pages/Actions are always there.

The palette asks two questions — the roster (`useUserSearch`) for Members, the index (`useGuildSearchSuggest`) for everything else — and each tab switches the other off. Both use `placeholderData: keepPreviousData`, and a **disabled** query with a changed key keeps serving the previous key's data as placeholder forever (verified: `data` intact, `isPlaceholderData: true`, `isPending: false`). Both result sets were then rendered unconditionally, so whichever tab was left behind stayed on screen.

## Changes

- `CommandCenter` renders only the scope being read: member rows on Members, index rows on the other three.
- A tab whose own query has settled with nothing shows `command:noResults` ("No results found.") in the Results group, keeping the "See all results" row so the reader can still cross over to the full page.
- Test in `guildSearchRoute.test.tsx`: with the index still holding a comment hit, tabbing to Members drops that row and says so. It fails on `dev` (the stale row renders) and passes here.

The `/search` page is unaffected — its Members tab renders its own component, so the disabled index query's placeholder never reaches the screen.

## Testing

- `pnpm vitest run src/__tests__/guildSearchRoute.test.tsx` — 16 passed
- `pnpm typecheck`, `pnpm exec biome check` on the touched files — clean