### PR TITLE
Carry ciphertext between two accounts

### DIFF
--- a/backend/alembic/versions/20260905_0226_dm_queue_bytes.py
+++ b/backend/alembic/versions/20260905_0226_dm_queue_bytes.py
@@ -1,0 +1,74 @@
+"""How full one account's mailbox is, asked by whoever is writing to it.
+
+The send path refuses a message that would push the recipient past their
+ceiling, which means the *sender's* session has to learn a number about the
+*recipient's* queue — rows its own policies rightly hide. So it asks a function
+instead, on the ``app_dm_reader`` pattern the rest of the DM rules use: a
+``SECURITY DEFINER`` reader that returns a total and never a row.
+
+Refusing a message is the honest failure. Accepting one and dropping it later
+is not, which is why nothing on the server side expires a queued message and
+this exists instead.
+
+Revision ID: 20260905_0226
+Revises: 20260905_0225
+Create Date: 2026-09-05
+"""
+
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260905_0226"
+down_revision = "20260905_0225"
+branch_labels = None
+depends_on = None
+
+READER = "app_dm_reader"
+
+_FUNCTION = """
+CREATE OR REPLACE FUNCTION public.dm_queue_bytes(account_id int)
+RETURNS bigint
+LANGUAGE sql STABLE PARALLEL SAFE SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $fn$
+  SELECT COALESCE(SUM(octet_length(q.payload)), 0)::bigint
+  FROM public.dm_queue q
+  JOIN public.dm_devices d ON d.id = q.recipient_device_id
+  WHERE d.user_id = account_id
+$fn$
+"""
+
+
+def _platform_base() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+def upgrade() -> None:
+    base = _platform_base()
+    statements = [
+        f'GRANT "{READER}" TO CURRENT_USER WITH INHERIT TRUE, SET TRUE',
+        "GRANT SELECT (id, payload, recipient_device_id) "
+        f'ON TABLE public.dm_queue TO "{READER}"',
+        "DROP POLICY IF EXISTS dm_reader_read ON public.dm_queue",
+        "CREATE POLICY dm_reader_read ON public.dm_queue "
+        f'AS PERMISSIVE FOR SELECT TO "{READER}" USING (true)',
+        _FUNCTION,
+        f'GRANT CREATE ON SCHEMA public TO "{READER}"',
+        f'ALTER FUNCTION public.dm_queue_bytes(int) OWNER TO "{READER}"',
+        "REVOKE ALL ON FUNCTION public.dm_queue_bytes(int) FROM PUBLIC",
+        f'REVOKE CREATE ON SCHEMA public FROM "{READER}"',
+        f'GRANT EXECUTE ON FUNCTION public.dm_queue_bytes(int) TO "{base}"',
+    ]
+    for statement in statements:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    statements = [
+        "DROP FUNCTION IF EXISTS public.dm_queue_bytes(int)",
+        "DROP POLICY IF EXISTS dm_reader_read ON public.dm_queue",
+        f'REVOKE ALL ON TABLE public.dm_queue FROM "{READER}"',
+    ]
+    for statement in statements:
+        op.execute(statement)

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -74,6 +74,7 @@ from app.api.v1.platform_endpoints import (
     users,
     version,
     dm,
+    dm_transport,
 )
 
 api_router = APIRouter()
