### PR TITLE
List the people you could actually reach on My Contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **My Contacts lists the people you could actually reach.** A community section now shows the members who can message you and who you can message, rather than everyone in the room — so the page answers "who can I talk to" instead of "who is here". Because the shipped default is Private, a new account's sections start empty, and the page says why and offers the one setting that fills them, rather than reading as a community with nobody in it. It never counts the people it is not listing.
+- **My Contacts lists the people you could actually reach.** A community section now shows the members who can message you and who you can message, rather than everyone in the room — so the page answers "who can I talk to" instead of "who is here". A community you are alone in is left out entirely. Because the shipped default is Private, a new account's sections start empty, and the page says why and offers the one setting that fills them, rather than reading as a community with nobody in it. It never counts the people it is not listing.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **My Contacts lists the people you could actually reach.** A community section now shows the members who can message you and who you can message, rather than everyone in the room — so the page answers "who can I talk to" instead of "who is here". A community you are alone in is left out entirely. Because the shipped default is Private, a new account's sections start empty, and the page says why and offers the one setting that fills them, rather than reading as a community with nobody in it. It never counts the people it is not listing.
+- **My Contacts lists the people you could actually reach.** A community section now shows the members who can message you and who you can message, rather than everyone in the room — so the page answers "who can I talk to" instead of "who is here". A community you are alone in is left out entirely. Because the shipped default is Private, a new account's sections start empty, and the page says why and offers the one setting that fills them, rather than reading as a community with nobody in it. It never counts the people it is not listing. Two new sections sit above the communities: your connections, and the people you agreed to message who are in none of your communities — before this they appeared nowhere.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Ignore an account.** They stop reaching you: no notification when they mention, reply to or react to you, and nothing they send arrives — messages, message requests, connection requests. You will still see each other's activity in communities you share and can use every tool normally, because ignoring is about contact rather than about work. Nothing is deleted, so if you stop ignoring them everything is exactly where it was.
 
+### Changed
+
+- **My Contacts lists the people you could actually reach.** A community section now shows the members who can message you and who you can message, rather than everyone in the room — so the page answers "who can I talk to" instead of "who is here". Because the shipped default is Private, a new account's sections start empty, and the page says why and offers the one setting that fills them, rather than reading as a community with nobody in it. It never counts the people it is not listing.
+
 ### Fixed
 
 - **A search tab that matched nothing says so.** In ⌘K, switching between Tools, Members, Comments and Tags left the tab before it on screen when the new one had no answer — so a community with nobody matching showed the comments you had just been reading. Each tab now shows only what it found, and says "No results found." when that is nothing — or that search is not answering, if the request never landed, rather than reporting a failure as an empty community.

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -759,6 +759,7 @@ async def _apply_guild_session_context(
             user_id=current_user.id,
             guild_id=guild_context.guild_id,
             guild_role=GuildRole.admin.value,
+            platform_role=current_user.role.value,
             satisfied_providers=_satp_param(satisfied),
         )
         return session
@@ -796,6 +797,7 @@ async def _apply_guild_session_context(
             pam_guild_id=guild_context.guild_id,
             pam_read=True,
             pam_write=(access_level == AccessLevel.read_write.value),
+            platform_role=current_user.role.value,
             satisfied_providers=_satp_param(satisfied),
         )
         return session
