### PR TITLE
Give somebody a way to say who can reach them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Say who can message you.** A Privacy tab under your profile settings, with one question at the top: who can ask to message you, outside your connections. *Private* means no one, *My communities* means people you share a community with, and *Anyone* means anyone here — and under it, a switch per community, all counting by default, so you can be reachable in one and not another. Asking is always a request and it is always yours to accept; nobody arrives in your messages because they found you. Messaging is for people aged 13 and over, and an account that has not answered that question yet is told so rather than left with controls that do nothing.
+
+- **Connections.** A connection is mutual, and it is how two people stay in touch after the thing that introduced them ends — you can keep messaging even once you no longer share a community. You make one by typing somebody's full handle, number included, so a private account is reached by someone who was given it rather than by being picked off a list. Requests wait in one place, either direction, and a connection you accept opens the channel with it: having agreed once, you are not asked again.
+
+- **Ignore an account.** They stop reaching you: no notification when they mention, reply to or react to you, and nothing they send arrives — messages, message requests, connection requests. You will still see each other's activity in communities you share and can use every tool normally, because ignoring is about contact rather than about work. Nothing is deleted, so if you stop ignoring them everything is exactly where it was.
+
 ## [0.65.0] - 2026-09-02
 
 ### Added

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -11,7 +11,8 @@
       "import": "Importieren",
       "security": "Sicherheit",
       "trash": "Papierkorb",
-      "danger": "Gefahrenzone"
+      "danger": "Gefahrenzone",
+      "privacy": "Privatsphäre"
     },
     "loginRequired": "Du musst angemeldet sein, um dein Profil zu verwalten.",
     "goToLogin": "Zur Anmeldung"
@@ -1148,5 +1149,55 @@
     "passwordTitle": "Passwort",
     "passwordDescription": "Hier änderst du es. Auf diesem Gerät bleibst du angemeldet.",
     "fullNameHelp": "Nur Communitys, die Klarnamen anzeigen, verwenden ihn. Überall sonst bist du dein Handle."
+  },
+  "privacy": {
+    "title": "Privatsphäre",
+    "dm": {
+      "title": "Direktnachrichten",
+      "description": "Wer dich außerhalb deiner Verbindungen um eine Nachricht bitten darf.",
+      "private": "Privat",
+      "privateHint": "Niemand.",
+      "community": "Meine Communities",
+      "communityHint": "Personen, mit denen du eine Community teilst.",
+      "public": "Alle",
+      "publicHint": "Alle auf Initiative.",
+      "communitiesTitle": "Welche Communities zählen",
+      "communitiesHint": "Standardmäßig zählen alle.",
+      "ageLocked": "Nachrichten sind ab 13 Jahren verfügbar. Du hast uns noch nicht gesagt, ob du das bist.",
+      "confirmAge": "Alter bestätigen",
+      "saved": "Gespeichert."
+    },
+    "connections": {
+      "title": "Verbindungen",
+      "description": "Verbindungen sind gegenseitig. Ihr bleibt in Kontakt, auch wenn ihr keine Community mehr teilt.",
+      "empty": "Du hast dich noch mit niemandem verbunden.",
+      "add": "Über Handle verbinden",
+      "addPlaceholder": "name#1234",
+      "addHint": "Gib das vollständige Handle inklusive Nummer ein.",
+      "send": "Anfrage senden",
+      "remove": "Entfernen",
+      "removeTitle": "Diese Verbindung entfernen?",
+      "removeKeepsChannel": "Ihr teilt eine Community, ihr könnt euch also weiterhin schreiben.",
+      "removeEndsChannel": "Damit endet auch euer Nachrichtenkanal.",
+      "connected": "Verbunden am {{date}}",
+      "sent": "Anfrage gesendet."
+    },
+    "requests": {
+      "title": "Ausstehend",
+      "empty": "Nichts offen.",
+      "wantsToConnect": "möchte sich verbinden",
+      "askedToMessage": "hat um eine Nachricht gebeten",
+      "youAskedToConnect": "du hast um Verbindung gebeten",
+      "youAskedToMessage": "du hast um eine Nachricht gebeten",
+      "accept": "Annehmen",
+      "decline": "Ablehnen",
+      "cancel": "Abbrechen"
+    },
+    "ignored": {
+      "title": "Ignorierte Konten",
+      "description": "Du wirst nicht benachrichtigt, wenn diese Konten dich erwähnen, dir antworten oder reagieren, und nichts, was sie dir senden, kommt an — Nachrichten, Nachrichtenanfragen, Verbindungsanfragen. Ihr seht weiterhin die Aktivitäten des anderen in gemeinsamen Communities und könnt alle Werkzeuge normal nutzen.",
+      "empty": "Du ignorierst niemanden.",
+      "stop": "Nicht mehr ignorieren"
+    }
   }
 }

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -11,7 +11,8 @@
       "import": "Import",
       "security": "Security",
       "trash": "Trash",
-      "danger": "Danger Zone"
+      "danger": "Danger Zone",
+      "privacy": "Privacy"
     },
     "loginRequired": "You need to be logged in to manage your profile.",
     "goToLogin": "Go to login"
@@ -1148,5 +1149,55 @@
     "passwordTitle": "Password",
     "passwordDescription": "Change it here. You will stay signed in on this device.",
     "fullNameHelp": "Only communities set to show real names use it. Everywhere else you are your handle."
+  },
+  "privacy": {
+    "title": "Privacy",
+    "dm": {
+      "title": "Direct messages",
+      "description": "Who can ask to message you, outside your connections.",
+      "private": "Private",
+      "privateHint": "No one.",
+      "community": "My communities",
+      "communityHint": "People you share a community with.",
+      "public": "Anyone",
+      "publicHint": "Anyone on Initiative.",
+      "communitiesTitle": "Which communities count",
+      "communitiesHint": "All count by default.",
+      "ageLocked": "Messaging is available to people aged 13 and over. You have not told us whether you are.",
+      "confirmAge": "Confirm my age",
+      "saved": "Saved."
+    },
+    "connections": {
+      "title": "Connections",
+      "description": "Connections are mutual. You can keep in touch even if you stop sharing a community.",
+      "empty": "You have not connected with anyone yet.",
+      "add": "Connect by handle",
+      "addPlaceholder": "name#1234",
+      "addHint": "Type someone's full handle, including the number.",
+      "send": "Send request",
+      "remove": "Remove",
+      "removeTitle": "Remove this connection?",
+      "removeKeepsChannel": "You share a community, so you will still be able to message each other.",
+      "removeEndsChannel": "This will also end your message channel with them.",
+      "connected": "Connected {{date}}",
+      "sent": "Request sent."
+    },
+    "requests": {
+      "title": "Pending",
+      "empty": "Nothing waiting.",
+      "wantsToConnect": "wants to connect",
+      "askedToMessage": "asked to message you",
+      "youAskedToConnect": "you asked to connect",
+      "youAskedToMessage": "you asked to message",
+      "accept": "Accept",
+      "decline": "Decline",
+      "cancel": "Cancel"
+    },
+    "ignored": {
+      "title": "Ignored accounts",
+      "description": "You will not be notified when these accounts mention, reply to or react to you, and nothing they send you arrives — messages, message requests, connection requests. You will still see each other's activity in communities you share, and be able to use all tools normally.",
+      "empty": "You are not ignoring anyone.",
+      "stop": "Stop ignoring"
+    }
   }
 }

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -11,7 +11,8 @@
       "import": "Importar",
       "security": "Seguridad",
       "trash": "Papelera",