@@ -90,6 +91,9 @@ api_router.include_router(admin.router, prefix="/admin", tags=["admin"])
 api_router.include_router(guilds.router, prefix="/guilds", tags=["guilds"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(dm.user_router, prefix="/users", tags=["direct-messages"])
+api_router.include_router(
+    dm_transport.user_router, prefix="/users", tags=["direct-messages"]
+)
 # What this deployment carries: the operator's catalog rescan, the signed
 # registry, and the mirrored listing artwork. A property of the deployment
 # rather than of any guild, so it takes no guild segment. Reading the
@@ -266,4 +270,5 @@ me_router.include_router(me_ai.me_router, tags=["ai-settings"])
 me_router.include_router(users.me_router, tags=["users"])
 me_router.include_router(contacts.me_router, tags=["contacts"])
 me_router.include_router(dm.me_router, tags=["direct-messages"])
+me_router.include_router(dm_transport.me_router, tags=["direct-messages"])
 api_router.include_router(me_router)

--- a/backend/app/api/v1/platform_endpoints/dm_transport.py
+++ b/backend/app/api/v1/platform_endpoints/dm_transport.py
@@ -1,0 +1,304 @@
+"""The direct-message transport: keys in, ciphertext through, nothing kept.
+
+All of it on ``UserSessionDep`` — a platform-tier session, RLS enforced. Every
+table these routes touch is own-row for the caller, with two exceptions the
+database itself gates: reading another account's public keys, and claiming one
+of its prekeys, both only where an accepted message grant already exists.
+
+There is no route that returns a conversation's history, because the server has
+none to return. A collected message is deleted; the client is the archive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Response, status
+
+from app.api.deps import UserSessionDep, get_current_active_user
+from app.core.messages import DirectMessageTransportMessages as Messages
+from app.models.platform.user import User
+from app.schemas.platform.dm_transport import (
+    DmConversationCreate,
+    DmConversationRead,
+    DmConversationsResponse,
+    DmDeviceRegistration,
+    DmDevicesResponse,
+    DmOneTimeKeyBatch,
+    DmQueueAck,
+    DmQueueResponse,
+    DmSafetyNumberResponse,
+    DmSendRequest,
+    DmSendResponse,
+    DmSessionKeysResponse,
+)
+from app.services.platform import dm_transport as service
+
+me_router = APIRouter()
+user_router = APIRouter()
+
+CurrentUser = Annotated[User, Depends(get_current_active_user)]
+TargetUserId = Annotated[int, Path(ge=1)]
+
+#: Every refusal that is about the pair answers the same way, so the endpoint is
+#: not a way to learn which of them it was.
+_STATUS = {
+    Messages.DEVICE_NOT_FOUND: status.HTTP_404_NOT_FOUND,
+    Messages.CONVERSATION_NOT_FOUND: status.HTTP_404_NOT_FOUND,
+    Messages.MALFORMED_KEY: status.HTTP_422_UNPROCESSABLE_CONTENT,
+    Messages.DUPLICATE_KEY_ID: status.HTTP_409_CONFLICT,
+    Messages.TOO_MANY_KEYS: status.HTTP_409_CONFLICT,
+    Messages.NOT_REACHABLE: status.HTTP_409_CONFLICT,
+    Messages.CANNOT_MESSAGE_SELF: status.HTTP_409_CONFLICT,
+    Messages.MESSAGE_TOO_LARGE: status.HTTP_413_CONTENT_TOO_LARGE,
+    Messages.RECIPIENT_QUEUE_FULL: status.HTTP_507_INSUFFICIENT_STORAGE,
+}
+
+
+def _error(exc: service.DmTransportError) -> HTTPException:
+    return HTTPException(
+        status_code=_STATUS.get(exc.code, status.HTTP_409_CONFLICT),
+        detail=exc.code,
+    )
+
+
+@me_router.post(
+    "/dm/devices", response_model=DmDevicesResponse, status_code=status.HTTP_201_CREATED
+)
+async def register_device(
+    body: DmDeviceRegistration,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+    user_agent: Annotated[str | None, Header()] = None,
+) -> DmDevicesResponse:
+    """Publish this installed client's public keys.
+
+    The device's label comes from the request's user-agent rather than the body:
+    a device list is more use when it says what actually connected.
+    """
+    try:
+        await service.register_device(
+            session,
+            user_id=current_user.id,
+            identity_key=body.identity_key,
+            fingerprint_key=body.fingerprint_key,
+            fallback_key=body.fallback_key,
+            one_time_keys=body.one_time_keys,
+            label=(user_agent or "")[:200] or None,
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return DmDevicesResponse(
+        devices=await service.list_devices(session, user_id=current_user.id)
+    )
+
+
+@me_router.get("/dm/devices", response_model=DmDevicesResponse)
+async def list_devices(
+    session: UserSessionDep, current_user: CurrentUser
+) -> DmDevicesResponse:
+    return DmDevicesResponse(
+        devices=await service.list_devices(session, user_id=current_user.id)
+    )
+
+
+@me_router.delete("/dm/devices/{device_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_device(
+    device_id: uuid.UUID,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> Response:
+    """Stop encrypted messaging on one device, without signing it out.
+
+    Takes its queued messages with it, which is the one thing that removes an
+    undelivered message and is a visible act by the person who owns it.
+    """
+    try:
+        await service.remove_device(
+            session, user_id=current_user.id, device_id=device_id
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@me_router.post("/dm/one-time-keys", response_model=DmDevicesResponse)
+async def top_up_keys(
+    body: DmOneTimeKeyBatch,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> DmDevicesResponse:
+    try:
+        await service.add_one_time_keys(
+            session,
+            user_id=current_user.id,
+            device_id=body.device_id,
+            keys=body.one_time_keys,
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return DmDevicesResponse(
+        devices=await service.list_devices(session, user_id=current_user.id)
+    )
+
+
+@user_router.post("/{user_id}/dm/session-keys", response_model=DmSessionKeysResponse)
+async def claim_session_keys(
+    user_id: TargetUserId,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> DmSessionKeysResponse:
+    """Claim what is needed to open a session with each of that account's
+    devices.
+
+    A POST rather than a GET because a claim spends a prekey — this writes.
+    """
+    if user_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=Messages.CANNOT_MESSAGE_SELF,
+        )
+    try:
+        devices = await service.claim_session_keys(session, target_id=user_id)
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return DmSessionKeysResponse(user_id=user_id, devices=devices)
+
+
+@user_router.get("/{user_id}/dm/safety-number", response_model=DmSafetyNumberResponse)
+async def safety_number(
+    user_id: TargetUserId,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> DmSafetyNumberResponse:
+    """Both parties' fingerprints, so the client can render the comparison."""
+    try:
+        theirs = await service.fingerprints(session, user_id=user_id)
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    if not theirs:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=Messages.DEVICE_NOT_FOUND,
+        )
+    return DmSafetyNumberResponse(
+        user_id=user_id,
+        their_fingerprints=theirs,
+        my_fingerprints=await service.fingerprints(session, user_id=current_user.id),
+    )
+
+
+@me_router.post(
+    "/dm/conversations",
+    response_model=DmConversationRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_conversation(
+    body: DmConversationCreate,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> DmConversationRead:
+    try:
+        conversation = await service.create_conversation(
+            session, actor_id=current_user.id, other_id=body.user_id
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return DmConversationRead(
+        id=conversation.id,
+        other_user_id=body.user_id,
+        created_at=conversation.created_at,
+    )
+
+
+@me_router.get("/dm/conversations", response_model=DmConversationsResponse)
+async def list_conversations(
+    session: UserSessionDep, current_user: CurrentUser
+) -> DmConversationsResponse:
+    return DmConversationsResponse(
+        conversations=await service.list_conversations(session, user_id=current_user.id)
+    )
+
+
+@me_router.delete(
+    "/dm/conversations/{conversation_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def leave_conversation(
+    conversation_id: uuid.UUID,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> Response:
+    try:
+        await service.leave_conversation(
+            session, user_id=current_user.id, conversation_id=conversation_id
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@me_router.post(
+    "/dm/conversations/{conversation_id}/messages", response_model=DmSendResponse
+)
+async def send_messages(
+    conversation_id: uuid.UUID,
+    body: DmSendRequest,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> DmSendResponse:
+    """Hand the server one already-encrypted copy per destination device."""
+    try:
+        written, _recipient = await service.send(
+            session,
+            user_id=current_user.id,
+            conversation_id=conversation_id,
+            messages=body.messages,
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return DmSendResponse(accepted=written)
+
+
+@me_router.get("/dm/queue", response_model=DmQueueResponse)
+async def collect_queue(
+    device_id: uuid.UUID,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> DmQueueResponse:
+    """Everything waiting for one device, oldest first."""
+    try:
+        items = await service.collect(
+            session, user_id=current_user.id, device_id=device_id
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return DmQueueResponse(items=items)
+
+
+@me_router.post("/dm/queue/ack", status_code=status.HTTP_204_NO_CONTENT)
+async def acknowledge_queue(
+    body: DmQueueAck,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> Response:
+    """Delete what this device has taken."""
+    try:
+        await service.acknowledge(
+            session,
+            user_id=current_user.id,
+            device_id=body.device_id,
+            message_ids=body.message_ids,
+        )
+    except service.DmTransportError as exc:
+        raise _error(exc) from exc
+    await session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/platform_endpoints/dm_transport_test.py
+++ b/backend/app/api/v1/platform_endpoints/dm_transport_test.py
@@ -1,0 +1,398 @@
+"""The transport endpoints: keys in, ciphertext through, nothing kept.
+
+The assertions worth keeping are about what the server *cannot* do and what a
+sender *cannot* learn: that a stranger gets no keys, that an ignored sender is
+answered exactly like an un-ignored one while nothing arrives, and that a
+collected message stops existing.
+"""
+
+import base64
+
+import pytest
+from sqlalchemy import text
+
+from app.models.platform.user_dm_settings import DmPolicy
+from app.models.platform.user_ignore import UserIgnore
+
+pytestmark = pytest.mark.asyncio
+
+
+def _key(seed: int) -> str:
+    return base64.b64encode(bytes([seed % 251]) * 32).decode()
+
+
+def _registration(seed: int = 1) -> dict:
+    return {
+        "identity_key": _key(seed),
+        "fingerprint_key": _key(seed + 1),
+        "fallback_key": {"key_id": "fb", "public_key": _key(seed + 2)},
+        "one_time_keys": [{"key_id": "otk-1", "public_key": _key(seed + 3)}],
+    }
+
+
+async def _set_policy(session, user, policy: DmPolicy) -> None:
+    await session.exec(
+        text(
+            "UPDATE public.user_dm_settings SET dm_policy = CAST(:p AS user_dm_policy) "
+            "WHERE user_id = :u"
+        ).bindparams(p=policy.value, u=user.id)
+    )
+    await session.commit()
+
+
+async def _open_channel(session, a, b) -> None:
+    """The accepted message grant a request earns, applied directly."""
+    low, high = (a.id, b.id) if a.id < b.id else (b.id, a.id)
+    await session.exec(
+        text(
+            "INSERT INTO public.contact_grants "
+            "(user_id_low, user_id_high, kind, state, requested_by, created_at) "
+            "VALUES (:lo, :hi, 'message', 'accepted', :by, now()) "
+            "ON CONFLICT DO NOTHING"
+        ).bindparams(lo=low, hi=high, by=a.id)
+    )
+    await session.commit()
+
+
+async def _register(client, actor, seed=1, user_agent="Firefox on Linux") -> str:
+    response = await client.post(
+        "/api/v1/me/dm/devices",
+        json=_registration(seed),
+        headers={**actor.headers, "user-agent": user_agent},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["devices"][0]["id"]
+
+
+# ------------------------------------------------------------------ devices ---
+
+
+async def test_a_device_publishes_only_public_keys(client, acting_user):
+    a = await acting_user()
+
+    device_id = await _register(client, a)
+    listed = await client.get("/api/v1/me/dm/devices", headers=a.headers)
+
+    body = listed.json()["devices"][0]
+    assert body["id"] == device_id
+    # Named by what connected, not by what the client asked to be called.
+    assert body["label"] == "Firefox on Linux"
+    assert body["one_time_key_count"] == 1
+    # The identity key is not on the caller's own device row: it is directory
+    # material, handed out by the claim route, not listed back here.
+    assert "identity_key" not in body
+
+
+async def test_a_malformed_key_is_refused(client, acting_user):
+    a = await acting_user()
+    payload = _registration()
+    payload["identity_key"] = "not-base64!!"
+
+    response = await client.post(
+        "/api/v1/me/dm/devices", json=payload, headers=a.headers
+    )
+    assert response.status_code == 422
+
+
+async def test_a_short_key_is_refused(client, acting_user):
+    a = await acting_user()
+    payload = _registration()
+    payload["identity_key"] = base64.b64encode(b"tooshort").decode()
+
+    response = await client.post(
+        "/api/v1/me/dm/devices", json=payload, headers=a.headers
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"] == "DM_MALFORMED_KEY"
+
+
+async def test_removing_a_device_takes_its_queue_with_it(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    await _set_policy(session, a.user, DmPolicy.public)
+    await _set_policy(session, b.user, DmPolicy.public)
+    await _open_channel(session, a.user, b.user)
+    b_device = await _register(client, b, seed=20)
+    await _register(client, a, seed=1)
+
+    conversation = await client.post(
+        "/api/v1/me/dm/conversations",
+        json={"user_id": b.user.id},
+        headers=a.headers,
+    )
+    conversation_id = conversation.json()["id"]
+    await client.post(
+        f"/api/v1/me/dm/conversations/{conversation_id}/messages",
+        json={
+            "messages": [
+                {
+                    "recipient_device_id": b_device,
+                    "message_type": 0,
+                    "payload": base64.b64encode(b"ciphertext").decode(),
+                }
+            ]
+        },
+        headers=a.headers,
+    )
+
+    removed = await client.delete(
+        f"/api/v1/me/dm/devices/{b_device}", headers=b.headers
+    )
+    assert removed.status_code == 204
+    remaining = (
+        await session.exec(text("SELECT count(*) FROM public.dm_queue"))
+    ).scalar_one()
+    assert remaining == 0
+
+
+# ---------------------------------------------------------------- directory ---
+
+
+async def test_a_stranger_gets_no_session_keys(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    await _register(client, b, seed=30)
+
+    response = await client.post(
+        f"/api/v1/users/{b.user.id}/dm/session-keys", headers=a.headers
+    )
+    assert response.status_code == 409
+    assert response.json()["detail"] == "DM_NOT_REACHABLE"
+
+
+async def test_claiming_spends_a_prekey_but_never_the_fallback(
+    client, session, acting_user
+):
+    a = await acting_user()
+    b = await acting_user()
+    await _set_policy(session, a.user, DmPolicy.public)
+    await _set_policy(session, b.user, DmPolicy.public)
+    await _open_channel(session, a.user, b.user)
+    await _register(client, b, seed=40)
+
+    first = await client.post(
+        f"/api/v1/users/{b.user.id}/dm/session-keys", headers=a.headers
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["devices"][0]["one_time_key"]["key_id"] == "otk-1"
+
+    # The pool is empty now, so the reusable last-resort key answers instead of
+    # the account becoming unreachable.
+    second = await client.post(
+        f"/api/v1/users/{b.user.id}/dm/session-keys", headers=a.headers
+    )
+    assert second.json()["devices"][0]["one_time_key"]["key_id"] == "fb"
+
+
+# ------------------------------------------------------------ conversations ---
+
+
+async def test_a_conversation_needs_an_accepted_grant(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    await _set_policy(session, a.user, DmPolicy.public)
+    await _set_policy(session, b.user, DmPolicy.public)
+
+    response = await client.post(
+        "/api/v1/me/dm/conversations",
+        json={"user_id": b.user.id},
+        headers=a.headers,
+    )
+    assert response.status_code == 409
+    assert response.json()["detail"] == "DM_NOT_REACHABLE"
+
+
+async def test_asking_twice_returns_the_same_channel(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    await _set_policy(session, a.user, DmPolicy.public)
+    await _set_policy(session, b.user, DmPolicy.public)
+    await _open_channel(session, a.user, b.user)
+
+    first = await client.post(
+        "/api/v1/me/dm/conversations", json={"user_id": b.user.id}, headers=a.headers
+    )
+    second = await client.post(
+        "/api/v1/me/dm/conversations", json={"user_id": b.user.id}, headers=a.headers
+    )
+    assert first.json()["id"] == second.json()["id"]
+
+
+async def test_a_third_account_cannot_see_the_conversation(
+    client, session, acting_user
+):
+    a = await acting_user()
+    b = await acting_user()
+    carol = await acting_user()
+    await _set_policy(session, a.user, DmPolicy.public)
+    await _set_policy(session, b.user, DmPolicy.public)
+    await _open_channel(session, a.user, b.user)
+    await client.post(
+        "/api/v1/me/dm/conversations", json={"user_id": b.user.id}, headers=a.headers
+    )
+
+    listed = await client.get("/api/v1/me/dm/conversations", headers=carol.headers)
+    assert listed.json()["conversations"] == []
+
+
+# ------------------------------------------------------------------- queue ---
+
+
+async def _conversation_with_devices(client, session, a, b):
+    await _set_policy(session, a.user, DmPolicy.public)
+    await _set_policy(session, b.user, DmPolicy.public)
+    await _open_channel(session, a.user, b.user)
+    a_device = await _register(client, a, seed=1)
+    b_device = await _register(client, b, seed=60)
+    created = await client.post(
+        "/api/v1/me/dm/conversations", json={"user_id": b.user.id}, headers=a.headers
+    )
+    return created.json()["id"], a_device, b_device
+
+
+async def test_a_message_reaches_the_recipient_and_the_senders_own_device(
+    client, session, acting_user
+):
+    a = await acting_user()
+    b = await acting_user()
+    conversation_id, a_device, b_device = await _conversation_with_devices(
+        client, session, a, b
+    )
+
+    sent = await client.post(
+        f"/api/v1/me/dm/conversations/{conversation_id}/messages",
+        json={
+            "messages": [
+                {
+                    "recipient_device_id": b_device,
+                    "message_type": 0,
+                    "payload": base64.b64encode(b"for-bob").decode(),
+                },
+                {
+                    "recipient_device_id": a_device,
+                    "message_type": 0,
+                    "payload": base64.b64encode(b"for-my-other-tab").decode(),
+                },
+            ]
+        },
+        headers=a.headers,
+    )
+    assert sent.status_code == 200, sent.text
+    assert sent.json()["accepted"] == 2
+
+    collected = await client.get(
+        f"/api/v1/me/dm/queue?device_id={b_device}", headers=b.headers
+    )
+    items = collected.json()["items"]
+    assert len(items) == 1
+    assert base64.b64decode(items[0]["payload"]) == b"for-bob"
+
+
+async def test_an_ignored_sender_is_answered_the_same_and_reaches_nobody(
+    client, session, acting_user
+):
+    """The whole point of the ignore, on the wire.
+
+    The send succeeds, the response is identical, and nothing lands in the
+    recipient's queue.
+    """
+    a = await acting_user()
+    b = await acting_user()
+    conversation_id, a_device, b_device = await _conversation_with_devices(
+        client, session, a, b
+    )
+    session.add(UserIgnore(user_id=b.user.id, ignored_user_id=a.user.id))
+    await session.commit()
+
+    sent = await client.post(
+        f"/api/v1/me/dm/conversations/{conversation_id}/messages",
+        json={
+            "messages": [
+                {
+                    "recipient_device_id": b_device,
+                    "message_type": 0,
+                    "payload": base64.b64encode(b"unheard").decode(),
+                },
+                {
+                    "recipient_device_id": a_device,
+                    "message_type": 0,
+                    "payload": base64.b64encode(b"my own copy").decode(),
+                },
+            ]
+        },
+        headers=a.headers,
+    )
+    assert sent.status_code == 200, sent.text
+
+    collected = await client.get(
+        f"/api/v1/me/dm/queue?device_id={b_device}", headers=b.headers
+    )
+    assert collected.json()["items"] == []
+    # The sender's own outbox copy still lands, so their other tabs render it.
+    own = await client.get(
+        f"/api/v1/me/dm/queue?device_id={a_device}", headers=a.headers
+    )
+    assert len(own.json()["items"]) == 1
+
+
+async def test_collecting_then_acknowledging_removes_the_row(
+    client, session, acting_user
+):
+    a = await acting_user()
+    b = await acting_user()
+    conversation_id, _a_device, b_device = await _conversation_with_devices(
+        client, session, a, b
+    )
+    await client.post(
+        f"/api/v1/me/dm/conversations/{conversation_id}/messages",
+        json={
+            "messages": [
+                {
+                    "recipient_device_id": b_device,
+                    "message_type": 0,
+                    "payload": base64.b64encode(b"collect me").decode(),
+                }
+            ]
+        },
+        headers=a.headers,
+    )
+    collected = await client.get(
+        f"/api/v1/me/dm/queue?device_id={b_device}", headers=b.headers
+    )
+    message_id = collected.json()["items"][0]["id"]
+
+    acked = await client.post(
+        "/api/v1/me/dm/queue/ack",
+        json={"device_id": b_device, "message_ids": [message_id]},
+        headers=b.headers,
+    )
+    assert acked.status_code == 204
+
+    remaining = (
+        await session.exec(text("SELECT count(*) FROM public.dm_queue"))
+    ).scalar_one()
+    assert remaining == 0
+
+
+async def test_a_queue_belongs_to_its_device(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    _conversation_id, _a_device, b_device = await _conversation_with_devices(
+        client, session, a, b
+    )
+
+    response = await client.get(
+        f"/api/v1/me/dm/queue?device_id={b_device}", headers=a.headers
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "DM_DEVICE_NOT_FOUND"
+
+
+async def test_messaging_yourself_is_refused(client, acting_user):
+    a = await acting_user()
+
+    response = await client.post(
+        "/api/v1/me/dm/conversations", json={"user_id": a.user.id}, headers=a.headers
+    )
+    assert response.status_code == 409
+    assert response.json()["detail"] == "DM_CANNOT_MESSAGE_SELF"

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -966,6 +966,31 @@ class DirectMessageMessages:
     NOT_A_MEMBER = "DM_NOT_A_MEMBER"
 
 
+class DirectMessageTransportMessages:
+    """Devices, keys, conversations and the queue."""
+
+    #: A device id that names nothing the caller owns.
+    DEVICE_NOT_FOUND = "DM_DEVICE_NOT_FOUND"
+    #: A key or payload that is not valid base64, or is the wrong length for the
+    #: curve it claims to be on.
+    MALFORMED_KEY = "DM_MALFORMED_KEY"
+    #: Two prekeys published under one name.
+    DUPLICATE_KEY_ID = "DM_DUPLICATE_KEY_ID"
+    #: A top-up that would take the device past what it may publish.
+    TOO_MANY_KEYS = "DM_TOO_MANY_KEYS"
+    #: The pair cannot open a channel right now. One code for every refusal,
+    #: the same way the permission layer answers.
+    NOT_REACHABLE = "DM_NOT_REACHABLE"
+    CANNOT_MESSAGE_SELF = "DM_CANNOT_MESSAGE_SELF"
+    CONVERSATION_NOT_FOUND = "DM_CONVERSATION_NOT_FOUND"
+    #: One message past the size a message may be. Anything larger is an
+    #: attachment, which travels out of band.
+    MESSAGE_TOO_LARGE = "DM_MESSAGE_TOO_LARGE"
+    #: The recipient is holding more undelivered ciphertext than they may.
+    #: Refused at the door rather than accepted and dropped later.
+    RECIPIENT_QUEUE_FULL = "DM_RECIPIENT_QUEUE_FULL"
+
+
 class ContactGrantMessages:
     """Connections and message requests."""
 

--- a/backend/app/schemas/platform/dm_transport.py
+++ b/backend/app/schemas/platform/dm_transport.py
@@ -1,0 +1,140 @@
+"""What the transport accepts and returns.
+
+Every key and every payload crosses this boundary as base64 in a string. The
+server never interprets any of it: a payload is bytes it stores until somebody
+collects them, and a key is bytes it hands to whoever is allowed to ask.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+#: A Curve25519 or Ed25519 public key is 32 bytes, which is 44 base64
+#: characters. The bound is on the encoded form because that is what arrives.
+KEY_B64_LENGTH = 44
+
+#: One message. Anything larger is an attachment, which travels out of band.
+MAX_PAYLOAD_BYTES = 64 * 1024
+#: Base64 costs four characters per three bytes, plus padding.
+MAX_PAYLOAD_B64 = (MAX_PAYLOAD_BYTES + 2) // 3 * 4
+
+#: How many prekeys a device may publish. A client tops up toward this.
+MAX_ONE_TIME_KEYS = 100
+
+
+class DmOneTimeKeyUpload(BaseModel):
+    key_id: str = Field(min_length=1, max_length=64)
+    public_key: str = Field(min_length=1, max_length=KEY_B64_LENGTH)
+
+
+class DmDeviceRegistration(BaseModel):
+    identity_key: str = Field(min_length=1, max_length=KEY_B64_LENGTH)
+    fingerprint_key: str = Field(min_length=1, max_length=KEY_B64_LENGTH)
+    #: The reusable last-resort key, so a sender who arrives after the pool is
+    #: drained can still open a session.
+    fallback_key: DmOneTimeKeyUpload
+    one_time_keys: list[DmOneTimeKeyUpload] = Field(
+        default_factory=list, max_length=MAX_ONE_TIME_KEYS
+    )
+    # No label here. It is derived at registration from the request's own
+    # user-agent, so it is a fact about the connection rather than a string the
+    # client chose -- which is what the device list is more useful for, and what
+    # keeps a name field out of a request body.
+
+
+class DmOneTimeKeyBatch(BaseModel):
+    device_id: uuid.UUID
+    one_time_keys: list[DmOneTimeKeyUpload] = Field(
+        min_length=1, max_length=MAX_ONE_TIME_KEYS
+    )
+
+
+class DmDeviceRead(BaseModel):
+    """One of the caller's own devices, for the Security page."""
+
+    id: uuid.UUID
+    fingerprint_key: str
+    label: str | None
+    created_at: datetime
+    last_seen_at: datetime
+    #: How many unclaimed prekeys it has left, so the client knows to top up.
+    one_time_key_count: int
+
+
+class DmDevicesResponse(BaseModel):
+    devices: list[DmDeviceRead]
+
+
+class DmSessionKey(BaseModel):
+    """What a sender needs to open a session with one device."""
+
+    device_id: uuid.UUID
+    identity_key: str
+    fingerprint_key: str
+    #: Absent only if the device published nothing at all, which a registered
+    #: device cannot do — a fallback key is required at registration.
+    one_time_key: DmOneTimeKeyUpload | None = None
+
+
+class DmSessionKeysResponse(BaseModel):
+    user_id: int
+    devices: list[DmSessionKey]
+
+
+class DmSafetyNumberResponse(BaseModel):
+    """Both parties' fingerprints, so the client can render the comparison."""
+
+    user_id: int
+    their_fingerprints: list[str]
+    my_fingerprints: list[str]
+
+
+class DmConversationCreate(BaseModel):
+    user_id: int = Field(ge=1)
+
+
+class DmConversationRead(BaseModel):
+    id: uuid.UUID
+    other_user_id: int
+    created_at: datetime
+
+
+class DmConversationsResponse(BaseModel):
+    conversations: list[DmConversationRead]
+
+
+class DmOutboundMessage(BaseModel):
+    recipient_device_id: uuid.UUID
+    #: Olm's own framing: 0 is a pre-key message, 1 continues a session.
+    message_type: int = Field(ge=0, le=1)
+    payload: str = Field(min_length=1, max_length=MAX_PAYLOAD_B64)
+
+
+class DmSendRequest(BaseModel):
+    messages: list[DmOutboundMessage] = Field(min_length=1, max_length=64)
+
+
+class DmSendResponse(BaseModel):
+    #: How many rows were written. Deliberately not per-recipient: what reached
+    #: whom is not something the sender is told.
+    accepted: int
+
+
+class DmQueueItemRead(BaseModel):
+    id: int
+    conversation_id: uuid.UUID
+    message_type: int
+    payload: str
+    created_at: datetime
+
+
+class DmQueueResponse(BaseModel):
+    items: list[DmQueueItemRead]
+
+
+class DmQueueAck(BaseModel):
+    device_id: uuid.UUID
+    message_ids: list[int] = Field(min_length=1, max_length=500)

--- a/backend/app/services/platform/dm_transport.py
+++ b/backend/app/services/platform/dm_transport.py
@@ -1,0 +1,601 @@
+"""The delivery service: a key directory, a roster, and a queue.
+
+Everything here treats a message as bytes. Nothing in this module branches on
+what a payload contains: no key to it exists on the server, which is also why
+there is nothing to configure about retention, moderation or search.
+
+Four things it does, and nothing else: publish public keys, hand a sender the
+keys it needs, write ciphertext to the recipients' queues, and delete a row once
+its recipient has collected it.
+
+Authorisation is the rule the permission layer already shipped. This module
+calls ``dm_apparent_permission`` for what the caller may be *told*, and
+``dm_deliverable`` for what actually reaches somebody — the difference is the
+recipient's ignore list, which the sender's own session cannot read and is never
+told about.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import delete, func, insert, text
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.messages import DirectMessageTransportMessages as Messages
+from app.models.platform.dm_conversation import (
+    DmConversation,
+    DmConversationMember,
+)
+from app.models.platform.dm_device import DmDevice
+from app.models.platform.dm_one_time_key import DmOneTimeKey
+from app.models.platform.dm_queue import DmQueueItem
+from app.schemas.platform.dm_transport import (
+    MAX_ONE_TIME_KEYS,
+    MAX_PAYLOAD_BYTES,
+    DmConversationRead,
+    DmDeviceRead,
+    DmOneTimeKeyUpload,
+    DmOutboundMessage,
+    DmQueueItemRead,
+    DmSessionKey,
+)
+
+#: A public key is 32 bytes on both curves.
+KEY_BYTES = 32
+
+#: How much undelivered ciphertext one account may be holding. Generous by
+#: design: a padded text message is about a kilobyte, so this is on the order of
+#: seventeen thousand messages nobody has collected on any device.
+QUEUE_CEILING_BYTES = 50 * 1024 * 1024
+
+#: How many messages one collection returns.
+QUEUE_PAGE = 200
+
+
+class DmTransportError(Exception):
+    """Raised with a message code the endpoint turns into a status."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _decode(value: str, *, expect: int | None = None) -> bytes:
+    try:
+        raw = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise DmTransportError(Messages.MALFORMED_KEY) from exc
+    if expect is not None and len(raw) != expect:
+        raise DmTransportError(Messages.MALFORMED_KEY)
+    if not raw:
+        raise DmTransportError(Messages.MALFORMED_KEY)
+    return raw
+
+
+def _encode(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+async def _permission(session: AsyncSession, target_id: int) -> str:
+    """What the caller may do about that account, as the caller sees it."""
+    return (
+        await session.exec(
+            text("SELECT public.dm_apparent_permission(:t)").bindparams(t=target_id)
+        )
+    ).scalar_one()
+
+
+async def _deliverable(session: AsyncSession, target_id: int) -> bool:
+    """Whether anything the caller sends that account actually arrives.
+
+    The answer is never returned to the caller. Where it is false the write
+    still succeeds and simply reaches nobody, so an account that has stopped
+    hearing from somebody does not announce it by behaving differently.
+    """
+    return (
+        await session.exec(
+            text("SELECT public.dm_deliverable(:t)").bindparams(t=target_id)
+        )
+    ).scalar_one()
+
+
+async def _queue_bytes(session: AsyncSession, user_id: int) -> int:
+    return (
+        await session.exec(
+            text("SELECT public.dm_queue_bytes(:u)").bindparams(u=user_id)
+        )
+    ).scalar_one()
+
+
+async def _own_device(
+    session: AsyncSession, *, user_id: int, device_id: uuid.UUID
+) -> DmDevice:
+    device = await session.get(DmDevice, device_id)
+    if device is None or device.user_id != user_id:
+        raise DmTransportError(Messages.DEVICE_NOT_FOUND)
+    return device
+
+
+# --------------------------------------------------------------------------
+# Devices and keys
+# --------------------------------------------------------------------------
+
+
+async def register_device(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    identity_key: str,
+    fingerprint_key: str,
+    fallback_key: DmOneTimeKeyUpload,
+    one_time_keys: list[DmOneTimeKeyUpload],
+    label: str | None,
+) -> DmDevice:
+    """Publish a new installed client's public keys.
+
+    A fallback key is required rather than optional: without one, a device whose
+    prekeys run out becomes unreachable to anyone starting a new conversation,
+    and the failure would land on the sender.
+    """
+    device = DmDevice(
+        user_id=user_id,
+        identity_key=_decode(identity_key, expect=KEY_BYTES),
+        fingerprint_key=_decode(fingerprint_key, expect=KEY_BYTES),
+        label=label,
+    )
+    session.add(device)
+    await session.flush()
+
+    session.add(
+        DmOneTimeKey(
+            device_id=device.id,
+            key_id=fallback_key.key_id,
+            public_key=_decode(fallback_key.public_key, expect=KEY_BYTES),
+            fallback=True,
+        )
+    )
+    _add_one_time_keys(session, device_id=device.id, keys=one_time_keys)
+    await session.flush()
+    return device
+
+
+def _add_one_time_keys(
+    session: AsyncSession, *, device_id: uuid.UUID, keys: list[DmOneTimeKeyUpload]
+) -> None:
+    seen: set[str] = set()
+    for key in keys:
+        if key.key_id in seen:
+            raise DmTransportError(Messages.DUPLICATE_KEY_ID)
+        seen.add(key.key_id)
+        session.add(
+            DmOneTimeKey(
+                device_id=device_id,
+                key_id=key.key_id,
+                public_key=_decode(key.public_key, expect=KEY_BYTES),
+                fallback=False,
+            )
+        )
+
+
+async def add_one_time_keys(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    device_id: uuid.UUID,
+    keys: list[DmOneTimeKeyUpload],
+) -> int:
+    """Top a device's pool back up. Returns how many it now holds."""
+    await _own_device(session, user_id=user_id, device_id=device_id)
+    held = await _unclaimed_count(session, device_id)
+    if held + len(keys) > MAX_ONE_TIME_KEYS:
+        raise DmTransportError(Messages.TOO_MANY_KEYS)
+    _add_one_time_keys(session, device_id=device_id, keys=keys)
+    await session.flush()
+    return held + len(keys)
+
+
+async def _unclaimed_count(session: AsyncSession, device_id: uuid.UUID) -> int:
+    return (
+        await session.exec(
+            select(func.count())
+            .select_from(DmOneTimeKey)
+            .where(
+                DmOneTimeKey.device_id == device_id,
+                DmOneTimeKey.fallback.is_(False),
+            )
+        )
+    ).one()
+
+
+async def list_devices(session: AsyncSession, *, user_id: int) -> list[DmDeviceRead]:
+    devices = list(
+        (
+            await session.exec(
+                select(DmDevice)
+                .where(DmDevice.user_id == user_id)
+                .order_by(DmDevice.created_at)
+            )
+        ).all()
+    )
+    return [
+        DmDeviceRead(
+            id=device.id,
+            fingerprint_key=_encode(device.fingerprint_key),
+            label=device.label,
+            created_at=device.created_at,
+            last_seen_at=device.last_seen_at,
+            one_time_key_count=await _unclaimed_count(session, device.id),
+        )
+        for device in devices
+    ]
+
+
+async def remove_device(
+    session: AsyncSession, *, user_id: int, device_id: uuid.UUID
+) -> None:
+    """Drop a device's keys and everything queued for it.
+
+    This is the one thing that removes an undelivered message, and it is a
+    visible act by the person who owns the mailbox.
+    """
+    device = await _own_device(session, user_id=user_id, device_id=device_id)
+    await session.delete(device)
+    await session.flush()
+
+
+async def claim_session_keys(
+    session: AsyncSession, *, target_id: int
+) -> list[DmSessionKey]:
+    """The keys the caller needs to open a session with each of that account's
+    devices, spending one prekey per device.
+
+    A claim is a delete: a prekey that cannot be handed out twice needs no state
+    to say so. The reusable fallback key is the exception, and is what a device
+    whose pool is drained answers with.
+    """
+    if await _permission(session, target_id) != "open":
+        raise DmTransportError(Messages.NOT_REACHABLE)
+
+    devices = list(
+        (
+            await session.exec(
+                select(DmDevice)
+                .where(DmDevice.user_id == target_id)
+                .order_by(DmDevice.created_at)
+            )
+        ).all()
+    )
+    claimed: list[DmSessionKey] = []
+    for device in devices:
+        # One statement, one key. The request path holds no DELETE on another
+        # account's pool, and two callers racing take different rows rather
+        # than the same one.
+        row = (
+            await session.exec(
+                text(
+                    "SELECT key_id, public_key FROM public.dm_claim_one_time_key(:d)"
+                ).bindparams(d=device.id)
+            )
+        ).first()
+        upload = None
+        if row is not None:
+            upload = DmOneTimeKeyUpload(
+                key_id=row[0], public_key=_encode(bytes(row[1]))
+            )
+        claimed.append(
+            DmSessionKey(
+                device_id=device.id,
+                identity_key=_encode(device.identity_key),
+                fingerprint_key=_encode(device.fingerprint_key),
+                one_time_key=upload,
+            )
+        )
+    await session.flush()
+    return claimed
+
+
+async def fingerprints(session: AsyncSession, *, user_id: int) -> list[str]:
+    rows = list(
+        (
+            await session.exec(
+                select(DmDevice.fingerprint_key)
+                .where(DmDevice.user_id == user_id)
+                .order_by(DmDevice.created_at)
+            )
+        ).all()
+    )
+    return [_encode(row) for row in rows]
+
+
+# --------------------------------------------------------------------------
+# Conversations
+# --------------------------------------------------------------------------
+
+
+async def _existing_conversation(
+    session: AsyncSession, *, actor_id: int, other_id: int
+) -> DmConversation | None:
+    mine = select(DmConversationMember.conversation_id).where(
+        DmConversationMember.user_id == actor_id
+    )
+    row = (
+        await session.exec(
+            select(DmConversation)
+            .join(
+                DmConversationMember,
+                DmConversationMember.conversation_id == DmConversation.id,
+            )
+            .where(
+                DmConversationMember.user_id == other_id,
+                DmConversationMember.conversation_id.in_(mine),
+            )
+            .limit(1)
+        )
+    ).first()
+    return row
+
+
+async def create_conversation(
+    session: AsyncSession, *, actor_id: int, other_id: int
+) -> DmConversation:
+    """Open the channel an accepted message request earned.
+
+    Idempotent: asking twice returns the conversation that already exists rather
+    than a second one, because a pair has one channel.
+    """
+    if actor_id == other_id:
+        raise DmTransportError(Messages.CANNOT_MESSAGE_SELF)
+    existing = await _existing_conversation(
+        session, actor_id=actor_id, other_id=other_id
+    )
+    if existing is not None:
+        return existing
+    if await _permission(session, other_id) != "open":
+        raise DmTransportError(Messages.NOT_REACHABLE)
+
+    conversation = DmConversation()
+    session.add(conversation)
+    await session.flush()
+    # Slot 0 is whoever opened it. The pair of slots is unique per conversation,
+    # so a third member is refused by the index rather than by a count somebody
+    # else could be reading at the same moment.
+    session.add(
+        DmConversationMember(conversation_id=conversation.id, user_id=actor_id, slot=0)
+    )
+    session.add(
+        DmConversationMember(conversation_id=conversation.id, user_id=other_id, slot=1)
+    )
+    await session.flush()
+    return conversation
+
+
+async def list_conversations(
+    session: AsyncSession, *, user_id: int
+) -> list[DmConversationRead]:
+    mine = select(DmConversationMember.conversation_id).where(
+        DmConversationMember.user_id == user_id
+    )
+    rows = list(
+        (
+            await session.exec(
+                select(DmConversation, DmConversationMember.user_id)
+                .join(
+                    DmConversationMember,
+                    DmConversationMember.conversation_id == DmConversation.id,
+                )
+                .where(
+                    DmConversation.id.in_(mine),
+                    DmConversationMember.user_id != user_id,
+                )
+                .order_by(DmConversation.created_at.desc())
+            )
+        ).all()
+    )
+    return [
+        DmConversationRead(
+            id=conversation.id,
+            other_user_id=other_id,
+            created_at=conversation.created_at,
+        )
+        for conversation, other_id in rows
+    ]
+
+
+async def _other_member(
+    session: AsyncSession, *, conversation_id: uuid.UUID, user_id: int
+) -> int:
+    other = (
+        await session.exec(
+            select(DmConversationMember.user_id).where(
+                DmConversationMember.conversation_id == conversation_id,
+                DmConversationMember.user_id != user_id,
+            )
+        )
+    ).first()
+    if other is None:
+        raise DmTransportError(Messages.CONVERSATION_NOT_FOUND)
+    return other
+
+
+async def leave_conversation(
+    session: AsyncSession, *, user_id: int, conversation_id: uuid.UUID
+) -> None:
+    conversation = await session.get(DmConversation, conversation_id)
+    if conversation is None:
+        raise DmTransportError(Messages.CONVERSATION_NOT_FOUND)
+    await session.exec(
+        delete(DmConversationMember).where(
+            DmConversationMember.conversation_id == conversation_id,
+            DmConversationMember.user_id == user_id,
+        )
+    )
+    await session.flush()
+
+
+# --------------------------------------------------------------------------
+# The queue
+# --------------------------------------------------------------------------
+
+
+async def send(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    conversation_id: uuid.UUID,
+    messages: list[DmOutboundMessage],
+) -> tuple[int, int | None]:
+    """Write one already-encrypted message to every device that should get it.
+
+    Returns the number of rows written and, when the other party was written to,
+    their account id — the caller uses it to signal them, and it is ``None``
+    where nothing reached them.
+
+    The sender's own devices are always written to, so their other clients
+    render their own outbox. The other party's devices are written to only if
+    ``dm_deliverable`` says so, and the sender is told the same thing either way.
+    """
+    conversation = await session.get(DmConversation, conversation_id)
+    if conversation is None:
+        raise DmTransportError(Messages.CONVERSATION_NOT_FOUND)
+    other_id = await _other_member(
+        session, conversation_id=conversation_id, user_id=user_id
+    )
+    if await _permission(session, other_id) != "open":
+        raise DmTransportError(Messages.NOT_REACHABLE)
+
+    own_device_ids = set(
+        (
+            await session.exec(select(DmDevice.id).where(DmDevice.user_id == user_id))
+        ).all()
+    )
+    delivers = await _deliverable(session, other_id)
+
+    payloads: list[tuple[DmOutboundMessage, bytes, bool]] = []
+    incoming_bytes = 0
+    for message in messages:
+        raw = _decode(message.payload)
+        if len(raw) > MAX_PAYLOAD_BYTES:
+            raise DmTransportError(Messages.MESSAGE_TOO_LARGE)
+        mine = message.recipient_device_id in own_device_ids
+        if not mine and not delivers:
+            continue
+        if not mine:
+            incoming_bytes += len(raw)
+        payloads.append((message, raw, mine))
+
+    if incoming_bytes:
+        # Two sends to the same near-full mailbox would otherwise both read the
+        # old total and both pass. Transaction-scoped, and keyed on the
+        # recipient, so only sends to the same person ever wait.
+        await session.exec(
+            select(
+                func.pg_advisory_xact_lock(
+                    func.hashtextextended(f"dm-queue:{other_id}", 0)
+                )
+            )
+        )
+    if incoming_bytes and (
+        await _queue_bytes(session, other_id) + incoming_bytes > QUEUE_CEILING_BYTES
+    ):
+        # Refusing is honest. Accepting a message we mean to drop later is not.
+        raise DmTransportError(Messages.RECIPIENT_QUEUE_FULL)
+
+    if payloads:
+        # A Core insert, deliberately: the ORM would ask for the new id back,
+        # and RETURNING re-checks the SELECT policy against a row addressed to
+        # somebody else's device -- which the sender is not entitled to read.
+        # Nothing here needs the id.
+        now = datetime.now(timezone.utc)
+        await session.exec(
+            insert(DmQueueItem).values(
+                [
+                    {
+                        "conversation_id": conversation_id,
+                        "recipient_device_id": message.recipient_device_id,
+                        "message_type": message.message_type,
+                        "payload": raw,
+                        "created_at": now,
+                    }
+                    for message, raw, _mine in payloads
+                ]
+            )
+        )
+    await session.flush()
+    return len(payloads), other_id if delivers else None
+
+
+async def collect(
+    session: AsyncSession, *, user_id: int, device_id: uuid.UUID
+) -> list[DmQueueItemRead]:
+    """Everything waiting for one device, oldest first.
+
+    The order is not a nicety. A ratchet keeps a bounded number of skipped
+    message keys, so handing them over in the order they were written is what
+    keeps a client able to read them.
+    """
+    device = await _own_device(session, user_id=user_id, device_id=device_id)
+    rows = list(
+        (
+            await session.exec(
+                select(DmQueueItem)
+                .where(DmQueueItem.recipient_device_id == device_id)
+                .order_by(DmQueueItem.id)
+                .limit(QUEUE_PAGE)
+            )
+        ).all()
+    )
+    device.last_seen_at = datetime.now(timezone.utc)
+    session.add(device)
+    await session.flush()
+    return [
+        DmQueueItemRead(
+            id=row.id,
+            conversation_id=row.conversation_id,
+            message_type=row.message_type,
+            payload=_encode(row.payload),
+            created_at=row.created_at,
+        )
+        for row in rows
+    ]
+
+
+async def acknowledge(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    device_id: uuid.UUID,
+    message_ids: list[int],
+) -> int:
+    """Delete what this device has taken. Collection is what empties the queue."""
+    await _own_device(session, user_id=user_id, device_id=device_id)
+    result = await session.exec(
+        delete(DmQueueItem).where(
+            DmQueueItem.recipient_device_id == device_id,
+            DmQueueItem.id.in_(message_ids),
+        )
+    )
+    await session.flush()
+    return result.rowcount or 0
+
+
+async def unread_counts(session: AsyncSession, *, user_id: int) -> dict[uuid.UUID, int]:
+    """How much is waiting, per conversation, across all the caller's devices.
+
+    This counts *uncollected* rows, which is a fact about syncing rather than
+    about reading. The badge people see is built on the notification rollup
+    instead; this is what a client uses to know there is something to fetch.
+    """
+    device_ids = select(DmDevice.id).where(DmDevice.user_id == user_id)
+    rows = (
+        await session.exec(
+            select(DmQueueItem.conversation_id, func.count())
+            .where(DmQueueItem.recipient_device_id.in_(device_ids))
+            .group_by(DmQueueItem.conversation_id)
+        )
+    ).all()
+    return {conversation_id: count for conversation_id, count in rows}

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -513,6 +513,15 @@
   "DM_CANNOT_IGNORE_SELF": "Du kannst dein eigenes Konto nicht ignorieren.",
   "DM_NOT_A_MEMBER": "Du bist kein Mitglied dieser Community.",
   "CONTACT_GRANT_CANNOT_REACH": "Du kannst dieses Konto derzeit nicht erreichen.",
+  "DM_DEVICE_NOT_FOUND": "Dieses Gerät ist nicht für verschlüsselte Nachrichten eingerichtet.",
+  "DM_MALFORMED_KEY": "Dieser Schlüssel konnte nicht gelesen werden. Versuche es auf diesem Gerät erneut.",
+  "DM_DUPLICATE_KEY_ID": "Dieses Gerät hat bereits einen Schlüssel mit diesem Namen veröffentlicht.",
+  "DM_TOO_MANY_KEYS": "Dieses Gerät hat so viele Schlüssel veröffentlicht, wie es halten darf.",
+  "DM_NOT_REACHABLE": "Du kannst diesem Konto derzeit keine Nachricht senden.",
+  "DM_CANNOT_MESSAGE_SELF": "Du kannst dir nicht selbst schreiben.",
+  "DM_CONVERSATION_NOT_FOUND": "Diese Unterhaltung ist nicht verfügbar.",
+  "DM_MESSAGE_TOO_LARGE": "Diese Nachricht ist zu lang zum Senden.",
+  "DM_RECIPIENT_QUEUE_FULL": "Dieses Konto hat zu viele unzugestellte Nachrichten. Versuche es erneut, sobald die App dort geöffnet wurde.",
   "CONTACT_GRANT_NO_REQUEST": "Von diesem Konto liegt keine Anfrage vor.",
   "CONTACT_GRANT_CANNOT_GRANT_SELF": "Du kannst dich nicht mit deinem eigenen Konto verbinden."
 }

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -513,6 +513,15 @@
   "DM_CANNOT_IGNORE_SELF": "You cannot ignore your own account.",
   "DM_NOT_A_MEMBER": "You are not a member of that community.",
   "CONTACT_GRANT_CANNOT_REACH": "You cannot reach that account right now.",
+  "DM_DEVICE_NOT_FOUND": "That device is not set up for encrypted messages.",
+  "DM_MALFORMED_KEY": "That key could not be read. Try again on this device.",
+  "DM_DUPLICATE_KEY_ID": "This device already published a key by that name.",
+  "DM_TOO_MANY_KEYS": "This device has published as many keys as it may hold.",
+  "DM_NOT_REACHABLE": "You cannot message that account right now.",
+  "DM_CANNOT_MESSAGE_SELF": "You cannot message yourself.",
+  "DM_CONVERSATION_NOT_FOUND": "That conversation is not available.",
+  "DM_MESSAGE_TOO_LARGE": "That message is too long to send.",
+  "DM_RECIPIENT_QUEUE_FULL": "That account has too many undelivered messages. Try again once they open the app.",
   "CONTACT_GRANT_NO_REQUEST": "There is no request from that account to accept.",
   "CONTACT_GRANT_CANNOT_GRANT_SELF": "You cannot connect with your own account."
 }

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -513,6 +513,15 @@
   "DM_CANNOT_IGNORE_SELF": "No puedes ignorar tu propia cuenta.",
   "DM_NOT_A_MEMBER": "No eres miembro de esa comunidad.",
   "CONTACT_GRANT_CANNOT_REACH": "No puedes contactar con esa cuenta ahora mismo.",
+  "DM_DEVICE_NOT_FOUND": "Ese dispositivo no está configurado para mensajes cifrados.",
+  "DM_MALFORMED_KEY": "No se pudo leer esa clave. Inténtalo de nuevo en este dispositivo.",
+  "DM_DUPLICATE_KEY_ID": "Este dispositivo ya publicó una clave con ese nombre.",
+  "DM_TOO_MANY_KEYS": "Este dispositivo ya publicó todas las claves que puede tener.",
+  "DM_NOT_REACHABLE": "No puedes enviar mensajes a esa cuenta en este momento.",
+  "DM_CANNOT_MESSAGE_SELF": "No puedes enviarte mensajes a ti mismo.",
+  "DM_CONVERSATION_NOT_FOUND": "Esa conversación no está disponible.",
+  "DM_MESSAGE_TOO_LARGE": "Ese mensaje es demasiado largo para enviarlo.",
+  "DM_RECIPIENT_QUEUE_FULL": "Esa cuenta tiene demasiados mensajes sin entregar. Inténtalo de nuevo cuando abra la aplicación.",
   "CONTACT_GRANT_NO_REQUEST": "No hay ninguna solicitud de esa cuenta que aceptar.",
   "CONTACT_GRANT_CANNOT_GRANT_SELF": "No puedes conectarte con tu propia cuenta."
 }

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -513,6 +513,15 @@
   "DM_CANNOT_IGNORE_SELF": "Vous ne pouvez pas ignorer votre propre compte.",
   "DM_NOT_A_MEMBER": "Vous n'êtes pas membre de cette communauté.",
   "CONTACT_GRANT_CANNOT_REACH": "Vous ne pouvez pas joindre ce compte pour le moment.",
+  "DM_DEVICE_NOT_FOUND": "Cet appareil n'est pas configuré pour les messages chiffrés.",
+  "DM_MALFORMED_KEY": "Cette clé n'a pas pu être lue. Réessaie sur cet appareil.",
+  "DM_DUPLICATE_KEY_ID": "Cet appareil a déjà publié une clé portant ce nom.",
+  "DM_TOO_MANY_KEYS": "Cet appareil a publié autant de clés qu'il peut en détenir.",
+  "DM_NOT_REACHABLE": "Tu ne peux pas envoyer de message à ce compte pour le moment.",
+  "DM_CANNOT_MESSAGE_SELF": "Tu ne peux pas t'envoyer de message à toi-même.",
+  "DM_CONVERSATION_NOT_FOUND": "Cette conversation n'est pas disponible.",
+  "DM_MESSAGE_TOO_LARGE": "Ce message est trop long pour être envoyé.",
+  "DM_RECIPIENT_QUEUE_FULL": "Ce compte a trop de messages non distribués. Réessaie une fois l'application ouverte.",
   "CONTACT_GRANT_NO_REQUEST": "Aucune demande de ce compte à accepter.",
   "CONTACT_GRANT_CANNOT_GRANT_SELF": "Vous ne pouvez pas vous connecter à votre propre compte."
 }

--- a/frontend/src/api/generated/direct-messages/direct-messages.ts
+++ b/frontend/src/api/generated/direct-messages/direct-messages.ts
@@ -21,12 +21,25 @@ import type {
 } from "@tanstack/react-query";
 
 import type {
+  CollectQueueApiV1MeDmQueueGetParams,
   ConnectionRequestCreate,
   ContactGrantRead,
   ContactGrantsResponse,
   DirectMessagePermissionRead,
   DirectMessageSettingsRead,
   DirectMessageSettingsUpdate,
+  DmConversationCreate,
+  DmConversationRead,
+  DmConversationsResponse,
+  DmDeviceRegistration,
+  DmDevicesResponse,
+  DmOneTimeKeyBatch,
+  DmQueueAck,
+  DmQueueResponse,
+  DmSafetyNumberResponse,
+  DmSendRequest,
+  DmSendResponse,
+  DmSessionKeysResponse,
   HTTPValidationError,
   IgnoredAccountsResponse,
   ListIgnoredAccountsApiV1MeIgnoredGetParams,
@@ -210,6 +223,257 @@ export function useReadDmPermissionApiV1UsersUserIdDmPermissionGet<
   queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getReadDmPermissionApiV1UsersUserIdDmPermissionGetQueryOptions(
+    userId,
+    options
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * Claim what is needed to open a session with each of that account's
+ * devices.
+ *
+ * A POST rather than a GET because a claim spends a prekey — this writes.
+ * @summary Claim Session Keys
+ */
+export const claimSessionKeysApiV1UsersUserIdDmSessionKeysPost = (
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmSessionKeysResponse>(
+    { url: `/api/v1/users/${userId}/dm/session-keys`, method: "POST", signal },
+    options
+  );
+};
+
+export const getClaimSessionKeysApiV1UsersUserIdDmSessionKeysPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof claimSessionKeysApiV1UsersUserIdDmSessionKeysPost>>,
+    TError,
+    { userId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof claimSessionKeysApiV1UsersUserIdDmSessionKeysPost>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  const mutationKey = ["claimSessionKeysApiV1UsersUserIdDmSessionKeysPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof claimSessionKeysApiV1UsersUserIdDmSessionKeysPost>>,
+    { userId: number }
+  > = (props) => {
+    const { userId } = props ?? {};
+
+    return claimSessionKeysApiV1UsersUserIdDmSessionKeysPost(userId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type ClaimSessionKeysApiV1UsersUserIdDmSessionKeysPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof claimSessionKeysApiV1UsersUserIdDmSessionKeysPost>>
+>;
+
+export type ClaimSessionKeysApiV1UsersUserIdDmSessionKeysPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Claim Session Keys
+ */
+export const useClaimSessionKeysApiV1UsersUserIdDmSessionKeysPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof claimSessionKeysApiV1UsersUserIdDmSessionKeysPost>>,
+      TError,
+      { userId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof claimSessionKeysApiV1UsersUserIdDmSessionKeysPost>>,
+  TError,
+  { userId: number },
+  TContext
+> => {
+  return useMutation(
+    getClaimSessionKeysApiV1UsersUserIdDmSessionKeysPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Both parties' fingerprints, so the client can render the comparison.
+ * @summary Safety Number
+ */
+export const safetyNumberApiV1UsersUserIdDmSafetyNumberGet = (
+  userId: number,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmSafetyNumberResponse>(
+    { url: `/api/v1/users/${userId}/dm/safety-number`, method: "GET", signal },
+    options
+  );
+};
+
+export const getSafetyNumberApiV1UsersUserIdDmSafetyNumberGetQueryKey = (userId: number) => {
+  return [`/api/v1/users/${userId}/dm/safety-number`] as const;
+};
+
+export const getSafetyNumberApiV1UsersUserIdDmSafetyNumberGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getSafetyNumberApiV1UsersUserIdDmSafetyNumberGetQueryKey(userId);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>
+  > = ({ signal }) => safetyNumberApiV1UsersUserIdDmSafetyNumberGet(userId, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: userId !== null && userId !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type SafetyNumberApiV1UsersUserIdDmSafetyNumberGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>
+>;
+export type SafetyNumberApiV1UsersUserIdDmSafetyNumberGetQueryError =
+  ErrorType<HTTPValidationError>;
+
+export function useSafetyNumberApiV1UsersUserIdDmSafetyNumberGet<
+  TData = Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+          TError,
+          Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useSafetyNumberApiV1UsersUserIdDmSafetyNumberGet<
+  TData = Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+          TError,
+          Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useSafetyNumberApiV1UsersUserIdDmSafetyNumberGet<
+  TData = Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Safety Number
+ */
+
+export function useSafetyNumberApiV1UsersUserIdDmSafetyNumberGet<
+  TData = Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  userId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof safetyNumberApiV1UsersUserIdDmSafetyNumberGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getSafetyNumberApiV1UsersUserIdDmSafetyNumberGetQueryOptions(
     userId,
     options
   );
@@ -1584,4 +1848,1039 @@ export const useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete = <
     getRemoveMessageRequestApiV1MeMessageRequestsUserIdDeleteMutationOptions(options),
     queryClient
   );
+};
+/**
+ * Publish this installed client's public keys.
+ *
+ * The device's label comes from the request's user-agent rather than the body:
+ * a device list is more use when it says what actually connected.
+ * @summary Register Device
+ */
+export const registerDeviceApiV1MeDmDevicesPost = (
+  dmDeviceRegistration: BodyType<DmDeviceRegistration>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmDevicesResponse>(
+    {
+      url: `/api/v1/me/dm/devices`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: dmDeviceRegistration,
+      signal,
+    },
+    options
+  );
+};
+
+export const getRegisterDeviceApiV1MeDmDevicesPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof registerDeviceApiV1MeDmDevicesPost>>,
+    TError,
+    { data: BodyType<DmDeviceRegistration> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof registerDeviceApiV1MeDmDevicesPost>>,
+  TError,
+  { data: BodyType<DmDeviceRegistration> },
+  TContext
+> => {
+  const mutationKey = ["registerDeviceApiV1MeDmDevicesPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof registerDeviceApiV1MeDmDevicesPost>>,
+    { data: BodyType<DmDeviceRegistration> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return registerDeviceApiV1MeDmDevicesPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RegisterDeviceApiV1MeDmDevicesPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof registerDeviceApiV1MeDmDevicesPost>>
+>;
+export type RegisterDeviceApiV1MeDmDevicesPostMutationBody = BodyType<DmDeviceRegistration>;
+export type RegisterDeviceApiV1MeDmDevicesPostMutationError = ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Register Device
+ */
+export const useRegisterDeviceApiV1MeDmDevicesPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof registerDeviceApiV1MeDmDevicesPost>>,
+      TError,
+      { data: BodyType<DmDeviceRegistration> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof registerDeviceApiV1MeDmDevicesPost>>,
+  TError,
+  { data: BodyType<DmDeviceRegistration> },
+  TContext
+> => {
+  return useMutation(getRegisterDeviceApiV1MeDmDevicesPostMutationOptions(options), queryClient);
+};
+/**
+ * @summary List Devices
+ */
+export const listDevicesApiV1MeDmDevicesGet = (
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmDevicesResponse>(
+    { url: `/api/v1/me/dm/devices`, method: "GET", signal },
+    options
+  );
+};
+
+export const getListDevicesApiV1MeDmDevicesGetQueryKey = () => {
+  return [`/api/v1/me/dm/devices`] as const;
+};
+
+export const getListDevicesApiV1MeDmDevicesGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getListDevicesApiV1MeDmDevicesGetQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>> = ({
+    signal,
+  }) => listDevicesApiV1MeDmDevicesGet(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListDevicesApiV1MeDmDevicesGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>
+>;
+export type ListDevicesApiV1MeDmDevicesGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useListDevicesApiV1MeDmDevicesGet<
+  TData = Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+          TError,
+          Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListDevicesApiV1MeDmDevicesGet<
+  TData = Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+          TError,
+          Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListDevicesApiV1MeDmDevicesGet<
+  TData = Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List Devices
+ */
+
+export function useListDevicesApiV1MeDmDevicesGet<
+  TData = Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof listDevicesApiV1MeDmDevicesGet>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getListDevicesApiV1MeDmDevicesGetQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * Stop encrypted messaging on one device, without signing it out.
+ *
+ * Takes its queued messages with it, which is the one thing that removes an
+ * undelivered message and is a visible act by the person who owns it.
+ * @summary Remove Device
+ */
+export const removeDeviceApiV1MeDmDevicesDeviceIdDelete = (
+  deviceId: string,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<void>(
+    { url: `/api/v1/me/dm/devices/${deviceId}`, method: "DELETE", signal },
+    options
+  );
+};
+
+export const getRemoveDeviceApiV1MeDmDevicesDeviceIdDeleteMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof removeDeviceApiV1MeDmDevicesDeviceIdDelete>>,
+    TError,
+    { deviceId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof removeDeviceApiV1MeDmDevicesDeviceIdDelete>>,
+  TError,
+  { deviceId: string },
+  TContext
+> => {
+  const mutationKey = ["removeDeviceApiV1MeDmDevicesDeviceIdDelete"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof removeDeviceApiV1MeDmDevicesDeviceIdDelete>>,
+    { deviceId: string }
+  > = (props) => {
+    const { deviceId } = props ?? {};
+
+    return removeDeviceApiV1MeDmDevicesDeviceIdDelete(deviceId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RemoveDeviceApiV1MeDmDevicesDeviceIdDeleteMutationResult = NonNullable<
+  Awaited<ReturnType<typeof removeDeviceApiV1MeDmDevicesDeviceIdDelete>>
+>;
+
+export type RemoveDeviceApiV1MeDmDevicesDeviceIdDeleteMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Remove Device
+ */
+export const useRemoveDeviceApiV1MeDmDevicesDeviceIdDelete = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof removeDeviceApiV1MeDmDevicesDeviceIdDelete>>,
+      TError,
+      { deviceId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof removeDeviceApiV1MeDmDevicesDeviceIdDelete>>,
+  TError,
+  { deviceId: string },
+  TContext
+> => {
+  return useMutation(
+    getRemoveDeviceApiV1MeDmDevicesDeviceIdDeleteMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * @summary Top Up Keys
+ */
+export const topUpKeysApiV1MeDmOneTimeKeysPost = (
+  dmOneTimeKeyBatch: BodyType<DmOneTimeKeyBatch>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmDevicesResponse>(
+    {
+      url: `/api/v1/me/dm/one-time-keys`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: dmOneTimeKeyBatch,
+      signal,
+    },
+    options
+  );
+};
+
+export const getTopUpKeysApiV1MeDmOneTimeKeysPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof topUpKeysApiV1MeDmOneTimeKeysPost>>,
+    TError,
+    { data: BodyType<DmOneTimeKeyBatch> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof topUpKeysApiV1MeDmOneTimeKeysPost>>,
+  TError,
+  { data: BodyType<DmOneTimeKeyBatch> },
+  TContext
+> => {
+  const mutationKey = ["topUpKeysApiV1MeDmOneTimeKeysPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof topUpKeysApiV1MeDmOneTimeKeysPost>>,
+    { data: BodyType<DmOneTimeKeyBatch> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return topUpKeysApiV1MeDmOneTimeKeysPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type TopUpKeysApiV1MeDmOneTimeKeysPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof topUpKeysApiV1MeDmOneTimeKeysPost>>
+>;
+export type TopUpKeysApiV1MeDmOneTimeKeysPostMutationBody = BodyType<DmOneTimeKeyBatch>;
+export type TopUpKeysApiV1MeDmOneTimeKeysPostMutationError = ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Top Up Keys
+ */
+export const useTopUpKeysApiV1MeDmOneTimeKeysPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof topUpKeysApiV1MeDmOneTimeKeysPost>>,
+      TError,
+      { data: BodyType<DmOneTimeKeyBatch> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof topUpKeysApiV1MeDmOneTimeKeysPost>>,
+  TError,
+  { data: BodyType<DmOneTimeKeyBatch> },
+  TContext
+> => {
+  return useMutation(getTopUpKeysApiV1MeDmOneTimeKeysPostMutationOptions(options), queryClient);
+};
+/**
+ * @summary Create Conversation
+ */
+export const createConversationApiV1MeDmConversationsPost = (
+  dmConversationCreate: BodyType<DmConversationCreate>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmConversationRead>(
+    {
+      url: `/api/v1/me/dm/conversations`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: dmConversationCreate,
+      signal,
+    },
+    options
+  );
+};
+
+export const getCreateConversationApiV1MeDmConversationsPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createConversationApiV1MeDmConversationsPost>>,
+    TError,
+    { data: BodyType<DmConversationCreate> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createConversationApiV1MeDmConversationsPost>>,
+  TError,
+  { data: BodyType<DmConversationCreate> },
+  TContext
+> => {
+  const mutationKey = ["createConversationApiV1MeDmConversationsPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createConversationApiV1MeDmConversationsPost>>,
+    { data: BodyType<DmConversationCreate> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return createConversationApiV1MeDmConversationsPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type CreateConversationApiV1MeDmConversationsPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof createConversationApiV1MeDmConversationsPost>>
+>;
+export type CreateConversationApiV1MeDmConversationsPostMutationBody =
+  BodyType<DmConversationCreate>;
+export type CreateConversationApiV1MeDmConversationsPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Create Conversation
+ */
+export const useCreateConversationApiV1MeDmConversationsPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createConversationApiV1MeDmConversationsPost>>,
+      TError,
+      { data: BodyType<DmConversationCreate> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof createConversationApiV1MeDmConversationsPost>>,
+  TError,
+  { data: BodyType<DmConversationCreate> },
+  TContext
+> => {
+  return useMutation(
+    getCreateConversationApiV1MeDmConversationsPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * @summary List Conversations
+ */
+export const listConversationsApiV1MeDmConversationsGet = (
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmConversationsResponse>(
+    { url: `/api/v1/me/dm/conversations`, method: "GET", signal },
+    options
+  );
+};
+
+export const getListConversationsApiV1MeDmConversationsGetQueryKey = () => {
+  return [`/api/v1/me/dm/conversations`] as const;
+};
+
+export const getListConversationsApiV1MeDmConversationsGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getListConversationsApiV1MeDmConversationsGetQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>
+  > = ({ signal }) => listConversationsApiV1MeDmConversationsGet(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListConversationsApiV1MeDmConversationsGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>
+>;
+export type ListConversationsApiV1MeDmConversationsGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useListConversationsApiV1MeDmConversationsGet<
+  TData = Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListConversationsApiV1MeDmConversationsGet<
+  TData = Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+          TError,
+          Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListConversationsApiV1MeDmConversationsGet<
+  TData = Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List Conversations
+ */
+
+export function useListConversationsApiV1MeDmConversationsGet<
+  TData = Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof listConversationsApiV1MeDmConversationsGet>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getListConversationsApiV1MeDmConversationsGetQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * @summary Leave Conversation
+ */
+export const leaveConversationApiV1MeDmConversationsConversationIdDelete = (
+  conversationId: string,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<void>(
+    { url: `/api/v1/me/dm/conversations/${conversationId}`, method: "DELETE", signal },
+    options
+  );
+};
+
+export const getLeaveConversationApiV1MeDmConversationsConversationIdDeleteMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof leaveConversationApiV1MeDmConversationsConversationIdDelete>>,
+    TError,
+    { conversationId: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof leaveConversationApiV1MeDmConversationsConversationIdDelete>>,
+  TError,
+  { conversationId: string },
+  TContext
+> => {
+  const mutationKey = ["leaveConversationApiV1MeDmConversationsConversationIdDelete"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof leaveConversationApiV1MeDmConversationsConversationIdDelete>>,
+    { conversationId: string }
+  > = (props) => {
+    const { conversationId } = props ?? {};
+
+    return leaveConversationApiV1MeDmConversationsConversationIdDelete(
+      conversationId,
+      requestOptions
+    );
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type LeaveConversationApiV1MeDmConversationsConversationIdDeleteMutationResult = NonNullable<
+  Awaited<ReturnType<typeof leaveConversationApiV1MeDmConversationsConversationIdDelete>>
+>;
+
+export type LeaveConversationApiV1MeDmConversationsConversationIdDeleteMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Leave Conversation
+ */
+export const useLeaveConversationApiV1MeDmConversationsConversationIdDelete = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof leaveConversationApiV1MeDmConversationsConversationIdDelete>>,
+      TError,
+      { conversationId: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof leaveConversationApiV1MeDmConversationsConversationIdDelete>>,
+  TError,
+  { conversationId: string },
+  TContext
+> => {
+  return useMutation(
+    getLeaveConversationApiV1MeDmConversationsConversationIdDeleteMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Hand the server one already-encrypted copy per destination device.
+ * @summary Send Messages
+ */
+export const sendMessagesApiV1MeDmConversationsConversationIdMessagesPost = (
+  conversationId: string,
+  dmSendRequest: BodyType<DmSendRequest>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmSendResponse>(
+    {
+      url: `/api/v1/me/dm/conversations/${conversationId}/messages`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: dmSendRequest,
+      signal,
+    },
+    options
+  );
+};
+
+export const getSendMessagesApiV1MeDmConversationsConversationIdMessagesPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof sendMessagesApiV1MeDmConversationsConversationIdMessagesPost>>,
+    TError,
+    { conversationId: string; data: BodyType<DmSendRequest> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof sendMessagesApiV1MeDmConversationsConversationIdMessagesPost>>,
+  TError,
+  { conversationId: string; data: BodyType<DmSendRequest> },
+  TContext
+> => {
+  const mutationKey = ["sendMessagesApiV1MeDmConversationsConversationIdMessagesPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof sendMessagesApiV1MeDmConversationsConversationIdMessagesPost>>,
+    { conversationId: string; data: BodyType<DmSendRequest> }
+  > = (props) => {
+    const { conversationId, data } = props ?? {};
+
+    return sendMessagesApiV1MeDmConversationsConversationIdMessagesPost(
+      conversationId,
+      data,
+      requestOptions
+    );
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type SendMessagesApiV1MeDmConversationsConversationIdMessagesPostMutationResult =
+  NonNullable<
+    Awaited<ReturnType<typeof sendMessagesApiV1MeDmConversationsConversationIdMessagesPost>>
+  >;
+export type SendMessagesApiV1MeDmConversationsConversationIdMessagesPostMutationBody =
+  BodyType<DmSendRequest>;
+export type SendMessagesApiV1MeDmConversationsConversationIdMessagesPostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Send Messages
+ */
+export const useSendMessagesApiV1MeDmConversationsConversationIdMessagesPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof sendMessagesApiV1MeDmConversationsConversationIdMessagesPost>>,
+      TError,
+      { conversationId: string; data: BodyType<DmSendRequest> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof sendMessagesApiV1MeDmConversationsConversationIdMessagesPost>>,
+  TError,
+  { conversationId: string; data: BodyType<DmSendRequest> },
+  TContext
+> => {
+  return useMutation(
+    getSendMessagesApiV1MeDmConversationsConversationIdMessagesPostMutationOptions(options),
+    queryClient
+  );
+};
+/**
+ * Everything waiting for one device, oldest first.
+ * @summary Collect Queue
+ */
+export const collectQueueApiV1MeDmQueueGet = (
+  params: CollectQueueApiV1MeDmQueueGetParams,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DmQueueResponse>(
+    { url: `/api/v1/me/dm/queue`, method: "GET", params, signal },
+    options
+  );
+};
+
+export const getCollectQueueApiV1MeDmQueueGetQueryKey = (
+  params?: CollectQueueApiV1MeDmQueueGetParams
+) => {
+  return [`/api/v1/me/dm/queue`, ...(params ? [params] : [])] as const;
+};
+
+export const getCollectQueueApiV1MeDmQueueGetQueryOptions = <
+  TData = Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params: CollectQueueApiV1MeDmQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  }
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getCollectQueueApiV1MeDmQueueGetQueryKey(params);
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>> = ({
+    signal,
+  }) => collectQueueApiV1MeDmQueueGet(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type CollectQueueApiV1MeDmQueueGetQueryResult = NonNullable<
+  Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>
+>;
+export type CollectQueueApiV1MeDmQueueGetQueryError = ErrorType<HTTPValidationError>;
+
+export function useCollectQueueApiV1MeDmQueueGet<
+  TData = Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params: CollectQueueApiV1MeDmQueueGetParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+          TError,
+          Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useCollectQueueApiV1MeDmQueueGet<
+  TData = Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params: CollectQueueApiV1MeDmQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+          TError,
+          Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useCollectQueueApiV1MeDmQueueGet<
+  TData = Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params: CollectQueueApiV1MeDmQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary Collect Queue
+ */
+
+export function useCollectQueueApiV1MeDmQueueGet<
+  TData = Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>,
+  TError = ErrorType<HTTPValidationError>,
+>(
+  params: CollectQueueApiV1MeDmQueueGetParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof collectQueueApiV1MeDmQueueGet>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+  const queryOptions = getCollectQueueApiV1MeDmQueueGetQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return withQueryKey(query, queryOptions.queryKey);
+}
+
+/**
+ * Delete what this device has taken.
+ * @summary Acknowledge Queue
+ */
+export const acknowledgeQueueApiV1MeDmQueueAckPost = (
+  dmQueueAck: BodyType<DmQueueAck>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<void>(
+    {
+      url: `/api/v1/me/dm/queue/ack`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: dmQueueAck,
+      signal,
+    },
+    options
+  );
+};
+
+export const getAcknowledgeQueueApiV1MeDmQueueAckPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof acknowledgeQueueApiV1MeDmQueueAckPost>>,
+    TError,
+    { data: BodyType<DmQueueAck> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof acknowledgeQueueApiV1MeDmQueueAckPost>>,
+  TError,
+  { data: BodyType<DmQueueAck> },
+  TContext
+> => {
+  const mutationKey = ["acknowledgeQueueApiV1MeDmQueueAckPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof acknowledgeQueueApiV1MeDmQueueAckPost>>,
+    { data: BodyType<DmQueueAck> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return acknowledgeQueueApiV1MeDmQueueAckPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type AcknowledgeQueueApiV1MeDmQueueAckPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof acknowledgeQueueApiV1MeDmQueueAckPost>>
+>;
+export type AcknowledgeQueueApiV1MeDmQueueAckPostMutationBody = BodyType<DmQueueAck>;
+export type AcknowledgeQueueApiV1MeDmQueueAckPostMutationError = ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Acknowledge Queue
+ */
+export const useAcknowledgeQueueApiV1MeDmQueueAckPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof acknowledgeQueueApiV1MeDmQueueAckPost>>,
+      TError,
+      { data: BodyType<DmQueueAck> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof acknowledgeQueueApiV1MeDmQueueAckPost>>,
+  TError,
+  { data: BodyType<DmQueueAck> },
+  TContext
+> => {
+  return useMutation(getAcknowledgeQueueApiV1MeDmQueueAckPostMutationOptions(options), queryClient);
 };

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2316,6 +2316,146 @@ export interface DirectMessageSettingsUpdate {
   communities?: CommunityDmToggleUpdate[] | null;
 }
 
+export interface DmConversationCreate {
+  /** @minimum 1 */
+  user_id: number;
+}
+
+export interface DmConversationRead {
+  id: string;
+  other_user_id: number;
+  created_at: string;
+}
+
+export interface DmConversationsResponse {
+  conversations: DmConversationRead[];
+}
+
+/**
+ * One of the caller's own devices, for the Security page.
+ */
+export interface DmDeviceRead {
+  id: string;
+  fingerprint_key: string;
+  label: string | null;
+  created_at: string;
+  last_seen_at: string;
+  one_time_key_count: number;
+}
+
+export interface DmOneTimeKeyUpload {
+  /**
+   * @minLength 1
+   * @maxLength 64
+   */
+  key_id: string;
+  /**
+   * @minLength 1
+   * @maxLength 44
+   */
+  public_key: string;
+}
+
+export interface DmDeviceRegistration {
+  /**
+   * @minLength 1
+   * @maxLength 44
+   */
+  identity_key: string;
+  /**
+   * @minLength 1
+   * @maxLength 44
+   */
+  fingerprint_key: string;
+  fallback_key: DmOneTimeKeyUpload;
+  /** @maxItems 100 */
+  one_time_keys?: DmOneTimeKeyUpload[];
+}
+
+export interface DmDevicesResponse {
+  devices: DmDeviceRead[];
+}
+
+export interface DmOneTimeKeyBatch {
+  device_id: string;
+  /**
+   * @minItems 1
+   * @maxItems 100
+   */
+  one_time_keys: DmOneTimeKeyUpload[];
+}
+
+export interface DmOutboundMessage {
+  recipient_device_id: string;
+  /**
+   * @minimum 0
+   * @maximum 1
+   */
+  message_type: number;
+  /**
+   * @minLength 1
+   * @maxLength 87384
+   */
+  payload: string;
+}
+
+export interface DmQueueAck {
+  device_id: string;
+  /**
+   * @minItems 1
+   * @maxItems 500
+   */
+  message_ids: number[];
+}
+
+export interface DmQueueItemRead {
+  id: number;
+  conversation_id: string;
+  message_type: number;
+  payload: string;
+  created_at: string;
+}
+
+export interface DmQueueResponse {
+  items: DmQueueItemRead[];
+}
+
+/**
+ * Both parties' fingerprints, so the client can render the comparison.
+ */
+export interface DmSafetyNumberResponse {
+  user_id: number;
+  their_fingerprints: string[];
+  my_fingerprints: string[];
+}
+
+export interface DmSendRequest {
+  /**
+   * @minItems 1
+   * @maxItems 64
+   */
+  messages: DmOutboundMessage[];
+}
+
+export interface DmSendResponse {
+  accepted: number;
+}
+
+/**
+ * What a sender needs to open a session with one device.
+ */
+export interface DmSessionKey {
+  device_id: string;
+  identity_key: string;
+  fingerprint_key: string;
+  one_time_key?: DmOneTimeKeyUpload | null;
+}
+
+export interface DmSessionKeysResponse {
+  user_id: number;
+  devices: DmSessionKey[];
+}
+
 /**
  * Document that links to another document.
  */
@@ -7089,4 +7229,8 @@ export type ListIgnoredAccountsApiV1MeIgnoredGetParams = {
    * @maximum 100
    */
   page_size?: number;
+};
+
+export type CollectQueueApiV1MeDmQueueGetParams = {
+  device_id: string;
 };


### PR DESCRIPTION
> **Stacked on #1384** — review that one first. This PR's diff is against `feat/dm-transport-schema`, so it shows only the API layer.

## Problem

#1384 gave direct messages somewhere to live. Nothing can reach it yet.

## What this adds

The delivery service, and nothing more. Four jobs:

1. Publish a device's public keys.
2. Hand a sender the keys it needs to open a session.
3. Write already-encrypted bytes to the recipients' queues.
4. Delete a row once its recipient has collected it.

Nothing in `services/platform/dm_transport.py` branches on what a payload contains — no key to one exists on the server, which is also why there is nothing to configure about retention, moderation or search.

## Endpoints

| Method | Path |
|---|---|
| `POST` / `GET` | `/me/dm/devices` |
| `DELETE` | `/me/dm/devices/{id}` |
| `POST` | `/me/dm/one-time-keys` |
| `POST` | `/users/{id}/dm/session-keys` |
| `GET` | `/users/{id}/dm/safety-number` |
| `POST` / `GET` | `/me/dm/conversations` |
| `DELETE` | `/me/dm/conversations/{id}` |
| `POST` | `/me/dm/conversations/{id}/messages` |
| `GET` | `/me/dm/queue` |
| `POST` | `/me/dm/queue/ack` |

There is deliberately **no** route returning a conversation's history. The server has none: a collected message is deleted, and the client is the archive.

Claiming session keys is a `POST` rather than the `GET` the design doc sketched, because a claim spends a prekey — it writes.

## Notable decisions

- **A send always writes to the sender's own devices** so their other tabs render their outbox, and writes to the other party only where `dm_deliverable` says so. The sender is answered identically either way, and there is a test for exactly that.
- **Queue rows go in through a Core insert, not the ORM.** The ORM asks for the new id back, and `RETURNING` re-checks the `SELECT` policy against a row addressed to somebody else's device — which the sender is not entitled to read. This cost me two failing tests before I understood it; the comment in `send()` says why so nobody re-introduces it.
- **The queue is bounded at the door, not by a sweep.** A send that would push the recipient past 50 MB of undelivered ciphertext is refused with `DM_RECIPIENT_QUEUE_FULL`. Refusing is honest; accepting a message we mean to drop later is not. Migration `0226` adds `dm_queue_bytes`, since the sender cannot see the recipient's rows.
- **No `dm_rate_events` table**, which the design doc assumed. Both operations a stranger could abuse — creating a conversation and claiming prekeys — already require an accepted message grant from the permission layer, so the rate limit is the consent step that already exists. Worth a second opinion.
- **A fallback key is required at registration**, so a device whose prekey pool is drained stays reachable instead of the failure landing on the sender.
- **Schema names are `Dm`-prefixed.** `QueueItemRead` collided with the tenant queue's type and Orval renamed the *existing* one across the frontend; prefixing keeps that diff to additions only.

## Schema / env

One migration, `20260905_0226` — one `SECURITY DEFINER` function, no tables, no env vars.

## Testing

```
pytest -n 0 app/api/v1/platform_endpoints/dm_transport_test.py   # 14 passed — new
pytest -n 0 app/api/v1/platform_endpoints/dm_test.py            # 17 passed — no regression
pytest -n 0 app/db/dm_transport_rules_test.py                   # 9 passed
ruff check app && ruff format app && ty check app
```

Error codes are in `errors.json` for **de, en, es, fr**. Generated API types regenerated and committed.

Full suite runs in CI.
