### PR TITLE
Act on somebody where you find them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Ignore an account.** They stop reaching you: no notification when they mention, reply to or react to you, and nothing they send arrives — messages, message requests, connection requests. You will still see each other's activity in communities you share and can use every tool normally, because ignoring is about contact rather than about work. Nothing is deleted, so if you stop ignoring them everything is exactly where it was.
 
+- **Act on somebody where you find them.** A menu on a profile, and on every row of My Contacts: connect, ask to message, ignore — and remove a connection, which confirms first. Ignoring used to mean knowing an account's exact handle and opening Settings, which is not where anybody reaches for it.
+
 ### Changed
+
+- **Choose what new accounts start on.** Settings › Community gains the direct-message policy an account is created with. It is read once, when the account is made, so changing it opens no account that already exists and closes none either. The shipped default is Private.
+
+- **Requests wait on My Contacts too.** Anything asking for an answer — either direction, connection or message — sits above the page rather than only in Settings.
 
 - **My Contacts lists the people you could actually reach.** A community section now shows the members who can message you and who you can message, rather than everyone in the room — so the page answers "who can I talk to" instead of "who is here". A community you are alone in is left out entirely. Because the shipped default is Private, a new account's sections start empty, and the page says why and offers the one setting that fills them, rather than reading as a community with nobody in it. It never counts the people it is not listing. Two new sections sit above the communities: your connections, and the people you agreed to message who are in none of your communities — before this they appeared nowhere.
 
 ### Fixed
+
+- **Everyone in a community hears that it was listed.** The notice that a community joined the directory — which is what asks its members their age — only reached people whose tab happened to be held by the same server process that made the change. On a deployment running more than one, everybody else waited until they next navigated.
 
 - **A search tab that matched nothing says so.** In ⌘K, switching between Tools, Members, Comments and Tags left the tab before it on screen when the new one had no answer — so a community with nobody matching showed the comments you had just been reading. Each tab now shows only what it found, and says "No results found." when that is nothing — or that search is not answering, if the request never landed, rather than reporting a failure as an empty community.
 

--- a/backend/app/services/platform/account_stream.py
+++ b/backend/app/services/platform/account_stream.py
@@ -47,9 +47,10 @@ def queue_for_members(session: Any, user_ids: Any, action: str = "changed") -> N
     """Signal a set of accounts at once — a whole community's members.
 
     Listing a community changes the answer for everybody already in it, which
-    is the one fan-out this channel has. Callers pass only the accounts worth
-    poking (see ``user_stream.stream.connected_users``), so the cost is the
-    sockets this worker holds rather than the size of the membership.
+    is the one fan-out this channel has. Callers pass the whole set: each frame
+    goes to this worker's sockets and onto the bus for every other worker's,
+    and a caller that narrowed to its own sockets first would be answering for
+    processes it cannot see.
     """
     for user_id in user_ids:
         queue_account_signal(session, user_id, action)

--- a/backend/app/services/platform/account_stream_test.py
+++ b/backend/app/services/platform/account_stream_test.py
@@ -32,6 +32,18 @@ async def _drain_tasks() -> None:
 
 
 @pytest.fixture
+def published_remotely(monkeypatch):
+    """The ids this worker handed to the bus for the other workers to deliver."""
+    seen: list[int] = []
+
+    async def _record(user_id: int, _frame) -> None:
+        seen.append(user_id)
+
+    monkeypatch.setattr(user_stream, "_publish_remote", _record)
+    return seen
+
+
+@pytest.fixture
 def captured_stream(monkeypatch):
     """A registry of this test's own, patched where the sockets really live."""
     stream = UserStream()