-      "danger": "Zona de peligro"
+      "danger": "Zona de peligro",
+      "privacy": "Privacidad"
     },
     "loginRequired": "Necesitas iniciar sesión para administrar tu perfil.",
     "goToLogin": "Ir a inicio de sesión"
@@ -1148,5 +1149,55 @@
     "passwordTitle": "Contraseña",
     "passwordDescription": "Cámbiala aquí. Seguirás con la sesión iniciada en este dispositivo.",
     "fullNameHelp": "Solo lo usan las comunidades configuradas para mostrar nombres reales. En el resto eres tu identificador."
+  },
+  "privacy": {
+    "title": "Privacidad",
+    "dm": {
+      "title": "Mensajes directos",
+      "description": "Quién puede pedirte enviarte un mensaje, aparte de tus conexiones.",
+      "private": "Privado",
+      "privateHint": "Nadie.",
+      "community": "Mis comunidades",
+      "communityHint": "Personas con las que compartes una comunidad.",
+      "public": "Cualquiera",
+      "publicHint": "Cualquiera en Initiative.",
+      "communitiesTitle": "Qué comunidades cuentan",
+      "communitiesHint": "Todas cuentan de forma predeterminada.",
+      "ageLocked": "Los mensajes están disponibles para mayores de 13 años. Aún no nos has dicho si lo eres.",
+      "confirmAge": "Confirmar mi edad",
+      "saved": "Guardado."
+    },
+    "connections": {
+      "title": "Conexiones",
+      "description": "Las conexiones son mutuas. Podéis seguir en contacto aunque dejéis de compartir una comunidad.",
+      "empty": "Aún no te has conectado con nadie.",
+      "add": "Conectar por identificador",
+      "addPlaceholder": "nombre#1234",
+      "addHint": "Escribe el identificador completo, incluido el número.",
+      "send": "Enviar solicitud",
+      "remove": "Quitar",
+      "removeTitle": "¿Quitar esta conexión?",
+      "removeKeepsChannel": "Compartís una comunidad, así que aún podréis escribiros.",
+      "removeEndsChannel": "Esto también terminará vuestro canal de mensajes.",
+      "connected": "Conectados el {{date}}",
+      "sent": "Solicitud enviada."
+    },
+    "requests": {
+      "title": "Pendiente",
+      "empty": "Nada pendiente.",
+      "wantsToConnect": "quiere conectar",
+      "askedToMessage": "pidió enviarte un mensaje",
+      "youAskedToConnect": "pediste conectar",
+      "youAskedToMessage": "pediste enviar un mensaje",
+      "accept": "Aceptar",
+      "decline": "Rechazar",
+      "cancel": "Cancelar"
+    },
+    "ignored": {
+      "title": "Cuentas ignoradas",
+      "description": "No recibirás notificaciones cuando estas cuentas te mencionen, te respondan o reaccionen, y nada de lo que te envíen llegará: mensajes, solicitudes de mensaje, solicitudes de conexión. Seguiréis viendo la actividad del otro en las comunidades que compartís y podréis usar todas las herramientas con normalidad.",
+      "empty": "No estás ignorando a nadie.",
+      "stop": "Dejar de ignorar"
+    }
   }
 }

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -11,7 +11,8 @@
       "import": "Importer",
       "security": "Sécurité",
       "trash": "Corbeille",
-      "danger": "Zone de danger"
+      "danger": "Zone de danger",
+      "privacy": "Confidentialité"
     },
     "loginRequired": "Vous devez être connecté pour gérer votre profil.",
     "goToLogin": "Aller à la connexion"
@@ -1148,5 +1149,55 @@
     "passwordTitle": "Mot de passe",
     "passwordDescription": "Changez-le ici. Vous resterez connecté sur cet appareil.",
     "fullNameHelp": "Seules les communautés réglées pour afficher les vrais noms l'utilisent. Ailleurs, vous êtes votre pseudo."
+  },
+  "privacy": {
+    "title": "Confidentialité",
+    "dm": {
+      "title": "Messages directs",
+      "description": "Qui peut demander à vous écrire, en dehors de vos connexions.",
+      "private": "Privé",
+      "privateHint": "Personne.",
+      "community": "Mes communautés",
+      "communityHint": "Les personnes avec qui vous partagez une communauté.",
+      "public": "Tout le monde",
+      "publicHint": "Tout le monde sur Initiative.",
+      "communitiesTitle": "Quelles communautés comptent",
+      "communitiesHint": "Toutes comptent par défaut.",
+      "ageLocked": "La messagerie est réservée aux personnes de 13 ans et plus. Vous ne nous avez pas dit si c'est votre cas.",
+      "confirmAge": "Confirmer mon âge",
+      "saved": "Enregistré."
+    },
+    "connections": {
+      "title": "Connexions",
+      "description": "Les connexions sont mutuelles. Vous pouvez rester en contact même si vous ne partagez plus de communauté.",
+      "empty": "Vous n'avez encore aucune connexion.",
+      "add": "Se connecter par identifiant",
+      "addPlaceholder": "nom#1234",
+      "addHint": "Saisissez l'identifiant complet, numéro compris.",
+      "send": "Envoyer la demande",
+      "remove": "Retirer",
+      "removeTitle": "Retirer cette connexion ?",
+      "removeKeepsChannel": "Vous partagez une communauté, vous pourrez donc continuer à vous écrire.",
+      "removeEndsChannel": "Cela mettra aussi fin à votre canal de messages.",
+      "connected": "Connectés le {{date}}",
+      "sent": "Demande envoyée."
+    },
+    "requests": {
+      "title": "En attente",
+      "empty": "Rien en attente.",
+      "wantsToConnect": "souhaite se connecter",
+      "askedToMessage": "a demandé à vous écrire",
+      "youAskedToConnect": "vous avez demandé une connexion",
+      "youAskedToMessage": "vous avez demandé à écrire",
+      "accept": "Accepter",
+      "decline": "Refuser",
+      "cancel": "Annuler"
+    },
+    "ignored": {
+      "title": "Comptes ignorés",
+      "description": "Vous ne serez pas notifié lorsque ces comptes vous mentionnent, vous répondent ou réagissent, et rien de ce qu'ils vous envoient n'arrive — messages, demandes de message, demandes de connexion. Vous verrez toujours vos activités respectives dans les communautés partagées et pourrez utiliser tous les outils normalement.",
+      "empty": "Vous n'ignorez personne.",
+      "stop": "Ne plus ignorer"
+    }
   }
 }