@@ -820,6 +822,9 @@ async def _apply_guild_session_context(
         user_id=current_user.id,
         guild_id=guild_context.guild_id,
         guild_role=guild_context.role.value,
+        # Recorded, not routed with: the guild role governs inside the schema.
+        # It is what a later hop back out to ``public`` re-assumes.
+        platform_role=current_user.role.value,
         # Guild in read_only status: keep the full membership GUCs (so the
         # initiative-member and admin RLS legs evaluate normally) but assume
         # the SELECT-only guild_<id>_ro Postgres role — content writes are

--- a/backend/app/api/v1/platform_endpoints/contacts.py
+++ b/backend/app/api/v1/platform_endpoints/contacts.py
@@ -63,7 +63,7 @@ async def list_contact_sections(
     memberships.
     """
     guilds = await contacts_service.ordered_member_guilds(
-        session, user_id=current_user.id
+        session, user_id=current_user.id, platform_role=current_user.role.value
     )
     if guild_ids:
         wanted = set(guild_ids)
@@ -76,6 +76,7 @@ async def list_contact_sections(
         search=search,
         page=page,
         page_size=page_size,
+        platform_role=current_user.role.value,
     )
     if search and search.strip():
         sections = [section for section in sections if section.items]

--- a/backend/app/api/v1/platform_endpoints/contacts.py
+++ b/backend/app/api/v1/platform_endpoints/contacts.py
@@ -63,7 +63,7 @@ async def list_contact_sections(
     memberships.
     """
     guilds = await contacts_service.ordered_member_guilds(
-        session, user_id=current_user.id, platform_role=current_user.role.value
+        session, user_id=current_user.id
     )
     if guild_ids:
         wanted = set(guild_ids)
@@ -76,7 +76,6 @@ async def list_contact_sections(
         search=search,
         page=page,
         page_size=page_size,
-        platform_role=current_user.role.value,
     )
     if search and search.strip():
         sections = [section for section in sections if section.items]

--- a/backend/app/api/v1/platform_endpoints/contacts_test.py
+++ b/backend/app/api/v1/platform_endpoints/contacts_test.py
@@ -83,6 +83,11 @@ async def test_sections_follow_rail_order(client: AsyncClient, session: AsyncSes
     await create_guild_membership(session, user=user, guild=first, position=2)
     await create_guild_membership(session, user=user, guild=second, position=0)
     await create_guild_membership(session, user=user, guild=third, position=1)
+    # Somebody else in each, or there would be no section to order.
+    for guild in (first, second, third):
+        await create_guild_membership(
+            session, user=await create_user(session), guild=guild
+        )
 
     response = await client.get(SECTIONS, headers=get_auth_headers(user))
     assert response.status_code == 200
@@ -101,6 +106,7 @@ async def test_a_guild_the_caller_left_has_no_section(
     mine = await create_guild(session)
     theirs = await create_guild(session)
     await create_guild_membership(session, user=user, guild=mine)
+    await create_guild_membership(session, user=await create_user(session), guild=mine)
 
     response = await client.get(SECTIONS, headers=get_auth_headers(user))
     ids = [s["guild_id"] for s in response.json()["sections"]]
@@ -176,6 +182,10 @@ async def test_guild_ids_narrows_to_one_section(
     second = await create_guild(session)
     await create_guild_membership(session, user=user, guild=first, position=0)
     await create_guild_membership(session, user=user, guild=second, position=1)
+    for guild in (first, second):
+        await create_guild_membership(
+            session, user=await create_user(session), guild=guild
+        )
 
     response = await client.get(
         f"{SECTIONS}?guild_ids={second.id}", headers=get_auth_headers(user)
@@ -549,3 +559,26 @@ async def test_guild_admin_gets_no_extra_reach_into_a_list(
     assert (await client.get(FAVORITES, headers=get_auth_headers(admin))).json()[
         "items"
     ] == []
+
+
+@pytest.mark.integration
+async def test_a_community_of_one_has_no_section(
+    client: AsyncClient, session: AsyncSession
+):
+    """Being alone somewhere is not an empty roster, it is no roster.
+
+    The section would otherwise say nobody there is accepting messages, which
+    is a remark about people who are not there.
+    """
+    user = await create_user(session)
+    alone = await create_guild(session)
+    shared = await create_guild(session)
+    await create_guild_membership(session, user=user, guild=alone)
+    await create_guild_membership(session, user=user, guild=shared)
+    await create_guild_membership(
+        session, user=await create_user(session), guild=shared
+    )
+
+    response = await client.get(SECTIONS, headers=get_auth_headers(user))
+    ids = [s["guild_id"] for s in response.json()["sections"]]
+    assert ids == [shared.id]

--- a/backend/app/api/v1/platform_endpoints/contacts_test.py
+++ b/backend/app/api/v1/platform_endpoints/contacts_test.py
@@ -7,9 +7,12 @@ from httpx import AsyncClient
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.models.platform.app_setting import AppSetting
 from app.models.platform.guild import GuildRole
 from app.models.platform.profile_favorite import ProfileFavorite
 from app.models.platform.user import UserStatus
+from app.models.platform.user_dm_settings import DmPolicy
+from app.services.platform.app_settings import GLOBAL_SETTINGS_ID
 from app.testing.factories import (
     create_guild,
     create_guild_membership,
@@ -19,6 +22,32 @@ from app.testing.factories import (
 
 SECTIONS = "/api/v1/me/contacts"
 FAVORITES = "/api/v1/me/contacts/favorites"
+
+
+@pytest.fixture(autouse=True)
+async def community_by_default(session: AsyncSession):
+    """Run these against a deployment whose operator default is ``community``.
+
+    A roster names the people the reader could actually reach out to, so on the
+    shipped default — ``private`` — every one of these sections is empty and
+    the paging, search and naming below have nothing to describe. Setting the
+    operator's default here is what gives them members to be about; the default
+    itself, and the empty page it makes, are
+    ``services/platform/contacts_reachable_test.py``.
+
+    Set before any account is made: the default is copied into the account when
+    it is created, and moving it afterwards moves nobody.
+    """
+    settings = (
+        await session.exec(
+            select(AppSetting).where(AppSetting.id == GLOBAL_SETTINGS_ID)
+        )
+    ).one_or_none()
+    if settings is None:
+        settings = AppSetting(id=GLOBAL_SETTINGS_ID)
+        session.add(settings)
+    settings.default_dm_policy = DmPolicy.community
+    await session.commit()
 
 
 def _section(payload: dict, guild_id: int) -> dict:

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -110,9 +110,12 @@ _RLS_PARAMS_INFO_KEY = "rls_params"
 SYSTEM_SATISFIED = "system"
 _RLS_ESTABLISHED_INFO_KEY = "rls_established_at"
 
-# The platform tier the session is acting for. Kept beside the context params
-# rather than inside them because it outlives any one of them: a request routes
-# into a guild and back out again, and the caller is the same person throughout.
+# The platform tier this REQUEST authenticated as, held in the SQLAlchemy
+# session's Python state — never on the connection. It is read only by
+# set_rls_context, which resolves it into the stored params below; from there it
+# reaches Postgres the same way every other value does, as a transaction-local
+# set_config replayed per transaction. Nothing here survives a request, and
+# nothing here is session state at the database.
 _RLS_TIER_INFO_KEY = "rls_platform_tier"
 
 
@@ -352,12 +355,15 @@ async def set_rls_context(
     schema (the guild role governs there) — pass it anyway, so the tier is on the
     session for the trip back out.
 
-    The tier is remembered for the session and reapplied to any later call that
+    The tier is remembered **for the request** — in the SQLAlchemy session's
+    Python state, not on the connection — and reapplied to any later call that
     names a ``user_id`` without one, so re-establishing context part-way through
-    a request keeps the role it authenticated as. Passing a tier sets it; passing
-    no ``user_id`` clears it. Every other parameter is write-only per call: they
-    are always written from this call's arguments, so nothing carries between
-    requests on a pooled connection.
+    keeps the role it authenticated as. Passing a tier sets it; passing no
+    ``user_id`` clears it. What is remembered is only an input to this function:
+    it is resolved here and written into the stored params, so it reaches
+    Postgres as the same transaction-local ``set_config`` as everything else and
+    is replayed per transaction. Every parameter is still written from this
+    call's arguments, so nothing carries between requests on a pooled connection.
     """
     _VALID_ROLES = {"admin", "member"}
     if guild_role is not None and guild_role not in _VALID_ROLES:
@@ -379,10 +385,11 @@ async def set_rls_context(
     # A call that names a user but not their tier is re-establishing this
     # request's own context — returning from a guild excursion, or narrowing
     # after a lookup — not becoming somebody else. Give it back the tier the
-    # session is acting for, so the role it assumes is the one the request
-    # authenticated as rather than the login role underneath it. A call that
-    # names no user is an unattributed context (workers, seeding, the
-    # deliberate reset) and forgets it.
+    # request authenticated as, so the role it assumes is that one rather than
+    # the login role underneath it. A call that names no user is an
+    # unattributed context (workers, seeding, the deliberate reset) and forgets
+    # it. Resolved into the stored params below, so the replay hook reapplies
+    # it per transaction like every other value.
     if platform_role is not None:
         session.info[_RLS_TIER_INFO_KEY] = platform_role
     elif user_id is None:
@@ -509,7 +516,7 @@ async def guild_schema_context(
     previous = session.info.get(_RLS_PARAMS_INFO_KEY)
     previous_established = session.info.get(_RLS_ESTABLISHED_INFO_KEY)
     # The excursion routes with no user of its own, which forgets the tier; the
-    # caller on the other side of it is still the same person.
+    # caller on the other side of it is still the same request.
     previous_tier = session.info.get(_RLS_TIER_INFO_KEY)
     routed = False
     try:

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -110,6 +110,11 @@ _RLS_PARAMS_INFO_KEY = "rls_params"
 SYSTEM_SATISFIED = "system"
 _RLS_ESTABLISHED_INFO_KEY = "rls_established_at"
 
+# The platform tier the session is acting for. Kept beside the context params
+# rather than inside them because it outlives any one of them: a request routes
+# into a guild and back out again, and the caller is the same person throughout.
+_RLS_TIER_INFO_KEY = "rls_platform_tier"
+
 
 class StaleAuthorizationContext(RuntimeError):
     """A transaction tried to begin on an authorization snapshot older than
@@ -344,7 +349,15 @@ async def set_rls_context(
     path assumes ``platform_<tier>`` instead of the bare login role, so the request
     is role-scoped at the database (fail-closed) rather than running with the login
     role's broad standing grants. It is ignored when the request routes into a guild
-    schema (the guild role governs there).
+    schema (the guild role governs there) — pass it anyway, so the tier is on the
+    session for the trip back out.
+
+    The tier is remembered for the session and reapplied to any later call that
+    names a ``user_id`` without one, so re-establishing context part-way through
+    a request keeps the role it authenticated as. Passing a tier sets it; passing
+    no ``user_id`` clears it. Every other parameter is write-only per call: they
+    are always written from this call's arguments, so nothing carries between
+    requests on a pooled connection.
     """
     _VALID_ROLES = {"admin", "member"}
     if guild_role is not None and guild_role not in _VALID_ROLES:
@@ -362,6 +375,20 @@ async def set_rls_context(
 
     if platform_role is not None and platform_role not in PLATFORM_TIERS:
         raise ValueError(f"Invalid platform_role: {platform_role!r}")
+
+    # A call that names a user but not their tier is re-establishing this
+    # request's own context — returning from a guild excursion, or narrowing
+    # after a lookup — not becoming somebody else. Give it back the tier the
+    # session is acting for, so the role it assumes is the one the request
+    # authenticated as rather than the login role underneath it. A call that
+    # names no user is an unattributed context (workers, seeding, the
+    # deliberate reset) and forgets it.
+    if platform_role is not None:
+        session.info[_RLS_TIER_INFO_KEY] = platform_role
+    elif user_id is None:
+        session.info.pop(_RLS_TIER_INFO_KEY, None)
+    else:
+        platform_role = session.info.get(_RLS_TIER_INFO_KEY)
 
     # Store params + freshness stamp BEFORE any execute: an execute may
     # autobegin a transaction, firing the replay hook, which must see the
@@ -481,6 +508,9 @@ async def guild_schema_context(
     """
     previous = session.info.get(_RLS_PARAMS_INFO_KEY)
     previous_established = session.info.get(_RLS_ESTABLISHED_INFO_KEY)
+    # The excursion routes with no user of its own, which forgets the tier; the
+    # caller on the other side of it is still the same person.
+    previous_tier = session.info.get(_RLS_TIER_INFO_KEY)
     routed = False
     try:
         await set_rls_context(session, guild_id=guild_id, guild_role=guild_role)
@@ -493,6 +523,10 @@ async def guild_schema_context(
         session.info[_RLS_PARAMS_INFO_KEY] = previous if previous is not None else {}
         if previous_established is not None:
             session.info[_RLS_ESTABLISHED_INFO_KEY] = previous_established
+        if previous_tier is not None:
+            session.info[_RLS_TIER_INFO_KEY] = previous_tier
+        else:
+            session.info.pop(_RLS_TIER_INFO_KEY, None)
         # Routing that did not complete leaves a transaction that accepts no
         # further statements, and its own rollback puts the settings back; more
         # SQL there would only replace the real error with a second one.

--- a/backend/app/db/users_own_row_test.py
+++ b/backend/app/db/users_own_row_test.py
@@ -254,6 +254,26 @@ class TestReestablishedContext:
         assert await _assumed_role(s) == platform_role_name("member")
         assert await _count_visible(s, other.id) == 0
 
+    async def test_it_crosses_a_transaction_boundary(
+        self, session, role_session, two_accounts
+    ):
+        """The carried tier reaches Postgres the way every other value does.
+
+        It is resolved once, into the stored parameters, and from there the
+        replay hook applies it as a transaction-local ``set_config`` at the
+        start of each transaction. Nothing is held on the connection, so the
+        role is whatever the parameters say on whichever backend the next
+        transaction lands on — which is what this commit forces.
+        """
+        member, other = two_accounts
+        s = await role_session("app_user")
+        await set_rls_context(s, user_id=member.id, platform_role="member")
+        await set_rls_context(s, user_id=member.id)
+        await s.commit()
+
+        assert await _assumed_role(s) == platform_role_name("member")
+        assert await _count_visible(s, other.id) == 0
+
     async def test_an_unattributed_context_forgets_it(
         self, session, role_session, two_accounts
     ):

--- a/backend/app/db/users_own_row_test.py
+++ b/backend/app/db/users_own_row_test.py
@@ -18,6 +18,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.db.schema_provisioning import guild_role_name, platform_role_name
 from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
 from app.models.platform.user import UserRole
@@ -61,6 +62,13 @@ async def _count_visible(session: AsyncSession, user_id: int) -> int:
     ).scalar()
     await session.rollback()
     return visible
+
+
+async def _assumed_role(session: AsyncSession) -> str:
+    """The Postgres role the session is currently wearing."""
+    role = (await session.exec(text("SELECT current_user"))).scalar()
+    await session.rollback()
+    return role
 
 
 class TestGuildSession:
@@ -189,3 +197,77 @@ class TestPlatformSession:
         assert await _update_returning(
             s, subject.id, "hashed_password", "self-chosen"
         ) == [subject.id]
+
+
+class TestReestablishedContext:
+    """A request that re-establishes its own context keeps the role it came in
+    with.
+
+    Services do this part-way through a request — coming back from a walk
+    across the caller's communities, or narrowing before a lookup — by naming
+    the user again. The tier is not theirs to re-derive, and on this table the
+    login role underneath reads every account while a ``member`` reads one, so
+    what the request may read must not widen on the way through.
+    """
+
+    @pytest.fixture
+    async def two_accounts(self, session):
+        return await create_user(session), await create_user(session)
+
+    async def test_naming_the_user_again_keeps_the_tier(
+        self, session, role_session, two_accounts
+    ):
+        member, other = two_accounts
+        s = await role_session("app_user")
+        await set_rls_context(s, user_id=member.id, platform_role="member")
+        assert await _assumed_role(s) == platform_role_name("member")
+        assert await _count_visible(s, other.id) == 0
+
+        # The shape of every "back to the platform path" call in the services.
+        await set_rls_context(s, user_id=member.id)
+
+        assert await _assumed_role(s) == platform_role_name("member")
+        assert await _count_visible(s, other.id) == 0
+
+    async def test_a_guild_trip_comes_back_at_the_same_tier(
+        self, session, role_session, two_accounts
+    ):
+        """The tier is recorded on the guild path too, where it does not route.
+
+        A guild request assumes ``guild_<id>``; the tier is what it re-assumes
+        when a cross-guild aggregate steps back out to ``public``.
+        """
+        member, other = two_accounts
+        guild = await create_guild(session, creator=member)
+        s = await role_session("app_user")
+        await set_rls_context(
+            s,
+            user_id=member.id,
+            guild_id=guild.id,
+            guild_role="admin",
+            platform_role="member",
+        )
+        assert await _assumed_role(s) == guild_role_name(guild.id)
+
+        await set_rls_context(s, user_id=member.id)
+
+        assert await _assumed_role(s) == platform_role_name("member")
+        assert await _count_visible(s, other.id) == 0
+
+    async def test_an_unattributed_context_forgets_it(
+        self, session, role_session, two_accounts
+    ):
+        """Naming no user is how a worker says it is acting for nobody.
+
+        It clears the tier rather than leaving one for the next call to inherit,
+        so a session cannot pick up an identity it was never given.
+        """
+        member, _other = two_accounts
+        s = await role_session("app_user")
+        await set_rls_context(s, user_id=member.id, platform_role="member")
+        await set_rls_context(s)
+        assert await _assumed_role(s) == "app_user"
+
+        await set_rls_context(s, user_id=member.id)
+
+        assert await _assumed_role(s) == "app_user"

--- a/backend/app/schemas/platform/dm.py
+++ b/backend/app/schemas/platform/dm.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 
 from pydantic import ConfigDict
 
+from app.models.platform.user import Presence, UserStatus
 from app.models.platform.user_dm_settings import DmPolicy
 from app.schemas.base import SanitizedBaseModel
 
@@ -99,6 +100,11 @@ class ContactGrantRead(SanitizedBaseModel):
     username: str
     discriminator: int
     avatar_url: Optional[str] = None
+    #: Carried so a grant renders as an ordinary contact row wherever one is
+    #: listed. No ``full_name``: a real name is a per-guild disclosure, and a
+    #: grant may name somebody the reader shares no community with.
+    status: UserStatus = UserStatus.active
+    presence: Presence = Presence.offline
     state: str
     #: True when the reader is the one who asked, which is what tells a
     #: cancellable request from one waiting on them.

--- a/backend/app/services/platform/contact_grants.py
+++ b/backend/app/services/platform/contact_grants.py
@@ -37,6 +37,7 @@ from app.models.platform.contact_grant import (
 )
 from app.models.platform.user_ignore import UserIgnore
 from app.services.platform import contacts_stream
+from app.services.platform import presence as presence_service
 from app.services.platform import user_ignores
 from app.schemas.platform.dm import (
     ContactGrantRead,
@@ -425,7 +426,7 @@ async def to_reads(
         for row in (
             await session.exec(
                 text(
-                    "SELECT id, username, discriminator, avatar_url "
+                    "SELECT id, username, discriminator, avatar_url, status "
                     "FROM public.user_profiles WHERE id = ANY(:ids)"
                 ).bindparams(ids=list(others))
             )
@@ -445,6 +446,8 @@ async def to_reads(
             username=profile[1],
             discriminator=profile[2],
             avatar_url=profile[3],
+            status=profile[4],
+            presence=presence_service.online.presence_of(other),
             state=grant.state.value,
             outgoing=grant.requested_by == user_id,
             created_at=grant.created_at,

--- a/backend/app/services/platform/contacts.py
+++ b/backend/app/services/platform/contacts.py
@@ -40,7 +40,7 @@ GuildRow = tuple[int, str, Optional[str]]
 
 
 async def ordered_member_guilds(
-    session: AsyncSession, *, user_id: int, platform_role: Optional[str] = None
+    session: AsyncSession, *, user_id: int
 ) -> list[GuildRow]:
     """The reader's guilds in rail order.
 
@@ -49,9 +49,7 @@ async def ordered_member_guilds(
     guild is left out, matching ``member_guild_ids`` and the ``/g/{guild_id}``
     path it stands in for.
     """
-    # Re-establishing context restores the role the request was routed with,
-    # so the tier travels alongside the user id.
-    await set_rls_context(session, user_id=user_id, platform_role=platform_role)
+    await set_rls_context(session, user_id=user_id)
     rows = (
         await session.exec(
             select(Guild.id, Guild.name)
@@ -98,7 +96,6 @@ async def guild_sections(
     search: Optional[str] = None,
     page: int = 1,
     page_size: int = DEFAULT_PAGE_SIZE,
-    platform_role: Optional[str] = None,
 ) -> list[ContactGuildSection]:
     """One section per guild, in the order given.
 
@@ -122,10 +119,7 @@ async def guild_sections(
     # callable from. It has to happen before the walk below, which routes this
     # same session into each guild in turn.
     listable = await listable_by_guild(
-        session,
-        user_id=user_id,
-        guilds=[gid for gid, _n, _i in guilds],
-        platform_role=platform_role,
+        session, user_id=user_id, guilds=[gid for gid, _n, _i in guilds]
     )
 
     async def _fetch(guild_session: AsyncSession, guild_id: int) -> list[int]:
@@ -143,6 +137,13 @@ async def guild_sections(
                 )
             ).all()
         )
+
+        # A community of one is not a section. Nobody is in it to list, and an
+        # empty section there would read as a remark about people who are not
+        # there — the reader is by themselves, which the page should not
+        # dress up as everybody being unreachable.
+        if not membership_map[guild_id]:
+            return []
 
         # Read from the guild projection, not from ``users``: this is a roster,
         # and a routed session has no reach into the account row behind it. The
@@ -209,11 +210,7 @@ async def guild_sections(
 
 
 async def listable_by_guild(
-    session: AsyncSession,
-    *,
-    user_id: int,
-    guilds: Sequence[int],
-    platform_role: Optional[str] = None,
+    session: AsyncSession, *, user_id: int, guilds: Sequence[int]
 ) -> dict[int, set[int]]:
     """Per community, the members this reader may ask to message.
 
@@ -223,9 +220,9 @@ async def listable_by_guild(
     Deliberately **not** narrowed by who has ignored the reader: an ignore
     governs what arrives, not who is listed, so both rosters stay as they were.
     """
-    # Asked as the caller's own tier: the rule reads who is asking from the
-    # request context, so the context has to be the caller's.
-    await set_rls_context(session, user_id=user_id, platform_role=platform_role)
+    # The rule reads who is asking from the request context, so this runs on
+    # the caller's own session rather than being told an id.
+    await set_rls_context(session, user_id=user_id)
     result: dict[int, set[int]] = {}
     for guild_id in guilds:
         rows = await session.exec(

--- a/backend/app/services/platform/contacts.py
+++ b/backend/app/services/platform/contacts.py
@@ -9,7 +9,7 @@ which needs no guild at all and may name people the reader shares none with.
 
 from typing import Iterable, Optional, Sequence
 
-from sqlalchemy import String, cast, func
+from sqlalchemy import String, cast, func, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -40,7 +40,7 @@ GuildRow = tuple[int, str, Optional[str]]
 
 
 async def ordered_member_guilds(
-    session: AsyncSession, *, user_id: int
+    session: AsyncSession, *, user_id: int, platform_role: Optional[str] = None
 ) -> list[GuildRow]:
     """The reader's guilds in rail order.
 
@@ -49,7 +49,9 @@ async def ordered_member_guilds(
     guild is left out, matching ``member_guild_ids`` and the ``/g/{guild_id}``
     path it stands in for.
     """
-    await set_rls_context(session, user_id=user_id)
+    # Re-establishing context restores the role the request was routed with,
+    # so the tier travels alongside the user id.
+    await set_rls_context(session, user_id=user_id, platform_role=platform_role)
     rows = (
         await session.exec(
             select(Guild.id, Guild.name)
@@ -96,6 +98,7 @@ async def guild_sections(
     search: Optional[str] = None,
     page: int = 1,
     page_size: int = DEFAULT_PAGE_SIZE,
+    platform_role: Optional[str] = None,
 ) -> list[ContactGuildSection]:
     """One section per guild, in the order given.
 
@@ -113,6 +116,17 @@ async def guild_sections(
     membership_map: dict[int, list[int]] = {}
     sections: dict[int, ContactGuildSection] = {}
     named = {gid: (name, icon) for gid, name, icon in guilds}
+
+    # Who, of each community, this reader may actually reach — asked here, on
+    # the platform-tier session, because that is the only role the rule is
+    # callable from. It has to happen before the walk below, which routes this
+    # same session into each guild in turn.
+    listable = await listable_by_guild(
+        session,
+        user_id=user_id,
+        guilds=[gid for gid, _n, _i in guilds],
+        platform_role=platform_role,
+    )
 
     async def _fetch(guild_session: AsyncSession, guild_id: int) -> list[int]:
         shows_names = guild_shows_member_names()
@@ -142,6 +156,8 @@ async def guild_sections(
                 # You are not your own contact.
                 MemberProfile.id != user_id,
                 users_service.visible_to_other_people(),
+                # And a contact is somebody you could actually reach out to.
+                col(MemberProfile.id).in_(listable.get(guild_id, set())),
             )
         )
         closest = None
@@ -190,6 +206,33 @@ async def guild_sections(
         for item in section.items:
             item.shared_guild_ids = shared.get(item.id, [])
     return ordered
+
+
+async def listable_by_guild(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    guilds: Sequence[int],
+    platform_role: Optional[str] = None,
+) -> dict[int, set[int]]:
+    """Per community, the members this reader may ask to message.
+
+    One call per section rather than one per member: the rule does the join
+    itself, so nothing large crosses the boundary in either direction.
+
+    Deliberately **not** narrowed by who has ignored the reader: an ignore
+    governs what arrives, not who is listed, so both rosters stay as they were.
+    """
+    # Asked as the caller's own tier: the rule reads who is asking from the
+    # request context, so the context has to be the caller's.
+    await set_rls_context(session, user_id=user_id, platform_role=platform_role)
+    result: dict[int, set[int]] = {}
+    for guild_id in guilds:
+        rows = await session.exec(
+            text("SELECT public.dm_listable_in_guild(:g)").bindparams(g=guild_id)
+        )
+        result[guild_id] = {row[0] for row in rows}
+    return result
 
 
 async def favorites(

--- a/backend/app/services/platform/contacts_reachable_test.py
+++ b/backend/app/services/platform/contacts_reachable_test.py
@@ -1,0 +1,109 @@
+"""My Contacts lists the people you could actually reach out to.
+
+The two to keep are the last: an ignore governs what arrives, so it takes the
+account you ignored off your own roster and leaves you on theirs.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from app.models.platform.guild import GuildRole
+from app.models.platform.user_dm_settings import DmPolicy
+from app.models.platform.user_ignore import UserIgnore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _policy(session, user, policy: DmPolicy) -> None:
+    await session.exec(
+        text(
+            "UPDATE public.user_dm_settings SET dm_policy = CAST(:p AS user_dm_policy) "
+            "WHERE user_id = :u"
+        ).bindparams(p=policy.value, u=user.id)
+    )
+    await session.commit()
+
+
+async def _roster(client, actor) -> set[int]:
+    response = await client.get("/api/v1/me/contacts", headers=actor.headers)
+    assert response.status_code == 200, response.text
+    return {
+        item["id"]
+        for section in response.json()["sections"]
+        for item in section["items"]
+    }
+
+
+async def test_a_community_member_you_can_ask_is_listed(client, session, acting_user):
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _policy(session, ada.user, DmPolicy.community)
+    await _policy(session, bram.user, DmPolicy.community)
+
+    assert bram.user.id in await _roster(client, ada)
+
+
+async def test_a_private_member_is_not_listed(client, session, acting_user):
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _policy(session, ada.user, DmPolicy.community)
+    await _policy(session, bram.user, DmPolicy.private)
+
+    assert bram.user.id not in await _roster(client, ada)
+
+
+async def test_a_private_reader_lists_nobody(client, session, acting_user):
+    """The reader's own policy decides the whole page, which is what makes the
+    default empty and worth explaining."""
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _policy(session, ada.user, DmPolicy.private)
+    await _policy(session, bram.user, DmPolicy.community)
+
+    assert await _roster(client, ada) == set()
+
+
+async def test_an_unconfirmed_age_lists_nobody(client, session, acting_user):
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _policy(session, ada.user, DmPolicy.community)
+    await _policy(session, bram.user, DmPolicy.community)
+    ada.user.age_confirmed_at = None
+    session.add(ada.user)
+    await session.commit()
+
+    assert await _roster(client, ada) == set()
+
+
+async def test_being_ignored_does_not_remove_you_from_their_roster(
+    client, session, acting_user
+):
+    """Ada ignores Bram. Bram's roster still has Ada on it, unchanged."""
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _policy(session, ada.user, DmPolicy.community)
+    await _policy(session, bram.user, DmPolicy.community)
+
+    before = await _roster(client, bram)
+    assert ada.user.id in before
+
+    session.add(UserIgnore(user_id=ada.user.id, ignored_user_id=bram.user.id))
+    await session.commit()
+
+    assert await _roster(client, bram) == before
+
+
+async def test_an_account_you_ignore_leaves_your_own_roster(
+    client, session, acting_user
+):
+    """The other direction is the reader's own doing, and theirs to see."""
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _policy(session, ada.user, DmPolicy.community)
+    await _policy(session, bram.user, DmPolicy.community)
+    assert bram.user.id in await _roster(client, ada)
+
+    session.add(UserIgnore(user_id=ada.user.id, ignored_user_id=bram.user.id))
+    await session.commit()
+
+    assert bram.user.id not in await _roster(client, ada)

--- a/frontend/public/locales/de/contacts.json
+++ b/frontend/public/locales/de/contacts.json
@@ -2,6 +2,8 @@
   "title": "Meine Kontakte",
   "subtitle": "Alle, mit denen du eine Community teilst, und alle, die du markiert hast.",
   "favorites": "Favoriten",
+  "connections": "Verbindungen",
+  "directMessages": "Direktnachrichten",
   "searchPlaceholder": "Kontakte durchsuchen",
   "searchLabel": "Alle auf dieser Seite durchsuchen",
   "clearSearch": "Suche zurücksetzen",

--- a/frontend/public/locales/de/contacts.json
+++ b/frontend/public/locales/de/contacts.json
@@ -29,11 +29,21 @@
     "title": "Noch niemand hier",
     "description": "Tritt einer Community bei, dann erscheinen ihre Mitglieder hier.",
     "favorites": "Markiere jemanden mit einem Stern, um ihn oben auf dieser Seite zu behalten.",
-    "guild": "Sonst ist noch niemand in dieser Community."
+    "guild": "Hier nimmt derzeit niemand Nachrichten an."
   },
   "noMatches": {
     "title": "Niemand mit diesem Namen",
     "description": "Versuche einen anderen Namen oder das vollständige Handle.",
     "section": "Hier keine Treffer."
+  },
+  "unreachable": {
+    "age": {
+      "title": "Direktnachrichten sind für dieses Konto deaktiviert"
+    },
+    "private": {
+      "body": "Du bist auf „Privat“ eingestellt. Du kannst dich weiterhin über den genauen Handle mit anderen verbinden, und eine Verbindung erlaubt euch unabhängig von dieser Einstellung, einander zu schreiben. Damit man dich hier erreichen kann, erlaube deinen Communitys, dir zu schreiben.",
+      "open": "Meine Communitys dürfen mir schreiben",
+      "settings": "Privatsphäre-Einstellungen"
+    }
   }
 }

--- a/frontend/public/locales/en/contacts.json
+++ b/frontend/public/locales/en/contacts.json
@@ -29,11 +29,21 @@
     "title": "Nobody here yet",
     "description": "Join a community and the people in it show up here.",
     "favorites": "Star anyone to keep them at the top of this page.",
-    "guild": "Nobody else is in this community yet."
+    "guild": "No one here is accepting messages right now."
   },
   "noMatches": {
     "title": "Nobody by that name",
     "description": "Try a different name, or the whole handle.",
     "section": "No matches here."
+  },
+  "unreachable": {
+    "age": {
+      "title": "Direct messages are off for this account"
+    },
+    "private": {
+      "body": "You're set to Private. You can still connect with anyone by their exact handle, and a connection lets you message each other whatever your setting is. To be reachable here, let your communities message you.",
+      "open": "Let my communities message me",
+      "settings": "Privacy settings"
+    }
   }
 }

--- a/frontend/public/locales/en/contacts.json
+++ b/frontend/public/locales/en/contacts.json
@@ -2,6 +2,8 @@
   "title": "My Contacts",
   "subtitle": "Everyone you share a community with, plus anyone you starred.",
   "favorites": "Favorites",
+  "connections": "Connections",
+  "directMessages": "Direct messages",
   "searchPlaceholder": "Search contacts",
   "searchLabel": "Search everyone on this page",
   "clearSearch": "Clear search",

--- a/frontend/public/locales/es/contacts.json
+++ b/frontend/public/locales/es/contacts.json
@@ -2,6 +2,8 @@
   "title": "Mis contactos",
   "subtitle": "Todas las personas con las que compartes una comunidad, y las que hayas marcado.",
   "favorites": "Favoritos",
+  "connections": "Conexiones",
+  "directMessages": "Mensajes directos",
   "searchPlaceholder": "Buscar contactos",
   "searchLabel": "Buscar a todos en esta página",
   "clearSearch": "Borrar búsqueda",

--- a/frontend/public/locales/es/contacts.json
+++ b/frontend/public/locales/es/contacts.json
@@ -29,11 +29,21 @@
     "title": "Todavía no hay nadie",
     "description": "Únete a una comunidad y sus miembros aparecerán aquí.",
     "favorites": "Marca a alguien con una estrella para tenerlo arriba en esta página.",
-    "guild": "Todavía no hay nadie más en esta comunidad."
+    "guild": "Ahora mismo nadie de aquí acepta mensajes."
   },
   "noMatches": {
     "title": "Nadie con ese nombre",
     "description": "Prueba con otro nombre o con el identificador completo.",
     "section": "Aquí no hay coincidencias."
+  },
+  "unreachable": {
+    "age": {
+      "title": "Los mensajes directos están desactivados en esta cuenta"
+    },
+    "private": {
+      "body": "Tienes la opción Privado. Aún puedes conectar con cualquiera mediante su identificador exacto, y una conexión os permite escribiros sea cual sea tu ajuste. Para que puedan encontrarte aquí, permite que tus comunidades te escriban.",
+      "open": "Permitir que mis comunidades me escriban",
+      "settings": "Ajustes de privacidad"
+    }
   }
 }

--- a/frontend/public/locales/fr/contacts.json
+++ b/frontend/public/locales/fr/contacts.json
@@ -2,6 +2,8 @@
   "title": "Mes contacts",
   "subtitle": "Toutes les personnes avec qui vous partagez une communauté, ainsi que vos favoris.",
   "favorites": "Favoris",
+  "connections": "Connexions",
+  "directMessages": "Messages directs",
   "searchPlaceholder": "Rechercher des contacts",
   "searchLabel": "Rechercher parmi tout le monde sur cette page",
   "clearSearch": "Effacer la recherche",

--- a/frontend/public/locales/fr/contacts.json
+++ b/frontend/public/locales/fr/contacts.json
@@ -29,11 +29,21 @@
     "title": "Personne pour l'instant",
     "description": "Rejoignez une communauté et ses membres apparaîtront ici.",
     "favorites": "Mettez quelqu'un en favori pour le garder en haut de cette page.",
-    "guild": "Personne d'autre dans cette communauté pour l'instant."
+    "guild": "Personne ici n'accepte de messages pour le moment."
   },
   "noMatches": {
     "title": "Personne de ce nom",
     "description": "Essayez un autre nom, ou l'identifiant complet.",
     "section": "Aucun résultat ici."
+  },
+  "unreachable": {
+    "age": {
+      "title": "Les messages privés sont désactivés pour ce compte"
+    },
+    "private": {
+      "body": "Vous êtes en mode Privé. Vous pouvez toujours vous connecter à quelqu'un via son identifiant exact, et une connexion vous permet de vous écrire quel que soit ce réglage. Pour être joignable ici, autorisez vos communautés à vous écrire.",
+      "open": "Autoriser mes communautés à m'écrire",
+      "settings": "Paramètres de confidentialité"
+    }
   }
 }

--- a/frontend/src/__tests__/myContactsRoute.test.tsx
+++ b/frontend/src/__tests__/myContactsRoute.test.tsx
@@ -12,7 +12,11 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ContactGuildSection, ContactRead } from "@/api/generated/initiativeAPI.schemas";
+import type {
+  ContactGuildSection,
+  ContactRead,
+  DmPolicy,
+} from "@/api/generated/initiativeAPI.schemas";
 import { routeTree } from "@/routeTree.gen";
 
 import { renderPage } from "./helpers/render";
@@ -25,6 +29,8 @@ const mocks = vi.hoisted(() => ({
   toggle: vi.fn(),
   sectionPage: vi.fn(),
   prefetch: vi.fn(),
+  dmSettings: vi.fn(),
+  updateDm: vi.fn(),
 }));
 
 vi.mock("@/hooks/useContacts", () => ({
@@ -36,6 +42,14 @@ vi.mock("@/hooks/useContacts", () => ({
     mocks.sectionPage(guildId, page, search),
   usePrefetchContactSectionPage: () => mocks.prefetch,
   contactsPrefetch: () => ({ sections: {}, favorites: {} }),
+}));
+
+// The reader's own policy decides whether the page has anything to list, so
+// every test below states it. The default is an account that answered its age
+// and let its communities in — the one whose sections have members.
+vi.mock("@/hooks/useDirectMessages", () => ({
+  useDmSettings: () => mocks.dmSettings(),
+  useUpdateDmSettings: () => ({ mutate: mocks.updateDm, isPending: false }),
 }));
 
 // The collapse preference is a server round-trip this page does not need to
@@ -86,6 +100,17 @@ const answer = (
   });
 };
 
+/** The reader's own direct-message settings, as the page reads them. */
+const reader = (overrides: { age_confirmed_at?: string | null; dm_policy?: DmPolicy } = {}) =>
+  mocks.dmSettings.mockReturnValue({
+    data: {
+      age_confirmed_at: "2020-01-01T00:00:00Z",
+      dm_policy: "community" as DmPolicy,
+      communities: [{ guild_id: 1, name: "Ravenloft Table", icon_url: null, enabled: false }],
+      ...overrides,
+    },
+  });
+
 /** A section page that has not arrived — what every page past the first is. */
 const pendingPage = { data: undefined, isPending: true, isPlaceholderData: false };
 
@@ -114,6 +139,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   nextId = 1;
   answer([]);
+  reader();
   mocks.sectionPage.mockReturnValue(pendingPage);
 });
 
@@ -375,5 +401,56 @@ describe("My Contacts", () => {
 
     const heading = await screen.findByRole("button", { name: /Big Table/ });
     expect(within(heading).getByText("31")).toBeInTheDocument();
+  });
+
+  describe("when the roster is empty because of the reader", () => {
+    it("asks an unanswered account its age, and offers no policy while it is unanswered", async () => {
+      reader({ age_confirmed_at: null, dm_policy: "private" });
+      answer([section({ total_count: 0, items: [] })]);
+      await renderContacts();
+
+      expect(await screen.findByText(/Direct messages are off for this account/i)).toBeVisible();
+      // Both conditions hold at once on a new account. Only the age panel may
+      // show: the other one offers a route this account has no access to.
+      expect(screen.queryByRole("button", { name: /Let my communities message me/i })).toBeNull();
+    });
+
+    it("explains a private account's empty communities and opens them in one click", async () => {
+      reader({ dm_policy: "private" });
+      answer([section({ guild_id: 1, total_count: 0, items: [] })]);
+      await renderContacts();
+
+      expect(screen.queryByText(/Direct messages are off for this account/i)).toBeNull();
+      await userEvent.click(
+        await screen.findByRole("button", { name: /Let my communities message me/i })
+      );
+
+      // Every community switched on, which is the state Private was designed
+      // to be one click away from.
+      expect(mocks.updateDm).toHaveBeenCalledWith({
+        data: { dm_policy: "community", communities: [{ guild_id: 1, enabled: true }] },
+      });
+    });
+
+    it("says nothing about the reader while a search is running", async () => {
+      reader({ dm_policy: "private" });
+      answer([section({ guild_id: 1, total_count: 0, items: [] })]);
+      await renderContacts("nobody");
+
+      // An empty page under a term is about the term.
+      expect(screen.queryByRole("button", { name: /Let my communities message me/i })).toBeNull();
+    });
+
+    it("never counts the people it is not listing", async () => {
+      reader();
+      answer([section({ guild_id: 1, total_count: 0, items: [] })]);
+      await renderContacts();
+
+      const line = await screen.findByText(/No one here is accepting messages right now/i);
+      expect(line).toBeVisible();
+      // The line describes other people's settings, which are not the
+      // reader's to count.
+      expect(line.textContent).not.toMatch(/\d/);
+    });
   });
 });

--- a/frontend/src/__tests__/myContactsRoute.test.tsx
+++ b/frontend/src/__tests__/myContactsRoute.test.tsx
@@ -13,6 +13,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
+  ContactGrantRead,
   ContactGuildSection,
   ContactRead,
   DmPolicy,
@@ -31,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   prefetch: vi.fn(),
   dmSettings: vi.fn(),
   updateDm: vi.fn(),
+  connections: vi.fn(),
+  messages: vi.fn(),
 }));
 
 vi.mock("@/hooks/useContacts", () => ({
@@ -50,6 +53,8 @@ vi.mock("@/hooks/useContacts", () => ({
 vi.mock("@/hooks/useDirectMessages", () => ({
   useDmSettings: () => mocks.dmSettings(),
   useUpdateDmSettings: () => ({ mutate: mocks.updateDm, isPending: false }),
+  useConnections: () => mocks.connections(),
+  useMessageRequests: () => mocks.messages(),
 }));
 
 // The collapse preference is a server round-trip this page does not need to
@@ -111,6 +116,29 @@ const reader = (overrides: { age_confirmed_at?: string | null; dm_policy?: DmPol
     },
   });
 
+let nextGrantId = 500;
+const grant = (overrides: Partial<ContactGrantRead> = {}): ContactGrantRead => ({
+  user_id: nextGrantId++,
+  username: `grant${nextGrantId}`,
+  discriminator: 4321,
+  avatar_url: null,
+  status: "active",
+  presence: "offline",
+  state: "accepted",
+  outgoing: false,
+  created_at: "2026-01-01T00:00:00Z",
+  responded_at: "2026-01-02T00:00:00Z",
+  ...overrides,
+});
+
+/** What the two grant lists hold. Empty unless a test says otherwise. */
+const grants = (connections: ContactGrantRead[] = [], messages: ContactGrantRead[] = []) => {
+  mocks.connections.mockReturnValue({
+    data: { accepted: connections, incoming: [], outgoing: [] },
+  });
+  mocks.messages.mockReturnValue({ data: { accepted: messages, incoming: [], outgoing: [] } });
+};
+
 /** A section page that has not arrived — what every page past the first is. */
 const pendingPage = { data: undefined, isPending: true, isPlaceholderData: false };
 
@@ -140,6 +168,8 @@ beforeEach(() => {
   nextId = 1;
   answer([]);
   reader();
+  grants();
+  nextGrantId = 500;
   mocks.sectionPage.mockReturnValue(pendingPage);
 });
 
@@ -425,11 +455,21 @@ describe("My Contacts", () => {
         await screen.findByRole("button", { name: /Let my communities message me/i })
       );
 
-      // Every community switched on, which is the state Private was designed
-      // to be one click away from.
-      expect(mocks.updateDm).toHaveBeenCalledWith({
-        data: { dm_policy: "community", communities: [{ guild_id: 1, enabled: true }] },
-      });
+      // The policy and nothing else: the community switches would stake the
+      // write on a membership list fetched earlier, and this is the button
+      // that must land.
+      expect(mocks.updateDm).toHaveBeenCalledWith({ data: { dm_policy: "community" } });
+    });
+
+    it("says nothing until it knows what the settings are", async () => {
+      // Absent settings read as an account that has answered nothing, and the
+      // age panel is the one thing never to show somebody who has.
+      mocks.dmSettings.mockReturnValue({ data: undefined });
+      answer([section({ guild_id: 1, total_count: 0, items: [] })]);
+      await renderContacts();
+
+      expect(screen.queryByText(/Direct messages are off for this account/i)).toBeNull();
+      expect(screen.queryByRole("button", { name: /Let my communities message me/i })).toBeNull();
     });
 
     it("says nothing about the reader while a search is running", async () => {
@@ -451,6 +491,41 @@ describe("My Contacts", () => {
       // The line describes other people's settings, which are not the
       // reader's to count.
       expect(line.textContent).not.toMatch(/\d/);
+    });
+  });
+
+  describe("people no community introduced", () => {
+    it("lists somebody you agreed to message and share nothing else with", async () => {
+      // Two accounts on Anyone who accepted each other: no connection, no
+      // community in common, and so no section on this page before now.
+      const pen = grant({ username: "penpal" });
+      grants([], [pen]);
+      answer([]);
+      await renderContacts();
+
+      expect(await screen.findByText(/penpal/)).toBeVisible();
+    });
+
+    it("does not list a connection twice", async () => {
+      // Accepting a connection opens the channel with it, so the same person
+      // is in both lists the server sends.
+      const lee = grant({ username: "leelee" });
+      grants([lee], [lee]);
+      answer([]);
+      await renderContacts();
+
+      expect(await screen.findByText("Connections")).toBeVisible();
+      expect(screen.queryByText("Direct messages")).toBeNull();
+      expect(screen.getAllByText(/leelee/)).toHaveLength(1);
+    });
+
+    it("does not send the reader to the generic empty page", async () => {
+      grants([], [grant({ username: "penpal" })]);
+      answer([]);
+      await renderContacts();
+
+      // In no communities and starring nobody, but not without contacts.
+      expect(screen.queryByText(/Join a community/i)).toBeNull();
     });
   });
 });

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1867,6 +1867,8 @@ export interface ContactGrantRead {
   username: string;
   discriminator: number;
   avatar_url: string | null;
+  status: UserStatus;
+  presence: Presence;
   state: string;
   outgoing: boolean;
   created_at: string;

--- a/frontend/src/components/contacts/GrantContactSection.tsx
+++ b/frontend/src/components/contacts/GrantContactSection.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+import type { ContactGrantRead, ContactRead } from "@/api/generated/initiativeAPI.schemas";
+import { ContactSection } from "@/components/contacts/ContactSection";
+import type { ChipGuild } from "@/components/contacts/SharedGuildChip";
+import { CONTACTS_PAGE_SIZE } from "@/hooks/useContacts";
+
+/**
+ * A grant, as a row of this page.
+ *
+ * No ``full_name``: a real name is a per-community disclosure, and a grant may
+ * name somebody the reader shares no community with — which is the whole point
+ * of listing them here. No shared communities either, for the same reason: the
+ * chip answers "where else do we meet", and this section is for people the
+ * answer may be nowhere for.
+ */
+export const grantAsContact = (grant: ContactGrantRead): ContactRead => ({
+  id: grant.user_id,
+  username: grant.username,
+  discriminator: grant.discriminator,
+  full_name: null,
+  avatar_url: grant.avatar_url,
+  status: grant.status,
+  presence: grant.presence,
+  shared_guild_ids: [],
+});
+
+interface GrantContactSectionProps {
+  value: string;
+  label: string;
+  title: ReactNode;
+  items: ContactGrantRead[];
+  starredIds: Set<number>;
+  onToggleFavorite: (contact: ContactRead) => void;
+  guilds: Map<number, ChipGuild>;
+  emptyLabel: string;
+}
+
+/**
+ * People the reader can reach because the two of them agreed to it, rather
+ * than because they share a community.
+ *
+ * Paged here rather than at the server: these lists arrive whole, being small
+ * and standing outside the walk that pages the community sections.
+ */
+export const GrantContactSection = ({
+  value,
+  label,
+  title,
+  items,
+  starredIds,
+  onToggleFavorite,
+  guilds,
+  emptyLabel,
+}: GrantContactSectionProps) => {
+  const [page, setPage] = useState(1);
+
+  // Removing the last row of the last page leaves the reader on a page that no
+  // longer exists, so the page shown is clamped rather than stored.
+  const lastPage = Math.max(1, Math.ceil(items.length / CONTACTS_PAGE_SIZE));
+  const current = Math.min(page, lastPage);
+  const start = (current - 1) * CONTACTS_PAGE_SIZE;
+
+  return (
+    <ContactSection
+      value={value}
+      label={label}
+      title={title}
+      items={items.slice(start, start + CONTACTS_PAGE_SIZE).map(grantAsContact)}
+      starredIds={starredIds}
+      onToggleFavorite={onToggleFavorite}
+      guilds={guilds}
+      emptyLabel={emptyLabel}
+      totalCount={items.length}
+      page={current}
+      pageSize={CONTACTS_PAGE_SIZE}
+      onPageChange={setPage}
+    />
+  );
+};

--- a/frontend/src/components/contacts/UnreachableEmptyState.tsx
+++ b/frontend/src/components/contacts/UnreachableEmptyState.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 
-import type { CommunityDmToggle } from "@/api/generated/initiativeAPI.schemas";
 import { BirthdateField } from "@/components/auth/BirthdateField";
 import { useAgeConfirmation } from "@/components/auth/useAgeConfirmation";
 import { Button } from "@/components/ui/button";
@@ -75,10 +74,10 @@ export const AgeUnansweredPanel = () => {
  * Two ways out, and the sentence is the more important of them: a connection
  * reaches this account whatever its policy, so somebody who means to stay
  * closed should leave knowing the feature works rather than thinking it broke.
- * The button is the other, and it writes the state Private was designed to be
- * one click from — open to every community, none of them switched off.
+ * The button is the other, and it writes the one value that changes who may
+ * ask.
  */
-export const PrivatePanel = ({ communities }: { communities: CommunityDmToggle[] }) => {
+export const PrivatePanel = () => {
   const { t } = useTranslation("contacts");
   const updateSettings = useUpdateDmSettings();
 
@@ -90,17 +89,15 @@ export const PrivatePanel = ({ communities }: { communities: CommunityDmToggle[]
           type="button"
           size="sm"
           disabled={updateSettings.isPending}
-          onClick={() =>
-            updateSettings.mutate({
-              data: {
-                dm_policy: "community",
-                communities: communities.map((community) => ({
-                  guild_id: community.guild_id,
-                  enabled: true,
-                })),
-              },
-            })
-          }
+          // The policy alone. Sending the community switches with it would
+          // stake the whole write on a membership list the page fetched
+          // earlier: leaving a community between the two makes the server
+          // refuse the unknown id, and the account that clicked "let my
+          // communities message me" stays Private. Every community counts by
+          // default, so a switch is only off where its owner turned it off,
+          // and that is theirs to keep — the link beside this is where they
+          // are changed.
+          onClick={() => updateSettings.mutate({ data: { dm_policy: "community" } })}
         >
           {t("unreachable.private.open")}
         </Button>

--- a/frontend/src/components/contacts/UnreachableEmptyState.tsx
+++ b/frontend/src/components/contacts/UnreachableEmptyState.tsx
@@ -1,0 +1,113 @@
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+
+import type { CommunityDmToggle } from "@/api/generated/initiativeAPI.schemas";
+import { BirthdateField } from "@/components/auth/BirthdateField";
+import { useAgeConfirmation } from "@/components/auth/useAgeConfirmation";
+import { Button } from "@/components/ui/button";
+import { useUpdateDmSettings } from "@/hooks/useDirectMessages";
+
+/**
+ * Why nothing is listed, in the order the reasons outrank one another.
+ *
+ * `age` first and alone: an account that has not answered has no policy worth
+ * offering and no connections to fall back on, so the panel below it would be
+ * pointing at a route that cannot work.
+ */
+export type UnreachableReason = "age" | "private" | null;
+
+export const unreachableReason = (
+  ageConfirmed: boolean,
+  policy: string | undefined
+): UnreachableReason => {
+  if (!ageConfirmed) return "age";
+  if (policy === "private") return "private";
+  return null;
+};
+
+/**
+ * The panel above the page for an account that has not said how old it is.
+ *
+ * It states the rule and the fact and stops there. What is on the other side
+ * of the answer is deliberately not sold: this is a checkbox about a birthday,
+ * and the only thing keeping the answer honest is that nothing here gave a
+ * reason to get it wrong.
+ */
+export const AgeUnansweredPanel = () => {
+  // The rule and the fact are the Privacy tab's own words: two surfaces say
+  // the same thing to the same account, and one string keeps them agreeing.
+  const { t } = useTranslation(["contacts", "settings"]);
+  const { birthdate, setBirthdate, submitting, error, confirm } = useAgeConfirmation();
+
+  return (
+    <section className="space-y-3 rounded-lg border p-4">
+      <div className="space-y-1">
+        <h2 className="font-medium text-sm">{t("unreachable.age.title")}</h2>
+        <p className="max-w-prose text-muted-foreground text-sm">
+          {t("settings:privacy.dm.ageLocked")}
+        </p>
+      </div>
+      <form
+        className="max-w-sm space-y-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void confirm();
+        }}
+      >
+        <BirthdateField
+          id="contacts-age"
+          value={birthdate}
+          onChange={setBirthdate}
+          disabled={submitting}
+        />
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <Button type="submit" size="sm" disabled={submitting}>
+          {t("settings:privacy.dm.confirmAge")}
+        </Button>
+      </form>
+    </section>
+  );
+};
+
+/**
+ * The panel for an account that is reachable by nobody because it chose to be.
+ *
+ * Two ways out, and the sentence is the more important of them: a connection
+ * reaches this account whatever its policy, so somebody who means to stay
+ * closed should leave knowing the feature works rather than thinking it broke.
+ * The button is the other, and it writes the state Private was designed to be
+ * one click from — open to every community, none of them switched off.
+ */
+export const PrivatePanel = ({ communities }: { communities: CommunityDmToggle[] }) => {
+  const { t } = useTranslation("contacts");
+  const updateSettings = useUpdateDmSettings();
+
+  return (
+    <section className="space-y-3 rounded-lg border border-dashed p-4">
+      <p className="max-w-prose text-muted-foreground text-sm">{t("unreachable.private.body")}</p>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          size="sm"
+          disabled={updateSettings.isPending}
+          onClick={() =>
+            updateSettings.mutate({
+              data: {
+                dm_policy: "community",
+                communities: communities.map((community) => ({
+                  guild_id: community.guild_id,
+                  enabled: true,
+                })),
+              },
+            })
+          }
+        >
+          {t("unreachable.private.open")}
+        </Button>
+        <Button type="button" size="sm" variant="outline" asChild>
+          <Link to="/profile/privacy">{t("unreachable.private.settings")}</Link>
+        </Button>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/pages/user/MyContactsPage.tsx
+++ b/frontend/src/pages/user/MyContactsPage.tsx
@@ -13,6 +13,11 @@ import {
 } from "@/components/contacts/FavoriteContactsSection";
 import { GuildContactSection } from "@/components/contacts/GuildContactSection";
 import type { ChipGuild } from "@/components/contacts/SharedGuildChip";
+import {
+  AgeUnansweredPanel,
+  PrivatePanel,
+  unreachableReason,
+} from "@/components/contacts/UnreachableEmptyState";
 import { StatusMessage } from "@/components/StatusMessage";
 import { Accordion } from "@/components/ui/accordion";
 import {
@@ -20,6 +25,7 @@ import {
   useFavoriteContacts,
   useToggleFavoriteContact,
 } from "@/hooks/useContacts";
+import { useDmSettings } from "@/hooks/useDirectMessages";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { cn } from "@/lib/utils";
 
@@ -57,6 +63,7 @@ export const MyContactsPage = () => {
   );
 
   const sectionsQuery = useContactSections(search);
+  const dmQuery = useDmSettings();
   const favoritesQuery = useFavoriteContacts(search);
 
   const sections = useMemo(() => sectionsQuery.data?.sections ?? [], [sectionsQuery.data]);
@@ -104,6 +111,12 @@ export const MyContactsPage = () => {
     [searching, sections, setCollapse]
   );
 
+  // Why the page is bare, if it is. Only worth saying while nothing is
+  // searched for: under a term an empty page means the term, not the policy.
+  const reason = searching
+    ? null
+    : unreachableReason(Boolean(dmQuery.data?.age_confirmed_at), dmQuery.data?.dm_policy);
+
   const isFirstLoad = sectionsQuery.isLoading || favoritesQuery.isLoading;
   // A term in flight, whether or not last term's answer is still on screen.
   const isSearchPending =
@@ -129,6 +142,11 @@ export const MyContactsPage = () => {
       />
 
       {isSearchPending ? <ContactSearchProgress /> : null}
+
+      {/* Above the table rather than inside it: an unanswered age closes
+          messaging in both directions, so it is not a remark about the
+          community sections. */}
+      {reason === "age" ? <AgeUnansweredPanel /> : null}
 
       {isFirstLoad ? (
         <div className="rounded-lg border px-3 py-2">
@@ -176,6 +194,13 @@ export const MyContactsPage = () => {
               />
             ))}
           </Accordion>
+          {/* Under the communities, which are the sections a policy empties.
+              Favorites above it are the reader's own list and stay. */}
+          {reason === "private" ? (
+            <div className="pt-2">
+              <PrivatePanel communities={dmQuery.data?.communities ?? []} />
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/frontend/src/pages/user/MyContactsPage.tsx
+++ b/frontend/src/pages/user/MyContactsPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { SearchX, Users } from "lucide-react";
+import { Link2, MessageSquare, SearchX, Users } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -11,6 +11,7 @@ import {
   FAVORITES_VALUE,
   FavoriteContactsSection,
 } from "@/components/contacts/FavoriteContactsSection";
+import { GrantContactSection } from "@/components/contacts/GrantContactSection";
 import { GuildContactSection } from "@/components/contacts/GuildContactSection";
 import type { ChipGuild } from "@/components/contacts/SharedGuildChip";
 import {
@@ -25,11 +26,13 @@ import {
   useFavoriteContacts,
   useToggleFavoriteContact,
 } from "@/hooks/useContacts";
-import { useDmSettings } from "@/hooks/useDirectMessages";
+import { useConnections, useDmSettings, useMessageRequests } from "@/hooks/useDirectMessages";
 import { useViewPreference } from "@/hooks/useViewPreference";
 import { cn } from "@/lib/utils";
 
 const COLLAPSE_SCOPE = "my-contacts-sections";
+const CONNECTIONS_VALUE = "connections";
+const OPEN_CHANNELS_VALUE = "open-channels";
 
 /** Which sections the reader has closed. Everything else is open. */
 type CollapseState = { closed: string[] };
@@ -64,12 +67,43 @@ export const MyContactsPage = () => {
 
   const sectionsQuery = useContactSections(search);
   const dmQuery = useDmSettings();
+  const connectionsQuery = useConnections();
+  const messagesQuery = useMessageRequests();
   const favoritesQuery = useFavoriteContacts(search);
 
   const sections = useMemo(() => sectionsQuery.data?.sections ?? [], [sectionsQuery.data]);
   const favorites = useMemo(() => favoritesQuery.data?.items ?? [], [favoritesQuery.data]);
 
   const starredIds = useMemo(() => new Set(favorites.map((contact) => contact.id)), [favorites]);
+
+  // Neither list is narrowed by the server — both arrive whole — so the term
+  // is applied here, on the handle, which is all these rows carry.
+  const matches = useCallback(
+    (grant: { username: string; discriminator: number }) => {
+      const term = search.trim().toLowerCase();
+      if (!term) return true;
+      const handle = `${grant.username}#${String(grant.discriminator).padStart(4, "0")}`;
+      return handle.includes(term.replace(/^@/, ""));
+    },
+    [search]
+  );
+
+  const connections = useMemo(
+    () => (connectionsQuery.data?.accepted ?? []).filter(matches),
+    [connectionsQuery.data, matches]
+  );
+
+  // Accepting a connection opens the channel with it, so every connection also
+  // holds a message grant. Listing those again here would make this section a
+  // near-copy of the one above it; what is left is the people this section
+  // exists for — the ones an agreement to message is the *only* thing the
+  // reader shares with, who appear nowhere else on the page.
+  const openChannels = useMemo(() => {
+    const connected = new Set((connectionsQuery.data?.accepted ?? []).map((g) => g.user_id));
+    return (messagesQuery.data?.accepted ?? []).filter(
+      (grant) => !connected.has(grant.user_id) && matches(grant)
+    );
+  }, [connectionsQuery.data, messagesQuery.data, matches]);
 
   // Every id a chip can name is one of these sections, so the chip resolves
   // against what the page already has.
@@ -94,34 +128,50 @@ export const MyContactsPage = () => {
 
   // While a term is set every matching section is open, and the reader's own
   // collapse state is left untouched so clearing the field restores it.
+  const allValues = useMemo(
+    () => [
+      FAVORITES_VALUE,
+      CONNECTIONS_VALUE,
+      OPEN_CHANNELS_VALUE,
+      ...sections.map((s) => `guild-${s.guild_id}`),
+    ],
+    [sections]
+  );
+
   const openValues = useMemo(() => {
-    const all = [FAVORITES_VALUE, ...sections.map((s) => `guild-${s.guild_id}`)];
-    if (searching) return all;
+    if (searching) return allValues;
     const closed = new Set(collapse.closed);
-    return all.filter((value) => !closed.has(value));
-  }, [sections, searching, collapse.closed]);
+    return allValues.filter((value) => !closed.has(value));
+  }, [allValues, searching, collapse.closed]);
 
   const onOpenChange = useCallback(
     (next: string[]) => {
       if (searching) return;
-      const all = [FAVORITES_VALUE, ...sections.map((s) => `guild-${s.guild_id}`)];
       const open = new Set(next);
-      setCollapse({ closed: all.filter((value) => !open.has(value)) });
+      setCollapse({ closed: allValues.filter((value) => !open.has(value)) });
     },
-    [searching, sections, setCollapse]
+    [searching, allValues, setCollapse]
   );
 
   // Why the page is bare, if it is. Only worth saying while nothing is
-  // searched for: under a term an empty page means the term, not the policy.
-  const reason = searching
-    ? null
-    : unreachableReason(Boolean(dmQuery.data?.age_confirmed_at), dmQuery.data?.dm_policy);
+  // searched for — under a term an empty page means the term, not the policy —
+  // and only once the settings are in hand: absent, they read as an account
+  // that has answered nothing, which is the one panel that must never be shown
+  // to somebody who has.
+  const reason =
+    searching || !dmQuery.data
+      ? null
+      : unreachableReason(Boolean(dmQuery.data.age_confirmed_at), dmQuery.data.dm_policy);
 
   const isFirstLoad = sectionsQuery.isLoading || favoritesQuery.isLoading;
   // A term in flight, whether or not last term's answer is still on screen.
   const isSearchPending =
     searching && (isFirstLoad || sectionsQuery.isFetching || favoritesQuery.isFetching);
-  const nothingAtAll = sections.length === 0 && favorites.length === 0;
+  const nothingAtAll =
+    sections.length === 0 &&
+    favorites.length === 0 &&
+    connections.length === 0 &&
+    openChannels.length === 0;
 
   return (
     <div className="space-y-4">
@@ -183,6 +233,45 @@ export const MyContactsPage = () => {
               guilds={guilds}
               searching={searching}
             />
+            {/* Under Favorites, because a link the reader made outranks the
+                community that introduced them — and above the community
+                sections for the same reason. */}
+            {connections.length > 0 ? (
+              <GrantContactSection
+                key={`connections:${search}`}
+                value={CONNECTIONS_VALUE}
+                label={t("connections")}
+                title={
+                  <>
+                    <Link2 className="size-4 text-muted-foreground" />
+                    <span>{t("connections")}</span>
+                  </>
+                }
+                items={connections}
+                starredIds={starredIds}
+                onToggleFavorite={toggleFavorite}
+                guilds={guilds}
+                emptyLabel={t("noMatches.section")}
+              />
+            ) : null}
+            {openChannels.length > 0 ? (
+              <GrantContactSection
+                key={`open-channels:${search}`}
+                value={OPEN_CHANNELS_VALUE}
+                label={t("directMessages")}
+                title={
+                  <>
+                    <MessageSquare className="size-4 text-muted-foreground" />
+                    <span>{t("directMessages")}</span>
+                  </>
+                }
+                items={openChannels}
+                starredIds={starredIds}
+                onToggleFavorite={toggleFavorite}
+                guilds={guilds}
+                emptyLabel={t("noMatches.section")}
+              />
+            ) : null}
             {sections.map((section) => (
               <GuildContactSection
                 key={`${section.guild_id}:${search}`}
@@ -198,7 +287,7 @@ export const MyContactsPage = () => {
               Favorites above it are the reader's own list and stay. */}
           {reason === "private" ? (
             <div className="pt-2">
-              <PrivatePanel communities={dmQuery.data?.communities ?? []} />
+              <PrivatePanel />
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
Last PR in the direct-message series. My Contacts becomes the roster of people the reader can actually message — and chasing one `permission denied` turned up a privilege bug in `set_rls_context` that is the more important half of this PR.

## The privilege bug

`set_rls_context` writes every parameter from the current call, so nothing carries between requests on a pooled connection. The platform tier was one of those parameters, and a session that re-established its own context by naming its user again — `set_rls_context(session, user_id=...)` — silently lost it and finished the request on the bare login role.

On `public.users` that is the wrong direction:

| role | SELECT policy |
|---|---|
| `platform_base` (the floor every tier inherits) | `users_platform_self` — own row |
| `app_user` (the login role underneath) | `users_app_user_read` — `qual: true`, every row |

So re-establishing context *widened* what the rest of the request could read, on the table the tier ladder exists to narrow. `set_rls_context`'s own docstring said this path "fails closed if a downstream query forgets to route"; on this table it did the opposite.

It is not a one-endpoint slip. `gather_across_guilds` does exactly this before its shared-table read, which puts it in front of every `/me` aggregate, and there are about a dozen call sites of the same shape across services and endpoints.

Nothing here is a demonstrated data leak — the queries that follow are app-written and read what they meant to. What was lost is the database-layer backstop that the repo treats as the enforcement point rather than as defence in depth.

### The fix

The tier belongs to the session rather than to each call:

- naming a `user_id` without a tier re-assumes the one the request authenticated as;
- naming no `user_id` clears it, so a worker's unattributed context still gets nothing and the deliberate reset still resets;
- the guild path records it too, where it provably does not route (`_render_context_bind_params` ignores `platform_role` whenever `route_guild` is not `None`), so the trip back out to `public` has it;
- `guild_schema_context` restores it with the rest of the context it already saves.

**Nothing here is session state at the database.** The tier is held in the SQLAlchemy session's Python state, which is per-request, and it is only an *input* to `set_rls_context`: it is resolved there and written into the stored params, so it reaches Postgres as the same transaction-local `set_config` as every other value and is replayed per transaction by the `after_begin` hook. A test commits between the re-establish and the read, forcing a fresh transaction — the path a transaction-pooled request takes when consecutive transactions land on different backends — and the role is still the tier.

Four tests in `users_own_row_test.py` pin it, and I checked they fail with the fix reverted rather than passing vacuously.

## My Contacts

**Roster filter.** `guild_sections` narrows each section by `public.dm_listable_in_guild` — one call per section, the rule does the join itself.

**An ignore does not narrow it.** An ignore governs what arrives, not who is listed: it takes the account you ignored off your own roster and leaves you on theirs. Two tests pin that direction.

**Communities you are alone in are left out.** A section for a community of one would say nobody there is accepting messages, which is a remark about people who are not there.

**Connections and open channels get their own sections, above the communities.** Two accounts on *Anyone* who accepted each other share no community and are not connections, so nothing listed them — and connections were in the same position, since the page only ever showed people a community introduced. Accepting a connection opens the channel with it, so every connection holds a message grant too; the second section drops those and keeps the people an agreement to message is the only thing shared with. `ContactGrantRead` now carries `status` and `presence` so a grant renders as an ordinary row — no real name, which is a per-community disclosure and these are the rows there may be no community behind.

**Empty is the ordinary case,** since the shipped default is Private, so the page says which reason it is:

| Why nothing is listed | What it shows |
|---|---|
| age unanswered | a panel above the whole page — nothing about policy or connections, neither of which this account has |
| policy is Private | a panel under the communities, with one button that opens every community, plus the handle route |
| reachable, nobody here is | "No one here is accepting messages right now." — no count, no names |
| in no communities | the existing empty state, unchanged |

The age panel deliberately does not sell what confirming unlocks. It states the rule and the fact, and stops.

## Schema / env

None. No migration; the rule and its grants shipped in #1372.

## Testing

- `pytest app/db/users_own_row_test.py` — 15 passed, and the three new ones fail with the fix reverted
- `pytest app/api/v1/platform_endpoints/contacts_test.py app/services/platform/contacts_reachable_test.py` — 31 passed
- `npx vitest run` — 222 files, 2469 passed
- `ruff check app`, `ruff format app`, `ty check app` — clean
- `pytest app/db app/api app/services/platform` — 2846 passed, 84 skipped, the whole blast radius of the `set_rls_context` change

Both Greptile P1s are fixed: the settings query resolving to `undefined` no longer reads as an unanswered age, and the Private panel's button sends only the policy rather than staking it on a membership list fetched earlier.

The nine existing roster tests moved onto a module fixture that sets the operator default to `community` — on the shipped default their sections are empty and their paging, search and naming assertions have nothing to describe. The default itself, and the empty page it makes, are what `contacts_reachable_test.py` is for.