@@ -183,10 +195,17 @@ async def test_re_adding_an_existing_member_pokes_nobody(
 
 
 @pytest.mark.integration
-async def test_listing_a_community_pokes_the_members_who_are_here(
-    session, captured_stream
+async def test_listing_a_community_pokes_every_member(
+    session, captured_stream, published_remotely
 ) -> None:
-    """The fan-out: nobody in the guild did anything, and it changes them all."""
+    """The fan-out: nobody in the guild did anything, and it changes them all.
+
+    Addressed to the whole roster rather than to the sockets this process is
+    holding. A member sitting on another worker has no socket *here*, and the
+    frame that reaches them is the one this worker puts on the bus — so a
+    roster narrowed by local sockets first would be deciding, from one
+    process, that everybody else is absent.
+    """
     here = await create_user(session)
     away = await create_user(session)
     guild = await create_guild(session)
@@ -220,6 +239,8 @@ async def test_listing_a_community_pokes_the_members_who_are_here(
     await _drain_tasks()
 
     assert [frame["resource"] for frame in tab.sent] == ["account"]
-    # The member with no socket here cost nothing: they were never queued, and
-    # they re-read their account whenever they next turn up.
-    assert captured_stream.socket_count(away.id) == 0
+    # And the one this worker holds nothing for: published, for whichever
+    # worker does hold them. Without it their tab would sit on the old answer
+    # until they navigated.
+    assert away.id in published_remotely
+    assert here.id in published_remotely

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -7,7 +7,7 @@ import secrets
 
 from sqlalchemy import Integer, bindparam, func, or_, text
 from sqlalchemy.dialects.postgresql import ARRAY
-from sqlmodel import col, select, delete
+from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.role_context import set_guild_shows_member_names
@@ -787,8 +787,7 @@ async def update_guild(
         updated = True
         # Listing a community — or taking it back off the shelf — changes what
         # is asked of everybody already in it, none of whom did anything. The
-        # one fan-out this channel has, and it is addressed to the members who
-        # are actually here rather than to the whole roster.
+        # one fan-out this channel has, and it is addressed to the roster.
         await _signal_members_present(session, guild_id=guild.id)
     if categories_provided:
         normalized = normalize_categories(categories)
@@ -1072,27 +1071,21 @@ async def redeem_invite_for_user(
 
 
 async def _signal_members_present(session: AsyncSession, *, guild_id: int) -> None:
-    """Poke this guild's members whose tabs this worker is holding.
+    """Poke this guild's members: listing it changes what their account says.
 
-    A guild may have thousands of members and almost none of them are at a
-    keyboard right now, so the roster is narrowed to the sockets this process
-    has before anything is queued: the cost is the people who are here, not the
-    people who exist. Everyone else re-reads their account when they next
-    arrive, which is the same moment they would have seen the change anyway.
+    Addressed to the whole membership rather than to the sockets this process
+    holds. A frame is published on the cross-worker bus, so narrowing to the
+    local sockets first would decide, on this worker, that members sitting on
+    every other worker are not here — and the frame for them would never be
+    published for their own worker to deliver. The bus serializes its sends
+    for exactly this fan-out.
 
-    Other workers' members are reached by their own listeners off the bus, so
-    what looks process-local here is not.
+    Members with nothing open are addressed too and cost a frame that reaches
+    no socket. That is the price of the question being unanswerable from one
+    process; they would re-read their account on arriving anyway.
     """
-    from app.services.platform.user_stream import stream as user_sockets
-
-    here = user_sockets.connected_users()
-    if not here:
-        return
     rows = await session.exec(
-        select(GuildMembership.user_id).where(
-            GuildMembership.guild_id == guild_id,
-            col(GuildMembership.user_id).in_(here),
-        )
+        select(GuildMembership.user_id).where(GuildMembership.guild_id == guild_id)
     )
     account_stream.queue_for_members(session, rows.all(), "community")
 

--- a/frontend/public/locales/de/contacts.json
+++ b/frontend/public/locales/de/contacts.json
@@ -4,6 +4,7 @@
   "favorites": "Favoriten",
   "connections": "Verbindungen",
   "directMessages": "Direktnachrichten",
+  "requests": "Anfragen",
   "searchPlaceholder": "Kontakte durchsuchen",
   "searchLabel": "Alle auf dieser Seite durchsuchen",
   "clearSearch": "Suche zurücksetzen",
@@ -47,5 +48,16 @@
       "open": "Meine Communitys dürfen mir schreiben",
       "settings": "Privatsphäre-Einstellungen"
     }
+  },
+  "actions": {
+    "label": "Aktionen für {{handle}}",
+    "connect": "Verbinden",
+    "ask": "Um Nachricht bitten",
+    "askSent": "Anfrage gesendet.",
+    "ignore": "Ignorieren",
+    "stopIgnoring": "Nicht mehr ignorieren",
+    "removeConnection": "Verbindung entfernen",
+    "removeConnectionTitle": "Diese Verbindung entfernen?",
+    "removeConnectionBody": "Ihr seid dann nicht mehr verbunden. Wenn euch sonst nichts erlaubt, einander zu schreiben – eine gemeinsame Community oder dass ihr beide für Nachrichten offen seid –, endet auch das."
   }
 }

--- a/frontend/public/locales/de/settings.json
+++ b/frontend/public/locales/de/settings.json
@@ -1126,7 +1126,9 @@
     "ageGateHelpText": "Solange dies aktiv ist, wird jede Person in einer gelisteten Community einmal um eine Altersbestätigung gebeten; die Antwort bleibt an ihrem Konto. Nur dort deaktivieren, wo bereits feststeht, dass jedes Konto einer erwachsenen Person gehört.",
     "ageGateOffTitle": "Nicht mehr nach dem Alter fragen?",
     "ageGateOffBody": "Das Deaktivieren erklärt, dass jedes Konto dieser Installation einer Person ab 18 Jahren gehört. Niemand wird erneut um eine Altersbestätigung gebeten – auch nicht bei einem späteren Beitritt zu einer gelisteten Community.",
-    "ageGateOffConfirm": "Hier sind alle mindestens 18"
+    "ageGateOffConfirm": "Hier sind alle mindestens 18",
+    "defaultDmLabel": "Direktnachrichten für neue Konten",
+    "defaultDmHelpText": "Die Einstellung, mit der ein Konto startet. Sie wird einmal gelesen, wenn das Konto erstellt wird – eine Änderung öffnet kein bestehendes Konto und schließt auch keines. „Privat“ ist die Voreinstellung; damit werden Personen nach und nach erreichbar, sobald sie es selbst wählen."
   },
   "audit": {
     "title": "Prüfprotokoll",

--- a/frontend/public/locales/en/contacts.json
+++ b/frontend/public/locales/en/contacts.json
@@ -4,6 +4,7 @@
   "favorites": "Favorites",
   "connections": "Connections",
   "directMessages": "Direct messages",
+  "requests": "Requests",
   "searchPlaceholder": "Search contacts",
   "searchLabel": "Search everyone on this page",
   "clearSearch": "Clear search",
@@ -47,5 +48,16 @@
       "open": "Let my communities message me",
       "settings": "Privacy settings"
     }
+  },
+  "actions": {
+    "label": "Actions for {{handle}}",
+    "connect": "Connect",
+    "ask": "Ask to message",
+    "askSent": "Request sent.",
+    "ignore": "Ignore",
+    "stopIgnoring": "Stop ignoring",
+    "removeConnection": "Remove connection",
+    "removeConnectionTitle": "Remove this connection?",
+    "removeConnectionBody": "You will no longer be connected. If nothing else lets the two of you message each other — a community you both belong to, or both of you being open to messages — that ends with it."
   }
 }

--- a/frontend/public/locales/en/settings.json
+++ b/frontend/public/locales/en/settings.json
@@ -1126,7 +1126,9 @@
     "ageGateHelpText": "While this is on, anyone who belongs to a listed community is asked once to confirm their age, and the answer is kept on their account. Turn it off only where you already know every account belongs to an adult.",
     "ageGateOffTitle": "Stop asking members their age?",
     "ageGateOffBody": "Turning this off asserts that every account on this deployment belongs to someone 18 or older. Nobody will be asked to confirm their age again, including people who join a listed community later.",
-    "ageGateOffConfirm": "Everyone here is 18 or older"
+    "ageGateOffConfirm": "Everyone here is 18 or older",
+    "defaultDmLabel": "Direct messages for new accounts",
+    "defaultDmHelpText": "The policy an account starts on. Read once, when the account is made — changing it opens no account that already exists and closes none either. “Private” is the shipped default; on it, people become reachable one at a time as they choose to be."
   },
   "audit": {
     "title": "Audit",

--- a/frontend/public/locales/es/contacts.json
+++ b/frontend/public/locales/es/contacts.json
@@ -4,6 +4,7 @@
   "favorites": "Favoritos",
   "connections": "Conexiones",
   "directMessages": "Mensajes directos",
+  "requests": "Solicitudes",
   "searchPlaceholder": "Buscar contactos",
   "searchLabel": "Buscar a todos en esta página",
   "clearSearch": "Borrar búsqueda",
@@ -47,5 +48,16 @@
       "open": "Permitir que mis comunidades me escriban",
       "settings": "Ajustes de privacidad"
     }
+  },
+  "actions": {
+    "label": "Acciones para {{handle}}",
+    "connect": "Conectar",
+    "ask": "Pedir escribir",
+    "askSent": "Solicitud enviada.",
+    "ignore": "Ignorar",
+    "stopIgnoring": "Dejar de ignorar",
+    "removeConnection": "Eliminar conexión",
+    "removeConnectionTitle": "¿Eliminar esta conexión?",
+    "removeConnectionBody": "Dejaréis de estar conectados. Si nada más os permite escribiros —una comunidad que compartáis, o que ambos estéis abiertos a mensajes—, eso también termina."
   }
 }

--- a/frontend/public/locales/es/settings.json
+++ b/frontend/public/locales/es/settings.json
@@ -1126,7 +1126,9 @@
     "ageGateHelpText": "Mientras esto esté activo, a quien pertenezca a una comunidad listada se le pide una vez que confirme su edad, y la respuesta queda en su cuenta. Desactívalo solo donde ya sepas que todas las cuentas pertenecen a personas adultas.",
     "ageGateOffTitle": "¿Dejar de preguntar la edad?",
     "ageGateOffBody": "Desactivarlo afirma que todas las cuentas de esta instalación pertenecen a personas de 18 años o más. No se volverá a pedir a nadie que confirme su edad, ni siquiera a quien se una más adelante a una comunidad listada.",
-    "ageGateOffConfirm": "Aquí todo el mundo tiene 18 o más"
+    "ageGateOffConfirm": "Aquí todo el mundo tiene 18 o más",
+    "defaultDmLabel": "Mensajes directos para cuentas nuevas",
+    "defaultDmHelpText": "El ajuste con el que empieza una cuenta. Se lee una sola vez, al crearla: cambiarlo no abre ninguna cuenta existente ni cierra ninguna. «Privado» es el valor de fábrica; con él, cada persona pasa a ser localizable cuando así lo decide."
   },
   "audit": {
     "title": "Auditoría",

--- a/frontend/public/locales/fr/contacts.json
+++ b/frontend/public/locales/fr/contacts.json
@@ -4,6 +4,7 @@
   "favorites": "Favoris",
   "connections": "Connexions",
   "directMessages": "Messages directs",
+  "requests": "Demandes",
   "searchPlaceholder": "Rechercher des contacts",
   "searchLabel": "Rechercher parmi tout le monde sur cette page",
   "clearSearch": "Effacer la recherche",
@@ -47,5 +48,16 @@
       "open": "Autoriser mes communautés à m'écrire",
       "settings": "Paramètres de confidentialité"
     }
+  },
+  "actions": {
+    "label": "Actions pour {{handle}}",
+    "connect": "Se connecter",
+    "ask": "Demander à écrire",
+    "askSent": "Demande envoyée.",
+    "ignore": "Ignorer",
+    "stopIgnoring": "Ne plus ignorer",
+    "removeConnection": "Supprimer la connexion",
+    "removeConnectionTitle": "Supprimer cette connexion ?",
+    "removeConnectionBody": "Vous ne serez plus connectés. Si rien d'autre ne vous permet de vous écrire — une communauté commune, ou le fait que vous soyez tous deux ouverts aux messages —, cela prend fin aussi."
   }
 }

--- a/frontend/public/locales/fr/settings.json
+++ b/frontend/public/locales/fr/settings.json
@@ -1126,7 +1126,9 @@
     "ageGateHelpText": "Tant que ceci est actif, toute personne appartenant à une communauté référencée doit confirmer son âge une fois, et la réponse reste attachée à son compte. Ne le désactivez que là où vous savez déjà que chaque compte appartient à une personne adulte.",
     "ageGateOffTitle": "Ne plus demander l'âge des membres ?",
     "ageGateOffBody": "Désactiver ceci affirme que chaque compte de cette installation appartient à une personne de 18 ans ou plus. Plus personne ne sera invité à confirmer son âge, y compris en rejoignant plus tard une communauté référencée.",
-    "ageGateOffConfirm": "Tout le monde ici a 18 ans ou plus"
+    "ageGateOffConfirm": "Tout le monde ici a 18 ans ou plus",
+    "defaultDmLabel": "Messages privés pour les nouveaux comptes",
+    "defaultDmHelpText": "Le réglage avec lequel un compte démarre. Il est lu une seule fois, à la création du compte : le modifier n'ouvre aucun compte existant et n'en ferme aucun. « Privé » est la valeur livrée ; avec elle, chacun devient joignable au moment où il le décide."
   },
   "audit": {
     "title": "Audit",

--- a/frontend/src/__tests__/factories/dm.factory.ts
+++ b/frontend/src/__tests__/factories/dm.factory.ts
@@ -1,0 +1,40 @@
+import type { ContactGrantRead, IgnoredAccountRead } from "@/api/generated/initiativeAPI.schemas";
+
+let counter = 0;
+
+export function resetCounter(): void {
+  counter = 0;
+}
+
+/** One connection or message request, from the reader's side of it. */
+export function buildContactGrant(overrides: Partial<ContactGrantRead> = {}): ContactGrantRead {
+  counter++;
+  return {
+    user_id: counter,
+    username: `person${counter}`,
+    discriminator: 1234,
+    avatar_url: null,
+    status: "active",
+    presence: "offline",
+    state: "accepted",
+    outgoing: false,
+    created_at: "2026-01-15T00:00:00.000Z",
+    responded_at: "2026-01-16T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** A row of the reader's own ignore list. */
+export function buildIgnoredAccount(
+  overrides: Partial<IgnoredAccountRead> = {}
+): IgnoredAccountRead {
+  counter++;
+  return {
+    user_id: counter,
+    username: `ignored${counter}`,
+    discriminator: 4321,
+    avatar_url: null,
+    created_at: "2026-01-15T00:00:00.000Z",
+    ...overrides,
+  };
+}

--- a/frontend/src/__tests__/factories/index.ts
+++ b/frontend/src/__tests__/factories/index.ts
@@ -4,6 +4,11 @@ export {
   buildRecentActivityEntry,
   resetCounter as resetCommentCounter,
 } from "./comment.factory";
+export {
+  buildContactGrant,
+  buildIgnoredAccount,
+  resetCounter as resetDmCounter,
+} from "./dm.factory";
 export { buildDocumentSummary, resetCounter as resetDocumentCounter } from "./document.factory";
 export {
   buildDefaultFilterPresets,
@@ -84,6 +89,7 @@ export {
 } from "./user.factory";
 
 import { resetCounter as resetCommentCounter } from "./comment.factory";
+import { resetCounter as resetDmCounter } from "./dm.factory";
 import { resetCounter as resetDocumentCounter } from "./document.factory";
 import { resetCounter as resetFilterPresetCounter } from "./filterPreset.factory";
 import { resetCounter as resetGuildCounter } from "./guild.factory";
@@ -119,4 +125,5 @@ export function resetFactories(): void {
   resetMarketplaceCounter();
   resetFilterPresetCounter();
   resetSearchCounter();
+  resetDmCounter();
 }

--- a/frontend/src/__tests__/helpers/handlers/dm.handlers.ts
+++ b/frontend/src/__tests__/helpers/handlers/dm.handlers.ts
@@ -1,0 +1,27 @@
+import { HttpResponse, http } from "msw";
+
+/**
+ * The direct-message surfaces, answering empty.
+ *
+ * Every page that draws a person now reads some of these — the actions menu on
+ * a contact row asks what it may offer about them — so the default is a quiet,
+ * complete answer rather than an unhandled request warning in every unrelated
+ * suite. A test about any of it overrides the one handler it cares about.
+ */
+const noGrants = { accepted: [], incoming: [], outgoing: [] };
+
+export const dmHandlers = [
+  http.get("/api/v1/me/dm-settings", () =>
+    HttpResponse.json({
+      dm_policy: "private",
+      communities: [],
+      age_confirmed_at: "2020-01-01T00:00:00Z",
+    })
+  ),
+  http.get("/api/v1/me/connections", () => HttpResponse.json(noGrants)),
+  http.get("/api/v1/me/message-requests", () => HttpResponse.json(noGrants)),
+  http.get("/api/v1/me/ignored", () => HttpResponse.json({ items: [], total: 0 })),
+  http.get("/api/v1/users/:userId/dm-permission", () =>
+    HttpResponse.json({ permission: "denied" })
+  ),
+];

--- a/frontend/src/__tests__/helpers/handlers/index.ts
+++ b/frontend/src/__tests__/helpers/handlers/index.ts
@@ -1,5 +1,6 @@
 import { authHandlers } from "./auth.handlers";
 import { commentHandlers } from "./comment.handlers";
+import { dmHandlers } from "./dm.handlers";
 import { documentHandlers } from "./document.handlers";
 import { filterPresetHandlers } from "./filterPreset.handlers";
 import { guildHandlers } from "./guild.handlers";
@@ -25,5 +26,6 @@ export const handlers = [
   ...commentHandlers,
   ...userHandlers,
   ...propertyHandlers,
+  ...dmHandlers,
   ...toolCountHandlers,
 ];

--- a/frontend/src/__tests__/myContactsRoute.test.tsx
+++ b/frontend/src/__tests__/myContactsRoute.test.tsx
@@ -50,7 +50,12 @@ vi.mock("@/hooks/useContacts", () => ({
 // The reader's own policy decides whether the page has anything to list, so
 // every test below states it. The default is an account that answered its age
 // and let its communities in — the one whose sections have members.
-vi.mock("@/hooks/useDirectMessages", () => ({
+vi.mock("@/hooks/useDirectMessages", async (importOriginal) => ({
+  // Spread rather than listed: the row's actions menu reads several more of
+  // these, and a mock that had to name every one would break on the next hook
+  // added rather than on anything this file is about. The four below are the
+  // ones a test here steers; the rest run for real, against the handlers.
+  ...(await importOriginal<Record<string, unknown>>()),
   useDmSettings: () => mocks.dmSettings(),
   useUpdateDmSettings: () => ({ mutate: mocks.updateDm, isPending: false }),
   useConnections: () => mocks.connections(),

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -270,6 +270,10 @@ export const invalidateStorageSettings = () =>
 // than a settings one.
 export const invalidateAppConfig = () => invalidatePersonalExact([`/api/v1/config`]);
 
+/** The owner's own read of the three community-wide decisions. */
+export const invalidateCommunitySettings = () =>
+  invalidatePersonalExact([`/api/v1/settings/community`]);
+
 export const invalidateOidcMappings = () =>
   invalidatePersonalPrefix("/api/v1/settings/oidc-mappings");
 

--- a/frontend/src/components/contacts/ContactActionsMenu.test.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * What one person can do about another, and when.
+ *
+ * The menu is the only caller the ignore write has: before it, ignoring an
+ * account meant already knowing its exact handle and opening Settings. So the
+ * assertions here are mostly about an item being *offered* at the moment
+ * somebody would reach for it.
+ */
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildContactGrant, buildIgnoredAccount } from "@/__tests__/factories";
+import { renderWithProviders } from "@/__tests__/helpers/render";
+
+const mocks = vi.hoisted(() => ({
+  permission: vi.fn(),
+  connections: vi.fn(),
+  ignored: vi.fn(),
+  requestConnection: vi.fn(),
+  requestMessage: vi.fn(),
+  removeConnection: vi.fn(),
+  ignore: vi.fn(),
+  stopIgnoring: vi.fn(),
+}));
+
+vi.mock("@/hooks/useDirectMessages", () => ({
+  useDmPermission: () => mocks.permission(),
+  useConnections: () => mocks.connections(),
+  useIgnoredAccounts: () => mocks.ignored(),
+  useRequestConnection: () => ({ mutate: mocks.requestConnection, isPending: false }),
+  useRequestMessage: () => ({ mutate: mocks.requestMessage, isPending: false }),
+  useRemoveConnection: () => ({ mutate: mocks.removeConnection, isPending: false }),
+  useIgnoreAccount: () => ({ mutate: mocks.ignore, isPending: false }),
+  useStopIgnoring: () => ({ mutate: mocks.stopIgnoring, isPending: false }),
+}));
+
+import { ContactActionsMenu } from "./ContactActionsMenu";
+
+const ADA = { id: 7, username: "ada", discriminator: 1234 };
+
+const open = async () => {
+  renderWithProviders(<ContactActionsMenu user={ADA} />);
+  await userEvent.click(screen.getByRole("button", { name: /Actions for ada/i }));
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.permission.mockReturnValue({ data: { permission: "denied" } });
+  mocks.connections.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
+  mocks.ignored.mockReturnValue({ data: { items: [], total: 0 } });
+});
+
+describe("ContactActionsMenu", () => {
+  it("offers ignoring somebody where you met them", async () => {
+    await open();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Ignore" }));
+
+    expect(mocks.ignore).toHaveBeenCalledWith({ userId: 7 });
+  });
+
+  it("offers to stop, once they are on the list", async () => {
+    mocks.ignored.mockReturnValue({
+      data: { items: [buildIgnoredAccount({ user_id: 7 })], total: 1 },
+    });
+    await open();
+
+    expect(await screen.findByRole("menuitem", { name: "Stop ignoring" })).toBeVisible();
+    expect(screen.queryByRole("menuitem", { name: "Ignore" })).toBeNull();
+  });
+
+  it("addresses a connection by handle, which is what reaches a private account", async () => {
+    await open();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Connect" }));
+
+    expect(mocks.requestConnection).toHaveBeenCalledWith(
+      { data: { username: "ada", discriminator: 1234 } },
+      expect.anything()
+    );
+  });
+
+  it("only offers to ask when the server says the reader may", async () => {
+    await open();
+    expect(screen.queryByRole("menuitem", { name: "Ask to message" })).toBeNull();
+  });
+
+  it("offers it when it does", async () => {
+    mocks.permission.mockReturnValue({ data: { permission: "may_request" } });
+    await open();
+
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Ask to message" }));
+    expect(mocks.requestMessage).toHaveBeenCalledWith({ data: { user_id: 7 } }, expect.anything());
+  });
+
+  it("confirms before removing a connection, and does not guess what it costs", async () => {
+    mocks.connections.mockReturnValue({
+      data: { accepted: [buildContactGrant({ user_id: 7 })], incoming: [], outgoing: [] },
+    });
+    await open();
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Remove connection" }));
+
+    // Whether the channel survives depends on the other account's own policy,
+    // which is not this dialog's to read out. So it says what is certain.
+    expect(await screen.findByText(/If nothing else lets the two of you message/i)).toBeVisible();
+    expect(mocks.removeConnection).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove connection" }));
+    await waitFor(() =>
+      expect(mocks.removeConnection).toHaveBeenCalledWith({ userId: 7 }, expect.anything())
+    );
+  });
+
+  it("does not offer connecting to somebody already asked", async () => {
+    mocks.connections.mockReturnValue({
+      data: { accepted: [], incoming: [], outgoing: [buildContactGrant({ user_id: 7 })] },
+    });
+    await open();
+
+    expect(screen.queryByRole("menuitem", { name: "Connect" })).toBeNull();
+  });
+});

--- a/frontend/src/components/contacts/ContactActionsMenu.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.tsx
@@ -1,0 +1,145 @@
+import { MoreHorizontal } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  useConnections,
+  useDmPermission,
+  useIgnoreAccount,
+  useIgnoredAccounts,
+  useRemoveConnection,
+  useRequestConnection,
+  useRequestMessage,
+  useStopIgnoring,
+} from "@/hooks/useDirectMessages";
+import { toast } from "@/lib/chesterToast";
+
+interface ContactActionsMenuProps {
+  /** The account being acted on. The handle is what a connection is addressed
+   *  by, so both halves of it are needed, not just the id. */
+  user: { id: number; username: string; discriminator: number };
+  /** Rendered inside a link or a row that is itself clickable. */
+  className?: string;
+}
+
+/**
+ * What one person can do about another, wherever they meet them.
+ *
+ * Until this existed the writes had no caller: ignoring was reachable only by
+ * already knowing somebody's exact handle and opening Settings, which is the
+ * opposite of the moment somebody reaches for it. So the menu goes where the
+ * person is — their profile, and their row on My Contacts.
+ *
+ * Which items appear is read from ``dm_permission``, one collapsed value the
+ * server computes. *Ask to message* on ``may_request``, nothing on ``denied``
+ * — and because every refusal collapses into that one word, a menu built from
+ * it says nothing about which refusal it is.
+ */
+export const ContactActionsMenu = ({ user, className }: ContactActionsMenuProps) => {
+  const { t } = useTranslation(["contacts", "settings"]);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+
+  const { data: permission } = useDmPermission(user.id);
+  const { data: connections } = useConnections();
+  const { data: ignored } = useIgnoredAccounts();
+
+  const requestConnection = useRequestConnection();
+  const requestMessage = useRequestMessage();
+  const removeConnection = useRemoveConnection();
+  const ignore = useIgnoreAccount();
+  const stopIgnoring = useStopIgnoring();
+
+  const isConnection = (connections?.accepted ?? []).some((g) => g.user_id === user.id);
+  const isPending = (connections?.incoming ?? [])
+    .concat(connections?.outgoing ?? [])
+    .some((g) => g.user_id === user.id);
+  const isIgnored = (ignored?.items ?? []).some((row) => row.user_id === user.id);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={className}
+            aria-label={t("actions.label", { handle: user.username })}
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {!isConnection && !isPending && (
+            <DropdownMenuItem
+              onSelect={() =>
+                requestConnection.mutate(
+                  { data: { username: user.username, discriminator: user.discriminator } },
+                  { onSuccess: () => toast.success(t("settings:privacy.connections.sent")) }
+                )
+              }
+            >
+              {t("actions.connect")}
+            </DropdownMenuItem>
+          )}
+          {permission?.permission === "may_request" && (
+            <DropdownMenuItem
+              onSelect={() =>
+                requestMessage.mutate(
+                  { data: { user_id: user.id } },
+                  { onSuccess: () => toast.success(t("actions.askSent")) }
+                )
+              }
+            >
+              {t("actions.ask")}
+            </DropdownMenuItem>
+          )}
+          {isConnection && (
+            <DropdownMenuItem onSelect={() => setConfirmingRemove(true)}>
+              {t("actions.removeConnection")}
+            </DropdownMenuItem>
+          )}
+          {isIgnored ? (
+            <DropdownMenuItem onSelect={() => stopIgnoring.mutate({ userId: user.id })}>
+              {t("actions.stopIgnoring")}
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              onSelect={() => ignore.mutate({ userId: user.id })}
+              className="text-destructive"
+            >
+              {t("actions.ignore")}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Removing a connection can take the open channel with it, and whether
+          it does depends on the other account's own policy — which is theirs,
+          not something to read off this dialog. So it says what is certain and
+          does not guess which case this pair is. */}
+      <ConfirmDialog
+        open={confirmingRemove}
+        onOpenChange={setConfirmingRemove}
+        title={t("actions.removeConnectionTitle")}
+        description={t("actions.removeConnectionBody")}
+        confirmLabel={t("actions.removeConnection")}
+        destructive
+        isLoading={removeConnection.isPending}
+        onConfirm={() =>
+          removeConnection.mutate(
+            { userId: user.id },
+            { onSuccess: () => setConfirmingRemove(false) }
+          )
+        }
+      />
+    </>
+  );
+};

--- a/frontend/src/components/contacts/ContactColumns.tsx
+++ b/frontend/src/components/contacts/ContactColumns.tsx
@@ -19,8 +19,9 @@ export const CONTACT_ROW_GRID = cn(
   "sm:grid-cols-[2rem_minmax(0,1.1fr)_minmax(0,1fr)_5rem]"
 );
 
-/** The row itself: everything above, plus the star that sits outside the link. */
-export const CONTACT_ROW_OUTER = "grid grid-cols-[minmax(0,1fr)_2rem] items-center gap-1";
+/** The row itself: everything above, plus the two controls that sit outside
+ *  the link — the star, and the menu of what can be done about this person. */
+export const CONTACT_ROW_OUTER = "grid grid-cols-[minmax(0,1fr)_2rem_2rem] items-center gap-1";
 
 /**
  * The one heading over the whole page.
@@ -44,6 +45,7 @@ export const ContactColumnHeader = () => {
         </span>
         <span className="text-muted-foreground text-xs">{t("columns.alsoIn")}</span>
       </div>
+      <span aria-hidden="true" />
       <span aria-hidden="true" />
     </div>
   );

--- a/frontend/src/components/contacts/ContactRequestsSection.tsx
+++ b/frontend/src/components/contacts/ContactRequestsSection.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { ContactGrantRead } from "@/api/generated/initiativeAPI.schemas";
@@ -26,7 +27,13 @@ type PendingRow = ContactGrantRead & { kind: Kind };
  * A request from an account the reader ignores never arrives here: the server
  * leaves it out, so there is nothing to filter and nothing that hints at it.
  */
-export const ContactRequestsSection = () => {
+export const ContactRequestsSection = ({
+  whenEmpty,
+}: {
+  /** What to show with nothing waiting. A page that only offers the section
+   *  when something is waiting passes ``null``. */
+  whenEmpty?: ReactNode;
+} = {}) => {
   const { t } = useTranslation("settings");
   const connections = useConnections();
   const messages = useMessageRequests();
@@ -65,7 +72,11 @@ export const ContactRequestsSection = () => {
       : removeMessage.mutate({ userId: row.user_id });
 
   if (rows.length === 0) {
-    return <p className="text-muted-foreground text-sm">{t("privacy.requests.empty")}</p>;
+    return whenEmpty === undefined ? (
+      <p className="text-muted-foreground text-sm">{t("privacy.requests.empty")}</p>
+    ) : (
+      <>{whenEmpty}</>
+    );
   }
 
   return (

--- a/frontend/src/components/contacts/ContactRow.tsx
+++ b/frontend/src/components/contacts/ContactRow.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 
 import type { ContactRead } from "@/api/generated/initiativeAPI.schemas";
+import { ContactActionsMenu } from "@/components/contacts/ContactActionsMenu";
 import { CONTACT_ROW_GRID, CONTACT_ROW_OUTER } from "@/components/contacts/ContactColumns";
 import { FavoriteToggle } from "@/components/contacts/FavoriteToggle";
 import { type ChipGuild, SharedGuildChip } from "@/components/contacts/SharedGuildChip";
@@ -61,6 +62,15 @@ export const ContactRow = ({
         />
       </Link>
       <FavoriteToggle starred={starred} name={name} onToggle={() => onToggleFavorite(contact)} />
+      {/* Outside the link, like the star: acting on somebody is not the same
+          gesture as going to look at them. */}
+      <ContactActionsMenu
+        user={{
+          id: contact.id,
+          username: contact.username,
+          discriminator: contact.discriminator,
+        }}
+      />
     </li>
   );
 };

--- a/frontend/src/hooks/useDirectMessages.ts
+++ b/frontend/src/hooks/useDirectMessages.ts
@@ -16,6 +16,7 @@ import {
   useListConnectionsApiV1MeConnectionsGet,
   useListIgnoredAccountsApiV1MeIgnoredGet,
   useListMessageRequestsApiV1MeMessageRequestsGet,
+  useReadDmPermissionApiV1UsersUserIdDmPermissionGet,
   useReadDmSettingsApiV1MeDmSettingsGet,
   useRemoveConnectionApiV1MeConnectionsUserIdDelete,
   useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete,
@@ -66,6 +67,19 @@ const refreshOnly = { mutation: { onSettled: refreshContactLists } };
 // ── Reads ───────────────────────────────────────────────────────────────────
 
 export const useDmSettings = () => useReadDmSettingsApiV1MeDmSettingsGet();
+
+/**
+ * What the reader may do about one account: ``open``, ``may_request`` or
+ * ``denied``.
+ *
+ * One value with nothing beside it — the server collapses every refusal into
+ * ``denied`` on purpose, so a menu built from this cannot tell the reasons
+ * apart either.
+ */
+export const useDmPermission = (userId: number | undefined) =>
+  useReadDmPermissionApiV1UsersUserIdDmPermissionGet(userId as number, {
+    query: { enabled: typeof userId === "number" },
+  });
 export const useConnections = () => useListConnectionsApiV1MeConnectionsGet();
 export const useMessageRequests = () => useListMessageRequestsApiV1MeMessageRequestsGet();
 export const useIgnoredAccounts = () => useListIgnoredAccountsApiV1MeIgnoredGet();

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -67,6 +67,7 @@ import {
   updateOidcSettingsApiV1SettingsAuthPut,
   updatePlatformGuildStorageApiV1SettingsGuildsGuildIdPatch,
   updateStorageSettingsApiV1SettingsStoragePut,
+  useReadCommunitySettingsApiV1SettingsCommunityGet,
 } from "@/api/generated/settings/settings";
 import {
   getChangelogApiV1ChangelogGet,
@@ -76,6 +77,7 @@ import {
   invalidateAppConfig,
   invalidateAuthProviders,
   invalidateAuthSettings,
+  invalidateCommunitySettings,
   invalidateEmailSettings,
   invalidateInterfaceSettings,
   invalidateOidcMappings,
@@ -246,11 +248,20 @@ export const useUpdateInterfaceSettings = (
   );
 
 /**
+ * The three community-wide decisions, for the owner's settings page.
+ *
+ * The two switches are on the boot config, which is where every other page
+ * reads them; the default direct-message policy is not, because nothing in the
+ * SPA acts on it — the server applies it when an account is made. So it is
+ * read here, behind the capability that writes it.
+ */
+export const useCommunitySettings = () => useReadCommunitySettingsApiV1SettingsCommunityGet();
+
+/**
  * Turn the community directory on or off for the whole deployment (owner only).
  *
- * There is no matching query: the value is public and every signed-in page
- * needs it, so it rides along with the SPA's boot config — which is what this
- * invalidates, so the owner's own session reflects the switch immediately.
+ * Invalidates the boot config, which carries the two switches every signed-in
+ * page reads, and this page's own read, which carries the third decision.
  */
 export const useUpdateCommunitySettings = (
   options?: MutationOpts<CommunitySettingsResponse, CommunitySettingsUpdate>
@@ -261,7 +272,7 @@ export const useUpdateCommunitySettings = (
         updateCommunitySettingsApiV1SettingsCommunityPut(
           data as Parameters<typeof updateCommunitySettingsApiV1SettingsCommunityPut>[0]
         ),
-      invalidate: () => invalidateAppConfig(),
+      invalidate: () => Promise.all([invalidateAppConfig(), invalidateCommunitySettings()]),
     },
     options
   );

--- a/frontend/src/pages/SettingsCommunityPage.test.tsx
+++ b/frontend/src/pages/SettingsCommunityPage.test.tsx
@@ -7,13 +7,18 @@
  * directory.
  */
 import { fireEvent, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildUser } from "@/__tests__/factories";
 import { renderWithProviders } from "@/__tests__/helpers/render";
 
 const updateMutate = vi.fn();
-const config = vi.hoisted(() => ({ communityDirectory: false, ageGate: true }));
+const config = vi.hoisted(() => ({
+  communityDirectory: false,
+  ageGate: true,
+  defaultDmPolicy: "private" as "private" | "community" | "public",
+}));
 
 vi.mock("@/hooks/useAppConfig", () => ({
   useAppConfig: () => ({
@@ -25,6 +30,13 @@ vi.mock("@/hooks/useAppConfig", () => ({
 
 vi.mock("@/hooks/useSettings", () => ({
   useUpdateCommunitySettings: () => ({ mutate: updateMutate, isPending: false }),
+  useCommunitySettings: () => ({
+    data: {
+      community_directory_enabled: config.communityDirectory,
+      age_gate_enabled: config.ageGate,
+      default_dm_policy: config.defaultDmPolicy,
+    },
+  }),
 }));
 
 import { SettingsCommunityPage } from "./SettingsCommunityPage";
@@ -41,6 +53,7 @@ describe("SettingsCommunityPage", () => {
     updateMutate.mockClear();
     config.communityDirectory = false;
     config.ageGate = true;
+    config.defaultDmPolicy = "private";
   });
 
   it("starts off, matching a deployment that has never turned it on", async () => {
@@ -120,5 +133,29 @@ describe("SettingsCommunityPage", () => {
     expect(
       screen.getByText("You need the platform owner role to run a community directory.")
     ).toBeInTheDocument();
+  });
+});
+
+describe("the policy new accounts start on", () => {
+  it("shows what this deployment ships with", async () => {
+    renderPage();
+    expect(await screen.findByLabelText("Direct messages for new accounts")).toHaveTextContent(
+      "Private"
+    );
+  });
+
+  it("changes it without disturbing the directory switch", async () => {
+    config.communityDirectory = true;
+    renderPage();
+
+    await userEvent.click(screen.getByLabelText("Direct messages for new accounts"));
+    await userEvent.click(await screen.findByRole("option", { name: "My communities" }));
+
+    // The directory value is carried through: the endpoint takes it on every
+    // write, and this control is not a decision about it.
+    expect(updateMutate).toHaveBeenCalledWith({
+      community_directory_enabled: true,
+      default_dm_policy: "community",
+    });
   });
 });

--- a/frontend/src/pages/SettingsCommunityPage.tsx
+++ b/frontend/src/pages/SettingsCommunityPage.tsx
@@ -15,13 +15,21 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { DmPolicy } from "@/api/generated/initiativeAPI.schemas";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { useAuth } from "@/hooks/useAuth";
-import { useUpdateCommunitySettings } from "@/hooks/useSettings";
+import { useCommunitySettings, useUpdateCommunitySettings } from "@/hooks/useSettings";
 import { toast } from "@/lib/chesterToast";
 import { getErrorMessage } from "@/lib/errorMessage";
 import { Capability, hasCapability } from "@/lib/permissions";
@@ -31,6 +39,7 @@ export const SettingsCommunityPage = () => {
   const { user } = useAuth();
   const isPlatformAdmin = hasCapability(user, Capability.configManage);
   const { communityDirectoryEnabled, communityAgeGateEnabled, isLoading } = useAppConfig();
+  const { data: community } = useCommunitySettings();
   // Turning the age gate off is an assertion about every account here, not a
   // preference, so it is confirmed. Turning it back on is not.
   const [confirmingAgeGateOff, setConfirmingAgeGateOff] = useState(false);
@@ -98,6 +107,33 @@ export const SettingsCommunityPage = () => {
             <Label htmlFor="community-age-gate-enabled">{t("community.ageGateLabel")}</Label>
           </div>
           <p className="text-muted-foreground text-sm">{t("community.ageGateHelpText")}</p>
+        </div>
+
+        {/* The third decision. Not a switch and not on the boot config: it is
+            read once, when an account is made, so changing it moves nobody who
+            is already here. */}
+        <div className="space-y-2 border-t pt-4">
+          <Label htmlFor="default-dm-policy">{t("community.defaultDmLabel")}</Label>
+          <Select
+            value={community?.default_dm_policy ?? "private"}
+            disabled={isLoading || update.isPending || !community}
+            onValueChange={(value) =>
+              update.mutate({
+                community_directory_enabled: communityDirectoryEnabled,
+                default_dm_policy: value as DmPolicy,
+              })
+            }
+          >
+            <SelectTrigger id="default-dm-policy" className="max-w-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="private">{t("privacy.dm.private")}</SelectItem>
+              <SelectItem value="community">{t("privacy.dm.community")}</SelectItem>
+              <SelectItem value="public">{t("privacy.dm.public")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-muted-foreground text-sm">{t("community.defaultDmHelpText")}</p>
         </div>
 
         <ConfirmDialog

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -2,6 +2,7 @@ import { useParams } from "@tanstack/react-router";
 import { Loader2, UserX } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import { ContactActionsMenu } from "@/components/contacts/ContactActionsMenu";
 import { TOOL_TRAY_SURFACE } from "@/components/guildHome/GuildToolRail";
 import { CommunityCard } from "@/components/guilds/CommunityCard";
 import { PageBanner } from "@/components/PageBanner";
@@ -100,6 +101,18 @@ export const UserProfilePage = () => {
             />
             {banner ? null : <h1 className="pb-1 font-semibold text-2xl">{name}</h1>}
             <ProfileJoined joinedAt={profile.joined_at} className="ms-auto pb-1" />
+            {/* Not on your own profile: there is nothing here to do about
+                yourself. */}
+            {mine ? null : (
+              <ContactActionsMenu
+                user={{
+                  id: profile.id,
+                  username: profile.username,
+                  discriminator: profile.discriminator,
+                }}
+                className="mb-1"
+              />
+            )}
           </div>
         </div>
 

--- a/frontend/src/pages/user/MyContactsPage.tsx
+++ b/frontend/src/pages/user/MyContactsPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import type { ContactRead } from "@/api/generated/initiativeAPI.schemas";
 import { ContactColumnHeader, ContactRowsSkeleton } from "@/components/contacts/ContactColumns";
+import { ContactRequestsSection } from "@/components/contacts/ContactRequestsSection";
 import { ContactSearchField } from "@/components/contacts/ContactSearchField";
 import { ContactSearchProgress } from "@/components/contacts/ContactSearchProgress";
 import {
@@ -87,6 +88,14 @@ export const MyContactsPage = () => {
     },
     [search]
   );
+
+  // Only the count, to decide whether the strip appears at all — the section
+  // itself reads the same two queries and renders them.
+  const pendingRequests =
+    (connectionsQuery.data?.incoming?.length ?? 0) +
+    (connectionsQuery.data?.outgoing?.length ?? 0) +
+    (messagesQuery.data?.incoming?.length ?? 0) +
+    (messagesQuery.data?.outgoing?.length ?? 0);
 
   const connections = useMemo(
     () => (connectionsQuery.data?.accepted ?? []).filter(matches),
@@ -197,6 +206,18 @@ export const MyContactsPage = () => {
           messaging in both directions, so it is not a remark about the
           community sections. */}
       {reason === "age" ? <AgeUnansweredPanel /> : null}
+
+      {/* Also above it, and only when something is waiting: a request is not a
+          contact yet, it is a question — few, actionable and transient, which
+          is not what the table below is for. The same section the Privacy tab
+          renders, so there is one definition of what a request looks like and
+          one set of answers to it. */}
+      {pendingRequests > 0 ? (
+        <section className="space-y-2 rounded-lg border p-4">
+          <h2 className="font-medium text-sm">{t("requests")}</h2>
+          <ContactRequestsSection whenEmpty={null} />
+        </section>
+      ) : null}
 
       {isFirstLoad ? (
         <div className="rounded-lg border px-3 py-2">


### PR DESCRIPTION
The four gaps left after #1382, in one PR.

## 1. You could not ignore anyone

`useIgnoreAccount` was wired and had no caller. `IgnoredAccountsSection` lists and *un*-ignores; `UserProfilePage` had no direct-message affordances at all. So the endpoint shipped, the list shipped, and the only route into it was knowing somebody's exact handle and opening Settings — which is not where anybody reaches for it. Connecting had the same shape.

`ContactActionsMenu` goes where the person is: their profile, and every row of My Contacts. Connect, ask to message, ignore / stop ignoring, remove connection.

- Which items appear comes from `dm_permission` — one value the server has already collapsed, so a menu built from it tells the refusals apart no better than the reader does. *Ask to message* on `may_request`, nothing on `denied`.
- A connection is addressed by handle, not by id, because that is the shape that reaches an account on Private.
- **Removing a connection confirms first**, and deliberately does not say whether the channel survives. The design said the confirmation should name which case the pair is in; it cannot. That turns on the other account's policy, which is account state and nobody else's (decision 10a). So the copy says what is certain and guesses nothing.

## 2. The operator could not set the default

`GET`/`PUT /settings/community` has carried `default_dm_policy` all along and nothing in the SPA read or wrote it. Settings › Community now has the control.

This is the switch that decides whether the feature is dormant: the shipped default is `private`, and because the rule is mutual, every roster on a fresh deployment is empty for everyone until people opt in one at a time.

## 3. Requests only existed in Settings

They now sit above the My Contacts table when something is waiting — few, actionable and transient, which is not what the table is for. Rendered by the same `ContactRequestsSection` the Privacy tab uses, which grew one presentational prop (`whenEmpty`) so a page that only offers it when something is waiting can pass `null`.

## 4. A community listing reached one worker's tabs

`_signal_members_present` narrowed the roster to `connected_users()` — the sockets *this* process holds — before queueing. But the frame that reaches a member on another worker is the one this worker publishes to the bus, so narrowing first decided, from one process, that every member on every other worker was absent. On a deployment running more than one, most members never got the frame; the docstring claimed the opposite ("what looks process-local here is not").

Removed. The bus is built for this fan-out — its send lock exists for exactly it — and members with nothing open cost a frame that reaches no socket, which is the price of the question being unanswerable from one process.

**Its test asserted the bug.** `test_listing_a_community_pokes_the_members_who_are_here` ended on `socket_count(away.id) == 0` — true whether or not the frame was published, since that member never connected. It now records what went to the bus and asserts both members are on it; I checked it fails with the narrowing restored.

## Schema / env

None. No migration, no new endpoint — items 1–3 are callers for API surface that already shipped.

## Testing

- `npx vitest run` — 223 files, 2478 passed
- `pytest app/services/platform/account_stream_test.py` — 9 passed; the rewritten one fails with the narrowing restored
- `pytest app/services/platform/guilds_test.py app/api/v1/platform_endpoints/settings_test.py` — 100 passed
- `ruff check app`, `ruff format app`, `ty check app` — clean

New: `buildContactGrant` / `buildIgnoredAccount` factories and MSW handlers for the direct-message endpoints, both of which the design called for. The handlers answer empty by default, since every page that draws a person now reads some of them.