--- a/frontend/src/components/contacts/ConnectionsSection.tsx
+++ b/frontend/src/components/contacts/ConnectionsSection.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { ContactGrantRead } from "@/api/generated/initiativeAPI.schemas";
+import { ContactPersonRow } from "@/components/contacts/ContactPersonRow";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  parseHandle,
+  useConnections,
+  useRemoveConnection,
+  useRequestConnection,
+} from "@/hooks/useDirectMessages";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
+import { formatDate } from "@/lib/formatDate";
+
+interface ConnectionsSectionProps {
+  /** Show the "connect by handle" field. Off where the page is a directory. */
+  allowAdding?: boolean;
+}
+
+/**
+ * Accepted connections, and the field that makes new ones.
+ *
+ * A connection is addressed by handle rather than picked from a list: that is
+ * the only shape that reaches an account on Private, which is never offered
+ * from a roster. Every target uses it, so there is no per-policy branch.
+ */
+export const ConnectionsSection = ({ allowAdding = true }: ConnectionsSectionProps) => {
+  const { t } = useTranslation("settings");
+  const { data } = useConnections();
+  const requestConnection = useRequestConnection();
+  const removeConnection = useRemoveConnection();
+  const [handle, setHandle] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const accepted: ContactGrantRead[] = data?.accepted ?? [];
+
+  const send = () => {
+    const parsed = parseHandle(handle);
+    if (!parsed) {
+      setError(t("privacy.connections.addHint"));
+      return;
+    }
+    setError(null);
+    requestConnection.mutate(
+      { data: parsed },
+      {
+        onSuccess: () => {
+          setHandle("");
+          toast.success(t("privacy.connections.sent"));
+        },
+        onError: (err) => setError(getErrorMessage(err, "errors:CONTACT_GRANT_CANNOT_REACH")),
+      }
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">{t("privacy.connections.description")}</p>
+
+      {allowAdding && (
+        <div className="space-y-1">
+          <div className="flex gap-2">
+            <Input
+              value={handle}
+              onChange={(event) => setHandle(event.target.value)}
+              placeholder={t("privacy.connections.addPlaceholder")}
+              aria-label={t("privacy.connections.add")}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") send();
+              }}
+            />
+            <Button onClick={send} disabled={requestConnection.isPending || !handle.trim()}>
+              {t("privacy.connections.send")}
+            </Button>
+          </div>
+          <p className={error ? "text-destructive text-xs" : "text-muted-foreground text-xs"}>
+            {error ?? t("privacy.connections.addHint")}
+          </p>
+        </div>
+      )}
+
+      {accepted.length === 0 ? (
+        <p className="text-muted-foreground text-sm">{t("privacy.connections.empty")}</p>
+      ) : (
+        <ul className="divide-y">
+          {accepted.map((connection) => (
+            <ContactPersonRow
+              key={connection.user_id}
+              user={{ ...connection, id: connection.user_id }}
+              detail={
+                connection.responded_at
+                  ? t("privacy.connections.connected", {
+                      date: formatDate(connection.responded_at),
+                    })
+                  : undefined
+              }
+            >
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => removeConnection.mutate({ userId: connection.user_id })}
+                disabled={removeConnection.isPending}
+              >
+                {t("privacy.connections.remove")}
+              </Button>
+            </ContactPersonRow>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/contacts/ContactPersonRow.tsx
+++ b/frontend/src/components/contacts/ContactPersonRow.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import { UserHandle } from "@/components/UserHandle";
+import { ProfileAvatar } from "@/components/user/ProfileAvatar";
+
+interface ContactPersonRowProps {
+  user: { id: number; username: string; discriminator: number; avatar_url?: string | null };
+  /** One line under the handle — when they connected, what they asked for. */
+  detail?: ReactNode;
+  /** The row's own controls. */
+  children?: ReactNode;
+}
+
+/**
+ * One person in a contacts *ledger* — connections, pending requests, ignored
+ * accounts — wherever that ledger is rendered.
+ *
+ * Distinct from `ContactRow`, which is the directory row on My Contacts: that
+ * one sits on the page's shared column template and links to a profile. This
+ * is a list item with buttons, and the two are not the same shape.
+ */
+export const ContactPersonRow = ({ user, detail, children }: ContactPersonRowProps) => (
+  <li className="flex items-center gap-3 py-2">
+    <ProfileAvatar user={user} className="size-8 shrink-0" />
+    <div className="min-w-0 flex-1">
+      <UserHandle user={user} className="text-sm" nameClassName="min-w-0 truncate" />
+      {detail ? <p className="truncate text-muted-foreground text-xs">{detail}</p> : null}
+    </div>
+    {children ? <div className="flex shrink-0 items-center gap-2">{children}</div> : null}
+  </li>
+);

--- a/frontend/src/components/contacts/ContactRequestsSection.tsx
+++ b/frontend/src/components/contacts/ContactRequestsSection.tsx
@@ -1,0 +1,97 @@
+import { useTranslation } from "react-i18next";
+
+import type { ContactGrantRead } from "@/api/generated/initiativeAPI.schemas";
+import { ContactPersonRow } from "@/components/contacts/ContactPersonRow";
+import { Button } from "@/components/ui/button";
+import {
+  useAcceptConnection,
+  useAcceptMessageRequest,
+  useConnections,
+  useMessageRequests,
+  useRemoveConnection,
+  useRemoveMessageRequest,
+} from "@/hooks/useDirectMessages";
+
+type Kind = "connection" | "message";
+type PendingRow = ContactGrantRead & { kind: Kind };
+
+/**
+ * Everything waiting on an answer, either way round.
+ *
+ * Both kinds in one list because they are the same question to the person
+ * reading it — somebody wants something, say yes or no — and separating them
+ * would make the reader learn a distinction the model keeps for its own
+ * reasons.
+ *
+ * A request from an account the reader ignores never arrives here: the server
+ * leaves it out, so there is nothing to filter and nothing that hints at it.
+ */
+export const ContactRequestsSection = () => {
+  const { t } = useTranslation("settings");
+  const connections = useConnections();
+  const messages = useMessageRequests();
+
+  const acceptConnection = useAcceptConnection();
+  const removeConnection = useRemoveConnection();
+  const acceptMessage = useAcceptMessageRequest();
+  const removeMessage = useRemoveMessageRequest();
+
+  const rows: PendingRow[] = [
+    ...(connections.data?.incoming ?? []).map((row) => ({ ...row, kind: "connection" as const })),
+    ...(messages.data?.incoming ?? []).map((row) => ({ ...row, kind: "message" as const })),
+    ...(connections.data?.outgoing ?? []).map((row) => ({ ...row, kind: "connection" as const })),
+    ...(messages.data?.outgoing ?? []).map((row) => ({ ...row, kind: "message" as const })),
+  ];
+
+  const detailFor = (row: PendingRow) => {
+    if (row.outgoing) {
+      return row.kind === "connection"
+        ? t("privacy.requests.youAskedToConnect")
+        : t("privacy.requests.youAskedToMessage");
+    }
+    return row.kind === "connection"
+      ? t("privacy.requests.wantsToConnect")
+      : t("privacy.requests.askedToMessage");
+  };
+
+  const accept = (row: PendingRow) =>
+    row.kind === "connection"
+      ? acceptConnection.mutate({ userId: row.user_id })
+      : acceptMessage.mutate({ userId: row.user_id });
+
+  const dismiss = (row: PendingRow) =>
+    row.kind === "connection"
+      ? removeConnection.mutate({ userId: row.user_id })
+      : removeMessage.mutate({ userId: row.user_id });
+
+  if (rows.length === 0) {
+    return <p className="text-muted-foreground text-sm">{t("privacy.requests.empty")}</p>;
+  }
+
+  return (
+    <ul className="divide-y">
+      {rows.map((row) => (
+        <ContactPersonRow
+          key={`${row.kind}-${row.user_id}`}
+          user={{ ...row, id: row.user_id }}
+          detail={detailFor(row)}
+        >
+          {row.outgoing ? (
+            <Button variant="ghost" size="sm" onClick={() => dismiss(row)}>
+              {t("privacy.requests.cancel")}
+            </Button>
+          ) : (
+            <>
+              <Button size="sm" onClick={() => accept(row)}>
+                {t("privacy.requests.accept")}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => dismiss(row)}>
+                {t("privacy.requests.decline")}
+              </Button>
+            </>
+          )}
+        </ContactPersonRow>
+      ))}
+    </ul>
+  );
+};

--- a/frontend/src/components/contacts/DirectMessagePolicyField.tsx
+++ b/frontend/src/components/contacts/DirectMessagePolicyField.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from "react-i18next";
+
+import type { CommunityDmToggle, DmPolicy } from "@/api/generated/initiativeAPI.schemas";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Switch } from "@/components/ui/switch";
+
+interface DirectMessagePolicyFieldProps {
+  policy: DmPolicy;
+  communities: CommunityDmToggle[];
+  /** Locked until the account has answered the age question. */
+  disabled?: boolean;
+  onPolicyChange: (policy: DmPolicy) => void;
+  onCommunityChange: (guildId: number, enabled: boolean) => void;
+}
+
+/**
+ * Who may ask to message this account, outside its connections.
+ *
+ * The heading scopes the whole group, so each option says only the one thing
+ * that differs between them: a connection satisfies every value, which makes
+ * it a property of the setting rather than of any option in it. That is also
+ * what lets "Private" read as "No one" without being a lie.
+ */
+export const DirectMessagePolicyField = ({
+  policy,
+  communities,
+  disabled = false,
+  onPolicyChange,
+  onCommunityChange,
+}: DirectMessagePolicyFieldProps) => {
+  const { t } = useTranslation("settings");
+  const options: { value: DmPolicy; label: string; hint: string }[] = [
+    { value: "private", label: t("privacy.dm.private"), hint: t("privacy.dm.privateHint") },
+    { value: "community", label: t("privacy.dm.community"), hint: t("privacy.dm.communityHint") },
+    { value: "public", label: t("privacy.dm.public"), hint: t("privacy.dm.publicHint") },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">{t("privacy.dm.description")}</p>
+
+      <RadioGroup
+        value={policy}
+        onValueChange={(next) => onPolicyChange(next as DmPolicy)}
+        disabled={disabled}
+        className="space-y-2"
+      >
+        {options.map((option) => (
+          <div key={option.value} className="flex items-start gap-3">
+            <RadioGroupItem
+              value={option.value}
+              id={`dm-policy-${option.value}`}
+              className="mt-1"
+            />
+            <Label htmlFor={`dm-policy-${option.value}`} className="font-normal leading-tight">
+              <span className="block font-medium">{option.label}</span>
+              <span className="block text-muted-foreground text-sm">{option.hint}</span>
+            </Label>
+          </div>
+        ))}
+      </RadioGroup>
+
+      {/* Only meaningful under `community`, and only worth showing if there is
+          more than nowhere to be reachable. */}
+      {policy === "community" && communities.length > 0 && (
+        <div className="space-y-3 border-t pt-4">
+          <div>
+            <p className="font-medium text-sm">{t("privacy.dm.communitiesTitle")}</p>
+            <p className="text-muted-foreground text-sm">{t("privacy.dm.communitiesHint")}</p>
+          </div>
+          <ul className="space-y-2">
+            {communities.map((community) => (
+              <li key={community.guild_id} className="flex items-center justify-between gap-4">
+                <Label
+                  htmlFor={`dm-community-${community.guild_id}`}
+                  className="font-normal text-sm"
+                >
+                  {community.name}
+                </Label>
+                <Switch
+                  id={`dm-community-${community.guild_id}`}
+                  checked={community.enabled}
+                  disabled={disabled}
+                  onCheckedChange={(next) => onCommunityChange(community.guild_id, next)}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/contacts/IgnoredAccountsSection.tsx
+++ b/frontend/src/components/contacts/IgnoredAccountsSection.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from "react-i18next";
+
+import { ContactPersonRow } from "@/components/contacts/ContactPersonRow";
+import { Button } from "@/components/ui/button";
+import { useIgnoredAccounts, useStopIgnoring } from "@/hooks/useDirectMessages";
+
+/**
+ * The accounts this person has chosen not to hear from.
+ *
+ * The lead line is four clauses because the word invites three wrong
+ * expectations: that only notifications stop, that it runs both ways, and that
+ * it hides them. It says nothing about what the other account sees.
+ */
+export const IgnoredAccountsSection = () => {
+  const { t } = useTranslation("settings");
+  const { data } = useIgnoredAccounts();
+  const stopIgnoring = useStopIgnoring();
+
+  const items = data?.items ?? [];
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted-foreground text-sm">{t("privacy.ignored.description")}</p>
+      {items.length === 0 ? (
+        <p className="text-muted-foreground text-sm">{t("privacy.ignored.empty")}</p>
+      ) : (
+        <ul className="divide-y">
+          {items.map((account) => (
+            <ContactPersonRow
+              key={account.user_id}
+              user={{
+                id: account.user_id,
+                username: account.username,
+                discriminator: account.discriminator,
+                avatar_url: account.avatar_url,
+              }}
+            >
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => stopIgnoring.mutate({ userId: account.user_id })}
+                disabled={stopIgnoring.isPending}
+              >
+                {t("privacy.ignored.stop")}
+              </Button>
+            </ContactPersonRow>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useDirectMessages.test.tsx
+++ b/frontend/src/hooks/useDirectMessages.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * What every contacts mutation does when it fails.
+ *
+ * These are ordinary conflicts, not bugs — accepting a request that was
+ * withdrawn a moment ago, removing a connection somebody else already removed.
+ * The lists refresh either way, so with nothing said the row just changes under
+ * the reader. There is no global mutation error handler, so this is the only
+ * thing standing between a failed action and silence.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+
+vi.mock("@/lib/chesterToast", () => ({
+  toast: { error: mocks.error, success: mocks.success },
+}));
+
+const failing = { response: { status: 409, data: { detail: "CONTACT_GRANT_CANNOT_REACH" } } };
+
+vi.mock("@/api/generated/direct-messages/direct-messages", () => {
+  const make = (options?: { mutation?: { onError?: (e: unknown) => void } }) => ({
+    mutate: () => options?.mutation?.onError?.(failing),
+    isPending: false,
+  });
+  return {
+    useAcceptConnectionApiV1MeConnectionsUserIdAcceptPost: make,
+    useAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost: make,
+    useIgnoreAccountApiV1MeIgnoredUserIdPut: make,
+    useRemoveConnectionApiV1MeConnectionsUserIdDelete: make,
+    useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete: make,
+    useRequestConnectionApiV1MeConnectionsPost: make,
+    useRequestMessageApiV1MeMessageRequestsPost: make,
+    useStopIgnoringAccountApiV1MeIgnoredUserIdDelete: make,
+    useUpdateDmSettingsApiV1MeDmSettingsPatch: make,
+    useListConnectionsApiV1MeConnectionsGet: () => ({ data: undefined }),
+    useListIgnoredAccountsApiV1MeIgnoredGet: () => ({ data: undefined }),
+    useListMessageRequestsApiV1MeMessageRequestsGet: () => ({ data: undefined }),
+    useReadDmSettingsApiV1MeDmSettingsGet: () => ({ data: undefined }),
+  };
+});
+
+import {
+  parseHandle,
+  useAcceptConnection,
+  useRemoveConnection,
+  useRequestConnection,
+  useStopIgnoring,
+} from "./useDirectMessages";
+
+describe("contacts mutations", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    ["accepting a connection", useAcceptConnection],
+    ["removing a connection", useRemoveConnection],
+    ["stopping ignoring", useStopIgnoring],
+  ])("says so when %s fails", async (_label, useMutation) => {
+    const { result } = renderHook(() => useMutation());
+
+    result.current.mutate({ userId: 1 });
+
+    await waitFor(() => expect(mocks.error).toHaveBeenCalledTimes(1));
+  });
+
+  it("leaves the connect-by-handle field to report its own", () => {
+    const { result } = renderHook(() => useRequestConnection());
+
+    result.current.mutate({ data: { username: "nobody", discriminator: 1 } });
+
+    // Reported next to the input instead, where the mistake usually is.
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseHandle", () => {
+  it.each([
+    ["ada#1234", { username: "ada", discriminator: 1234 }],
+    ["@ada#1234", { username: "ada", discriminator: 1234 }],
+    ["  ada#0007  ", { username: "ada", discriminator: 7 }],
+  ])("reads %s", (raw, expected) => {
+    expect(parseHandle(raw)).toEqual(expected);
+  });
+
+  it.each(["ada", "ada#", "#1234", "ada#12345", "ada 1234"])("refuses %s", (raw) => {
+    expect(parseHandle(raw)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useDirectMessages.ts
+++ b/frontend/src/hooks/useDirectMessages.ts
@@ -1,0 +1,88 @@
+/**
+ * Who may reach this account, and who it has agreed something with.
+ *
+ * Three lists that move together — accepting a connection opens a channel,
+ * leaving a community closes one — so every mutation here invalidates all of
+ * them, the same set the `contacts` realtime frame invalidates. A tab that
+ * acted and a tab that only watched end up saying the same thing.
+ */
+
+import { useCallback } from "react";
+
+import {
+  useAcceptConnectionApiV1MeConnectionsUserIdAcceptPost,
+  useAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost,
+  useIgnoreAccountApiV1MeIgnoredUserIdPut,
+  useListConnectionsApiV1MeConnectionsGet,
+  useListIgnoredAccountsApiV1MeIgnoredGet,
+  useListMessageRequestsApiV1MeMessageRequestsGet,
+  useReadDmSettingsApiV1MeDmSettingsGet,
+  useRemoveConnectionApiV1MeConnectionsUserIdDelete,
+  useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete,
+  useRequestConnectionApiV1MeConnectionsPost,
+  useRequestMessageApiV1MeMessageRequestsPost,
+  useStopIgnoringAccountApiV1MeIgnoredUserIdDelete,
+  useUpdateDmSettingsApiV1MeDmSettingsPatch,
+} from "@/api/generated/direct-messages/direct-messages";
+import {
+  invalidateContactGrants,
+  invalidateDmSettings,
+  invalidateIgnoredAccounts,
+} from "@/api/query-keys";
+
+/** Everything a change to one of these lists can affect. */
+export const refreshContactLists = () => {
+  void invalidateContactGrants();
+  void invalidateIgnoredAccounts();
+  void invalidateDmSettings();
+};
+
+const onSettled = { mutation: { onSettled: refreshContactLists } };
+
+// ── Reads ───────────────────────────────────────────────────────────────────
+
+export const useDmSettings = () => useReadDmSettingsApiV1MeDmSettingsGet();
+export const useConnections = () => useListConnectionsApiV1MeConnectionsGet();
+export const useMessageRequests = () => useListMessageRequestsApiV1MeMessageRequestsGet();
+export const useIgnoredAccounts = () => useListIgnoredAccountsApiV1MeIgnoredGet();
+
+// ── Writes ──────────────────────────────────────────────────────────────────
+
+export const useUpdateDmSettings = () => useUpdateDmSettingsApiV1MeDmSettingsPatch(onSettled);
+
+export const useRequestConnection = () => useRequestConnectionApiV1MeConnectionsPost(onSettled);
+export const useAcceptConnection = () =>
+  useAcceptConnectionApiV1MeConnectionsUserIdAcceptPost(onSettled);
+export const useRemoveConnection = () =>
+  useRemoveConnectionApiV1MeConnectionsUserIdDelete(onSettled);
+
+export const useRequestMessage = () => useRequestMessageApiV1MeMessageRequestsPost(onSettled);
+export const useAcceptMessageRequest = () =>
+  useAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost(onSettled);
+export const useRemoveMessageRequest = () =>
+  useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete(onSettled);
+
+export const useIgnoreAccount = () => useIgnoreAccountApiV1MeIgnoredUserIdPut(onSettled);
+export const useStopIgnoring = () => useStopIgnoringAccountApiV1MeIgnoredUserIdDelete(onSettled);
+
+/**
+ * A handle typed as `name#1234`, split for the connection endpoint.
+ *
+ * A connection is addressed by handle whatever the target's policy: it is the
+ * only shape that reaches an account on Private, which is never offered from a
+ * roster or a picker.
+ */
+export const parseHandle = (raw: string): { username: string; discriminator: number } | null => {
+  const match = /^@?([^#\s]{1,32})#(\d{1,4})$/.exec(raw.trim());
+  if (!match) return null;
+  return { username: match[1], discriminator: Number(match[2]) };
+};
+
+/** Whether this account has answered the age question, which gates everything. */
+export const useCanUseDirectMessages = (): boolean => {
+  const { data } = useDmSettings();
+  return Boolean(data?.age_confirmed_at);
+};
+
+/** One place for "these lists moved", for callers outside a mutation. */
+export const useRefreshContacts = () => useCallback(refreshContactLists, []);

--- a/frontend/src/hooks/useDirectMessages.ts
+++ b/frontend/src/hooks/useDirectMessages.ts
@@ -29,6 +29,8 @@ import {
   invalidateDmSettings,
   invalidateIgnoredAccounts,
 } from "@/api/query-keys";
+import { toast } from "@/lib/chesterToast";
+import { getErrorMessage } from "@/lib/errorMessage";
 
 /** Everything a change to one of these lists can affect. */
 export const refreshContactLists = () => {
@@ -37,7 +39,29 @@ export const refreshContactLists = () => {
   void invalidateDmSettings();
 };
 
-const onSettled = { mutation: { onSettled: refreshContactLists } };
+/**
+ * What every one of these mutations does on the way out.
+ *
+ * `onSettled` refreshes all three lists; `onError` says so out loud. These are
+ * ordinary conflicts rather than bugs — accepting a request that was withdrawn
+ * a moment ago, removing a connection somebody else already removed — and the
+ * lists refresh either way, so without a word the row simply changes under the
+ * reader with nothing to explain it. There is no global mutation error handler
+ * to fall back on, so it lives here rather than at each call site.
+ */
+const reportAndRefresh = {
+  mutation: {
+    onSettled: refreshContactLists,
+    onError: (error: unknown) =>
+      toast.error(getErrorMessage(error, "errors:CONTACT_GRANT_CANNOT_REACH")),
+  },
+};
+
+/**
+ * The same, minus the toast: the connect-by-handle field reports next to the
+ * input, where the mistake usually is.
+ */
+const refreshOnly = { mutation: { onSettled: refreshContactLists } };
 
 // ── Reads ───────────────────────────────────────────────────────────────────
 
@@ -48,22 +72,25 @@ export const useIgnoredAccounts = () => useListIgnoredAccountsApiV1MeIgnoredGet(
 
 // ── Writes ──────────────────────────────────────────────────────────────────
 
-export const useUpdateDmSettings = () => useUpdateDmSettingsApiV1MeDmSettingsPatch(onSettled);
+export const useUpdateDmSettings = () =>
+  useUpdateDmSettingsApiV1MeDmSettingsPatch(reportAndRefresh);
 
-export const useRequestConnection = () => useRequestConnectionApiV1MeConnectionsPost(onSettled);
+export const useRequestConnection = () => useRequestConnectionApiV1MeConnectionsPost(refreshOnly);
 export const useAcceptConnection = () =>
-  useAcceptConnectionApiV1MeConnectionsUserIdAcceptPost(onSettled);
+  useAcceptConnectionApiV1MeConnectionsUserIdAcceptPost(reportAndRefresh);
 export const useRemoveConnection = () =>
-  useRemoveConnectionApiV1MeConnectionsUserIdDelete(onSettled);
+  useRemoveConnectionApiV1MeConnectionsUserIdDelete(reportAndRefresh);
 
-export const useRequestMessage = () => useRequestMessageApiV1MeMessageRequestsPost(onSettled);
+export const useRequestMessage = () =>
+  useRequestMessageApiV1MeMessageRequestsPost(reportAndRefresh);
 export const useAcceptMessageRequest = () =>
-  useAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost(onSettled);
+  useAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost(reportAndRefresh);
 export const useRemoveMessageRequest = () =>
-  useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete(onSettled);
+  useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete(reportAndRefresh);
 
-export const useIgnoreAccount = () => useIgnoreAccountApiV1MeIgnoredUserIdPut(onSettled);
-export const useStopIgnoring = () => useStopIgnoringAccountApiV1MeIgnoredUserIdDelete(onSettled);
+export const useIgnoreAccount = () => useIgnoreAccountApiV1MeIgnoredUserIdPut(reportAndRefresh);
+export const useStopIgnoring = () =>
+  useStopIgnoringAccountApiV1MeIgnoredUserIdDelete(reportAndRefresh);
 
 /**
  * A handle typed as `name#1234`, split for the connection endpoint.

--- a/frontend/src/pages/user/settings/UserSettingsLayout.test.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsLayout.test.tsx
@@ -76,4 +76,22 @@ describe("the settings tabs", () => {
 
     expect(await screen.findByRole("tab", { name: "AI" })).toBeInTheDocument();
   });
+
+  it("offers the Privacy tab, and its path resolves to a real route", async () => {
+    answerWith([connection()]);
+    const { createRouter } = await import("@tanstack/react-router");
+    const { routeTree } = await import("@/routeTree.gen");
+
+    renderPage(UserSettingsLayout);
+    expect(await screen.findByRole("tab", { name: /privacy/i })).toBeInTheDocument();
+
+    // Resolved through a real router over the generated tree: a tab pointing
+    // at a path nothing registered would render exactly the same.
+    const router = createRouter({ routeTree });
+    const matches = router.matchRoutes(
+      { pathname: "/profile/privacy", search: {} },
+      { preload: true }
+    );
+    expect(String(matches.at(-1)?.routeId)).toContain("profile/privacy");
+  });
 });

--- a/frontend/src/pages/user/settings/UserSettingsLayout.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsLayout.tsx
@@ -13,6 +13,7 @@ const userSettingsTabs = [
   { value: "account", labelKey: "layout.tabs.account", path: "/profile/account" },
   { value: "interface", labelKey: "layout.tabs.interface", path: "/profile/interface" },
   { value: "notifications", labelKey: "layout.tabs.notifications", path: "/profile/notifications" },
+  { value: "privacy", labelKey: "layout.tabs.privacy", path: "/profile/privacy" },
   { value: "ai", labelKey: "layout.tabs.ai", path: "/profile/ai" },
   { value: "import", labelKey: "layout.tabs.import", path: "/profile/import" },
   { value: "security", labelKey: "layout.tabs.security", path: "/profile/security" },

--- a/frontend/src/pages/user/settings/UserSettingsPrivacyPage.test.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsPrivacyPage.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * The Privacy tab.
+ *
+ * The two worth keeping are about the age question, which gates every one of
+ * these controls on every deployment: an account that has not answered it can
+ * choose no policy, and is told why rather than left with a dead radio group.
+ */
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+
+import { UserSettingsPrivacyPage } from "./UserSettingsPrivacyPage";
+
+const mocks = vi.hoisted(() => ({
+  settings: vi.fn(),
+  update: vi.fn(),
+  connections: vi.fn(),
+  messages: vi.fn(),
+  ignored: vi.fn(),
+  noop: vi.fn(),
+}));
+
+vi.mock("@/hooks/useDirectMessages", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/useDirectMessages")>()),
+  useDmSettings: () => mocks.settings(),
+  useUpdateDmSettings: () => ({ mutate: mocks.update, isPending: false }),
+  useConnections: () => mocks.connections(),
+  useMessageRequests: () => mocks.messages(),
+  useIgnoredAccounts: () => mocks.ignored(),
+  useRequestConnection: () => ({ mutate: mocks.noop, isPending: false }),
+  useRemoveConnection: () => ({ mutate: mocks.noop, isPending: false }),
+  useAcceptConnection: () => ({ mutate: mocks.noop, isPending: false }),
+  useAcceptMessageRequest: () => ({ mutate: mocks.noop, isPending: false }),
+  useRemoveMessageRequest: () => ({ mutate: mocks.noop, isPending: false }),
+  useStopIgnoring: () => ({ mutate: mocks.noop, isPending: false }),
+}));
+
+const dmSettings = (overrides: Record<string, unknown> = {}) => ({
+  data: {
+    dm_policy: "private",
+    age_confirmed_at: "2026-01-01T00:00:00Z",
+    communities: [{ guild_id: 1, name: "Ravenloft Table", icon_url: null, enabled: true }],
+    ...overrides,
+  },
+  isLoading: false,
+});
+
+describe("UserSettingsPrivacyPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settings.mockReturnValue(dmSettings());
+    mocks.connections.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
+    mocks.messages.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
+    mocks.ignored.mockReturnValue({ data: { items: [], total: 0 } });
+  });
+
+  it("offers the three options the rule has, and nothing else", async () => {
+    renderPage(UserSettingsPrivacyPage);
+
+    expect(await screen.findByRole("radio", { name: /private/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /communities/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /anyone/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(3);
+  });
+
+  it("locks the policy and says why until the age question is answered", async () => {
+    mocks.settings.mockReturnValue(dmSettings({ age_confirmed_at: null }));
+
+    renderPage(UserSettingsPrivacyPage);
+
+    expect(await screen.findByText(/13 and over/i)).toBeInTheDocument();
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toBeDisabled();
+    }
+  });
+
+  it("shows the community toggles only under My communities", async () => {
+    renderPage(UserSettingsPrivacyPage);
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+
+    mocks.settings.mockReturnValue(dmSettings({ dm_policy: "community" }));
+    renderPage(UserSettingsPrivacyPage);
+
+    expect(await screen.findByRole("switch", { name: /ravenloft/i })).toBeInTheDocument();
+  });
+
+  it("writes only the half that changed", async () => {
+    renderPage(UserSettingsPrivacyPage);
+
+    await userEvent.click(await screen.findByRole("radio", { name: /anyone/i }));
+
+    expect(mocks.update).toHaveBeenCalledWith({ data: { dm_policy: "public" } }, expect.anything());
+  });
+
+  it("says nothing about who ignored whom", async () => {
+    mocks.ignored.mockReturnValue({
+      data: {
+        items: [
+          {
+            user_id: 7,
+            username: "bram",
+            discriminator: 4410,
+            avatar_url: null,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        total: 1,
+      },
+    });
+
+    renderPage(UserSettingsPrivacyPage);
+
+    // The list is the holder's own, and the copy stays on what it does for
+    // them — never on what the other account can tell.
+    const ignored = await screen.findByText(/bram/i);
+    expect(ignored).toBeInTheDocument();
+    expect(screen.queryByText(/they will not know/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/notified that/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/user/settings/UserSettingsPrivacyPage.tsx
+++ b/frontend/src/pages/user/settings/UserSettingsPrivacyPage.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from "react-i18next";
+
+import type { DmPolicy } from "@/api/generated/initiativeAPI.schemas";
+import { ConnectionsSection } from "@/components/contacts/ConnectionsSection";
+import { ContactRequestsSection } from "@/components/contacts/ContactRequestsSection";
+import { DirectMessagePolicyField } from "@/components/contacts/DirectMessagePolicyField";
+import { IgnoredAccountsSection } from "@/components/contacts/IgnoredAccountsSection";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { useDmSettings, useUpdateDmSettings } from "@/hooks/useDirectMessages";
+import { toast } from "@/lib/chesterToast";
+
+/**
+ * Who may reach this account.
+ *
+ * The policy says who may ask; the three lists under it are the standing
+ * exceptions to it — connections ask whatever it says, pending requests are
+ * asking to become one of those, and ignored accounts are the refusal that
+ * outranks all of it. Read top to bottom the tab answers one question.
+ */
+export const UserSettingsPrivacyPage = () => {
+  const { t } = useTranslation("settings");
+  const { data, isLoading } = useDmSettings();
+  const updateSettings = useUpdateDmSettings();
+
+  // The age question gates everything, on every deployment — there is no
+  // policy to choose while it is unanswered.
+  const ageConfirmed = Boolean(data?.age_confirmed_at);
+
+  const save = (body: Parameters<typeof updateSettings.mutate>[0]["data"]) =>
+    updateSettings.mutate(
+      { data: body },
+      { onSuccess: () => toast.success(t("privacy.dm.saved")) }
+    );
+
+  return (
+    <div className="space-y-6">
+      <SettingsSection title={t("privacy.dm.title")}>
+        {!ageConfirmed && !isLoading && (
+          <p className="rounded-md border border-dashed p-3 text-muted-foreground text-sm">
+            {t("privacy.dm.ageLocked")}
+          </p>
+        )}
+        <DirectMessagePolicyField
+          policy={(data?.dm_policy ?? "private") as DmPolicy}
+          communities={data?.communities ?? []}
+          disabled={!ageConfirmed || updateSettings.isPending}
+          onPolicyChange={(policy) => save({ dm_policy: policy })}
+          onCommunityChange={(guildId, enabled) =>
+            save({ communities: [{ guild_id: guildId, enabled }] })
+          }
+        />
+      </SettingsSection>
+
+      <SettingsSection title={t("privacy.connections.title")}>
+        <ConnectionsSection />
+        <div className="space-y-2 border-t pt-4">
+          <p className="font-medium text-sm">{t("privacy.requests.title")}</p>
+          <ContactRequestsSection />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title={t("privacy.ignored.title")}>
+        <IgnoredAccountsSection />
+      </SettingsSection>
+    </div>
+  );
+};

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as ServerRequiredAuthenticatedProfileDangerRouteImport } from './
 import { Route as ServerRequiredAuthenticatedProfileImportRouteImport } from './routes/_serverRequired/_authenticated/profile/import'
 import { Route as ServerRequiredAuthenticatedProfileInterfaceRouteImport } from './routes/_serverRequired/_authenticated/profile/interface'
 import { Route as ServerRequiredAuthenticatedProfileNotificationsRouteImport } from './routes/_serverRequired/_authenticated/profile/notifications'
+import { Route as ServerRequiredAuthenticatedProfilePrivacyRouteImport } from './routes/_serverRequired/_authenticated/profile/privacy'
 import { Route as ServerRequiredAuthenticatedProfileSecurityRouteImport } from './routes/_serverRequired/_authenticated/profile/security'
 import { Route as ServerRequiredAuthenticatedProfileTrashRouteImport } from './routes/_serverRequired/_authenticated/profile/trash'
 import { Route as ServerRequiredAuthenticatedSettingsAdminRouteImport } from './routes/_serverRequired/_authenticated/settings/admin'
@@ -359,6 +360,12 @@ const ServerRequiredAuthenticatedProfileNotificationsRoute =
   ServerRequiredAuthenticatedProfileNotificationsRouteImport.update({
     id: '/notifications',
     path: '/notifications',
+    getParentRoute: () => ServerRequiredAuthenticatedProfileRoute,
+  } as any)
+const ServerRequiredAuthenticatedProfilePrivacyRoute =
+  ServerRequiredAuthenticatedProfilePrivacyRouteImport.update({
+    id: '/privacy',
+    path: '/privacy',
     getParentRoute: () => ServerRequiredAuthenticatedProfileRoute,
   } as any)
 const ServerRequiredAuthenticatedProfileSecurityRoute =
@@ -1161,6 +1168,7 @@ export interface FileRoutesByFullPath {
   '/profile/import': typeof ServerRequiredAuthenticatedProfileImportRoute
   '/profile/interface': typeof ServerRequiredAuthenticatedProfileInterfaceRoute
   '/profile/notifications': typeof ServerRequiredAuthenticatedProfileNotificationsRoute
+  '/profile/privacy': typeof ServerRequiredAuthenticatedProfilePrivacyRoute
   '/profile/security': typeof ServerRequiredAuthenticatedProfileSecurityRoute
   '/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
   '/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminRouteWithChildren
@@ -1296,6 +1304,7 @@ export interface FileRoutesByTo {
   '/profile/import': typeof ServerRequiredAuthenticatedProfileImportRoute
   '/profile/interface': typeof ServerRequiredAuthenticatedProfileInterfaceRoute
   '/profile/notifications': typeof ServerRequiredAuthenticatedProfileNotificationsRoute
+  '/profile/privacy': typeof ServerRequiredAuthenticatedProfilePrivacyRoute
   '/profile/security': typeof ServerRequiredAuthenticatedProfileSecurityRoute
   '/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
   '/u/$handle': typeof ServerRequiredAuthenticatedUHandleRoute
@@ -1424,6 +1433,7 @@ export interface FileRoutesById {
   '/_serverRequired/_authenticated/profile/import': typeof ServerRequiredAuthenticatedProfileImportRoute
   '/_serverRequired/_authenticated/profile/interface': typeof ServerRequiredAuthenticatedProfileInterfaceRoute
   '/_serverRequired/_authenticated/profile/notifications': typeof ServerRequiredAuthenticatedProfileNotificationsRoute
+  '/_serverRequired/_authenticated/profile/privacy': typeof ServerRequiredAuthenticatedProfilePrivacyRoute
   '/_serverRequired/_authenticated/profile/security': typeof ServerRequiredAuthenticatedProfileSecurityRoute
   '/_serverRequired/_authenticated/profile/trash': typeof ServerRequiredAuthenticatedProfileTrashRoute
   '/_serverRequired/_authenticated/settings/admin': typeof ServerRequiredAuthenticatedSettingsAdminRouteWithChildren
@@ -1563,6 +1573,7 @@ export interface FileRouteTypes {
     | '/profile/import'
     | '/profile/interface'
     | '/profile/notifications'
+    | '/profile/privacy'
     | '/profile/security'
     | '/profile/trash'
     | '/settings/admin'
@@ -1698,6 +1709,7 @@ export interface FileRouteTypes {
     | '/profile/import'
     | '/profile/interface'
     | '/profile/notifications'
+    | '/profile/privacy'
     | '/profile/security'
     | '/profile/trash'
     | '/u/$handle'
@@ -1825,6 +1837,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/_authenticated/profile/import'
     | '/_serverRequired/_authenticated/profile/interface'
     | '/_serverRequired/_authenticated/profile/notifications'
+    | '/_serverRequired/_authenticated/profile/privacy'
     | '/_serverRequired/_authenticated/profile/security'
     | '/_serverRequired/_authenticated/profile/trash'
     | '/_serverRequired/_authenticated/settings/admin'
@@ -2193,6 +2206,13 @@ declare module '@tanstack/react-router' {
       path: '/notifications'
       fullPath: '/profile/notifications'
       preLoaderRoute: typeof ServerRequiredAuthenticatedProfileNotificationsRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedProfileRoute
+    }
+    '/_serverRequired/_authenticated/profile/privacy': {
+      id: '/_serverRequired/_authenticated/profile/privacy'
+      path: '/privacy'
+      fullPath: '/profile/privacy'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedProfilePrivacyRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedProfileRoute
     }
     '/_serverRequired/_authenticated/profile/security': {
@@ -2905,6 +2925,7 @@ interface ServerRequiredAuthenticatedProfileRouteChildren {
   ServerRequiredAuthenticatedProfileImportRoute: typeof ServerRequiredAuthenticatedProfileImportRoute
   ServerRequiredAuthenticatedProfileInterfaceRoute: typeof ServerRequiredAuthenticatedProfileInterfaceRoute
   ServerRequiredAuthenticatedProfileNotificationsRoute: typeof ServerRequiredAuthenticatedProfileNotificationsRoute
+  ServerRequiredAuthenticatedProfilePrivacyRoute: typeof ServerRequiredAuthenticatedProfilePrivacyRoute
   ServerRequiredAuthenticatedProfileSecurityRoute: typeof ServerRequiredAuthenticatedProfileSecurityRoute
   ServerRequiredAuthenticatedProfileTrashRoute: typeof ServerRequiredAuthenticatedProfileTrashRoute
   ServerRequiredAuthenticatedProfileIndexRoute: typeof ServerRequiredAuthenticatedProfileIndexRoute
@@ -2924,6 +2945,8 @@ const ServerRequiredAuthenticatedProfileRouteChildren: ServerRequiredAuthenticat
       ServerRequiredAuthenticatedProfileInterfaceRoute,
     ServerRequiredAuthenticatedProfileNotificationsRoute:
       ServerRequiredAuthenticatedProfileNotificationsRoute,
+    ServerRequiredAuthenticatedProfilePrivacyRoute:
+      ServerRequiredAuthenticatedProfilePrivacyRoute,
     ServerRequiredAuthenticatedProfileSecurityRoute:
       ServerRequiredAuthenticatedProfileSecurityRoute,
     ServerRequiredAuthenticatedProfileTrashRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/profile/privacy.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/profile/privacy.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { lazy, Suspense } from "react";
+
+const UserSettingsPrivacyPage = lazy(() =>
+  import("@/pages/user/settings/UserSettingsPrivacyPage").then((m) => ({
+    default: m.UserSettingsPrivacyPage,
+  }))
+);
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/profile/privacy")({
+  component: PrivacyPage,
+});
+
+function PrivacyPage() {
+  return (
+    <Suspense fallback={null}>
+      <UserSettingsPrivacyPage />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Problem

Four PRs of backend and nothing a person can touch. This is the Privacy tab —
the policy, its per-community switches, connections, what is pending, and the
ignore list — which makes the whole thing usable.

Sixth of seven; My Contacts integration is the last.

Design doc: `history/dm-connections-blocks-design.md` (local, gitignored).

## The tab

```
Direct messages
  Who can ask to message you, outside your connections.

  ( ) Private          No one.
  (•) My communities   People you share a community with.
  ( ) Anyone           Anyone on Initiative.

  Which communities count                    [all count by default]
    Ravenloft Table   [on ]     Sunday Sci-Fi   [off]

Connections            + connect by handle (name#1234)
  Pending              incoming and outgoing, both kinds

Ignored accounts
```

**The heading scopes the group**, so each option says only what differs between
them. A connection satisfies every value, which makes it a property of the
setting rather than of any option — and that is what lets *Private* read as
*No one* without being a lie. An earlier draft had it as "No one can send you a
message request", which stopped being true once connections became the key that
fits every lock.

**The community switches carry no explanation.** A labelled switch under *Which
communities count* has already said what switching one off does.

**The three lists are the standing exceptions to the policy above them** —
connections ask whatever it says, pending requests are asking to become one,
ignored accounts are the refusal that outranks all of it. Read top to bottom
the tab answers one question, which is why the ignore list is here rather than
somewhere else.

## Notes for review

- **A connection is addressed by handle**, whatever the target's policy — the
  only shape that reaches an account on Private, and one shape means no
  per-policy branch.
- **Both kinds of pending request share a list.** To the person reading it they
  are the same question; the model's distinction is for its own reasons.
- **The age question disables the policy group and says why**, rather than
  leaving a radio group that does nothing.
- **`ConnectionsSection`, `ContactRequestsSection` and `IgnoredAccountsSection`
  are components, not page code** — My Contacts renders the same ones in the
  next PR rather than a second copy. `ContactPersonRow` is deliberately
  separate from the existing `ContactRow`: that one is the directory row on the
  shared column template, this is a ledger row with buttons.
- **The Privacy tab test asserts its path resolves through a real router** over
  `routeTree.gen`, because a tab pointing at a path nothing registered renders
  exactly the same as one that works.

## Testing

```
pnpm test:run     221 files, 2447 passed
pnpm lint         clean
tsc --noEmit      clean
```

## Changelog

The entry lands here — three bullets covering the policy, connections and
ignoring — because this is the first PR where any of it can be done.

## What is not here

My Contacts still shows every member of every community, unfiltered, and has no
Connections section. That is the last PR: the roster filter, the sections above
Favorites, and the empty states.
