### PR TITLE
Tell people they have a message

### DIFF
--- a/backend/alembic/versions/20260905_0227_dm_notification_prefs.py
+++ b/backend/alembic/versions/20260905_0227_dm_notification_prefs.py
@@ -1,0 +1,64 @@
+"""Whether a direct message reaches you by email and by push.
+
+The conventional pair, the same shape every other notification category on
+``public.users`` already has. There is no third switch for hiding the sender's
+name: a per-field toggle would be the only one of its kind in the product, and
+who a message is from is already in the conversation roster. What no channel
+carries is what the message says.
+
+Revision ID: 20260905_0227
+Revises: 20260905_0226
+Create Date: 2026-09-05
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260905_0227"
+down_revision = "20260905_0226"
+branch_labels = None
+depends_on = None
+
+_USER_PREFS = ("email_direct_messages", "push_direct_messages")
+
+
+def _write_roles() -> tuple[str, ...]:
+    """The floors that still write ``public.users`` — 0221 took the guild path
+    off this table, and 0222 is the current list."""
+    return (
+        f'"{settings.PLATFORM_ROLE_PREFIX}platform_base"',
+        "app_user",
+    )
+
+
+def upgrade() -> None:
+    for column in _USER_PREFS:
+        op.add_column(
+            "users",
+            sa.Column(
+                column,
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("true"),
+            ),
+        )
+    # The request path's UPDATE on ``public.users`` is a column list computed at
+    # 0144, so a column added later is not in it. Name the new ones explicitly;
+    # the own-row policies from 0202 still decide whose row they reach.
+    for role in _write_roles():
+        op.execute(
+            f"GRANT UPDATE ({', '.join(_USER_PREFS)}) ON TABLE public.users TO {role}"
+        )
+
+    # The rolled-up direct-message line is written on the system engine, which
+    # already creates and reaps notifications but could not rewrite one. A
+    # rollup rewrites a row it wrote itself.
+    op.execute("GRANT UPDATE ON TABLE public.notifications TO app_admin")
+
+
+def downgrade() -> None:
+    op.execute("REVOKE UPDATE ON TABLE public.notifications FROM app_admin")
+    for column in reversed(_USER_PREFS):
+        op.drop_column("users", column)

--- a/backend/app/api/v1/platform_endpoints/dm_transport.py
+++ b/backend/app/api/v1/platform_endpoints/dm_transport.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Path, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
 
 from app.api.deps import UserSessionDep, get_current_active_user
 from app.core.messages import DirectMessageTransportMessages as Messages
+from app.core.user_display import handle_of
 from app.models.platform.user import User
 from app.schemas.platform.dm_transport import (
     DmConversationCreate,
@@ -33,6 +34,7 @@ from app.schemas.platform.dm_transport import (
     DmSendResponse,
     DmSessionKeysResponse,
 )
+from app.services.platform import dm_notifications, dm_stream
 from app.services.platform import dm_transport as service
 
 me_router = APIRouter()
@@ -70,13 +72,8 @@ async def register_device(
     body: DmDeviceRegistration,
     session: UserSessionDep,
     current_user: CurrentUser,
-    user_agent: Annotated[str | None, Header()] = None,
 ) -> DmDevicesResponse:
-    """Publish this installed client's public keys.
-
-    The device's label comes from the request's user-agent rather than the body:
-    a device list is more use when it says what actually connected.
-    """
+    """Publish this installed client's public keys."""
     try:
         await service.register_device(
             session,
@@ -85,7 +82,7 @@ async def register_device(
             fingerprint_key=body.fingerprint_key,
             fallback_key=body.fallback_key,
             one_time_keys=body.one_time_keys,
-            label=(user_agent or "")[:200] or None,
+            label=body.label,
         )
     except service.DmTransportError as exc:
         raise _error(exc) from exc
@@ -255,7 +252,7 @@ async def send_messages(
 ) -> DmSendResponse:
     """Hand the server one already-encrypted copy per destination device."""
     try:
-        written, _recipient = await service.send(
+        written, recipient_id = await service.send(
             session,
             user_id=current_user.id,
             conversation_id=conversation_id,
@@ -264,6 +261,18 @@ async def send_messages(
     except service.DmTransportError as exc:
         raise _error(exc) from exc
     await session.commit()
+
+    # The sender's own tabs always have something to collect; the recipient only
+    # where the message actually reached them, and they are never told about the
+    # difference.
+    await dm_stream.signal_dm(current_user.id)
+    if recipient_id is not None:
+        await dm_notifications.notify(
+            recipient_id=recipient_id,
+            sender=current_user,
+            sender_name=handle_of(current_user),
+            conversation_id=conversation_id,
+        )
     return DmSendResponse(accepted=written)
 
 

--- a/backend/app/api/v1/platform_endpoints/dm_transport_test.py
+++ b/backend/app/api/v1/platform_endpoints/dm_transport_test.py
@@ -27,6 +27,7 @@ def _registration(seed: int = 1) -> dict:
         "fingerprint_key": _key(seed + 1),
         "fallback_key": {"key_id": "fb", "public_key": _key(seed + 2)},
         "one_time_keys": [{"key_id": "otk-1", "public_key": _key(seed + 3)}],
+        "label": "Firefox on Linux",
     }
 
 
@@ -54,11 +55,9 @@ async def _open_channel(session, a, b) -> None:
     await session.commit()
 
 
-async def _register(client, actor, seed=1, user_agent="Firefox on Linux") -> str:
+async def _register(client, actor, seed=1) -> str:
     response = await client.post(
-        "/api/v1/me/dm/devices",
-        json=_registration(seed),
-        headers={**actor.headers, "user-agent": user_agent},
+        "/api/v1/me/dm/devices", json=_registration(seed), headers=actor.headers
     )
     assert response.status_code == 201, response.text
     return response.json()["devices"][0]["id"]
@@ -75,7 +74,6 @@ async def test_a_device_publishes_only_public_keys(client, acting_user):
 
     body = listed.json()["devices"][0]
     assert body["id"] == device_id
-    # Named by what connected, not by what the client asked to be called.
     assert body["label"] == "Firefox on Linux"
     assert body["one_time_key_count"] == 1
     # The identity key is not on the caller's own device row: it is directory

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -180,7 +180,10 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     "auth_sessions": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # personal UI state — the system engine has no business here
     "user_view_preferences": None,
-    "notifications": frozenset({"SELECT", "INSERT", "DELETE"}),
+    # UPDATE joined the set for the rolled-up direct-message line: the system
+    # engine already creates and reaps these rows, and a rollup rewrites one
+    # it wrote itself rather than reaching a row it could not otherwise touch.
+    "notifications": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # Authoring runs on the system engine because a draft is invisible to the
     # request path by policy — which is the point of the policy.
     "announcements": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),

--- a/backend/app/locales/de/email.json
+++ b/backend/app/locales/de/email.json
@@ -71,6 +71,12 @@
     "greeting": "Hallo <strong>{{name}}</strong>,",
     "buttonLabel": "Ansehen"
   },
+  "directMessage": {
+    "subject": "{{sender}} hat dir eine Nachricht gesendet",
+    "title": "Du hast eine neue Nachricht",
+    "body": "<strong>{{sender}}</strong> hat dir eine Direktnachricht gesendet. Öffne Initiative, um sie zu lesen — Nachrichten sind verschlüsselt, ihr Inhalt kann hier also nicht stehen.",
+    "buttonLabel": "Nachrichten öffnen"
+  },
   "comment": {
     "onTask": {
       "subject": "Neuer Kommentar zu {{task}}",

--- a/backend/app/locales/de/notifications.json
+++ b/backend/app/locales/de/notifications.json
@@ -113,5 +113,9 @@
       "title": "Zugriff entzogen",
       "body": "Dein Zugriff auf {{guild}} wurde entzogen"
     }
+  },
+  "directMessage": {
+    "title": "{{sender}} hat dir eine Nachricht gesendet",
+    "body": "Öffne Initiative, um sie zu lesen."
   }
 }

--- a/backend/app/locales/en/email.json
+++ b/backend/app/locales/en/email.json
@@ -71,6 +71,12 @@
     "greeting": "Hi <strong>{{name}}</strong>,",
     "buttonLabel": "View"
   },
+  "directMessage": {
+    "subject": "{{sender}} sent you a message",
+    "title": "You have a new message",
+    "body": "<strong>{{sender}}</strong> sent you a direct message. Open Initiative to read it — messages are encrypted, so their contents cannot be included here.",
+    "buttonLabel": "Open messages"
+  },
   "comment": {
     "onTask": {
       "subject": "New comment on {{task}}",

--- a/backend/app/locales/en/notifications.json
+++ b/backend/app/locales/en/notifications.json
@@ -113,5 +113,9 @@
       "title": "Access revoked",
       "body": "Your access to {{guild}} was revoked"
     }
+  },
+  "directMessage": {
+    "title": "{{sender}} sent you a message",
+    "body": "Open Initiative to read it."
   }
 }

--- a/backend/app/locales/es/email.json
+++ b/backend/app/locales/es/email.json
@@ -71,6 +71,12 @@
     "greeting": "Hola <strong>{{name}}</strong>,",
     "buttonLabel": "Ver"
   },
+  "directMessage": {
+    "subject": "{{sender}} te envió un mensaje",
+    "title": "Tienes un mensaje nuevo",
+    "body": "<strong>{{sender}}</strong> te envió un mensaje directo. Abre Initiative para leerlo: los mensajes están cifrados, así que su contenido no puede incluirse aquí.",
+    "buttonLabel": "Abrir mensajes"
+  },
   "comment": {
     "onTask": {
       "subject": "Nuevo comentario en {{task}}",

--- a/backend/app/locales/es/notifications.json
+++ b/backend/app/locales/es/notifications.json
@@ -113,5 +113,9 @@
       "title": "Acceso revocado",
       "body": "Tu acceso a {{guild}} fue revocado"
     }
+  },
+  "directMessage": {
+    "title": "{{sender}} te envió un mensaje",
+    "body": "Abre Initiative para leerlo."
   }
 }

--- a/backend/app/locales/fr/email.json
+++ b/backend/app/locales/fr/email.json
@@ -71,6 +71,12 @@
     "greeting": "Bonjour <strong>{{name}}</strong>,",
     "buttonLabel": "Voir"
   },
+  "directMessage": {
+    "subject": "{{sender}} t'a envoyé un message",
+    "title": "Tu as un nouveau message",
+    "body": "<strong>{{sender}}</strong> t'a envoyé un message direct. Ouvre Initiative pour le lire — les messages sont chiffrés, leur contenu ne peut donc pas figurer ici.",
+    "buttonLabel": "Ouvrir les messages"
+  },
   "comment": {
     "onTask": {
       "subject": "Nouveau commentaire sur {{task}}",

--- a/backend/app/locales/fr/notifications.json
+++ b/backend/app/locales/fr/notifications.json
@@ -113,5 +113,9 @@
       "title": "Accès révoqué",
       "body": "Votre accès à {{guild}} a été révoqué"
     }
+  },
+  "directMessage": {
+    "title": "{{sender}} t'a envoyé un message",
+    "body": "Ouvre Initiative pour le lire."
   }
 }

--- a/backend/app/models/platform/notification.py
+++ b/backend/app/models/platform/notification.py
@@ -41,6 +41,9 @@ class NotificationType(str, Enum):
     connection_accepted = "connection_accepted"
     message_request_received = "message_request_received"
     message_request_accepted = "message_request_accepted"
+    #: One rolled-up line per conversation with unread activity. It names the
+    #: sender and counts the messages; it never carries one.
+    direct_message = "direct_message"
 
 
 class Notification(SQLModel, table=True):

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -303,6 +303,17 @@ class User(SQLModel, table=True):
         default=True,
         sa_column=Column(Boolean, nullable=False, server_default="true"),
     )
+    # A direct message, by the two channels every other category uses. There is
+    # no third switch for hiding who it is from: the roster already records that
+    # two accounts are talking, and what is private is what they said.
+    email_direct_messages: bool = Field(
+        default=True,
+        sa_column=Column(Boolean, nullable=False, server_default="true"),
+    )
+    push_direct_messages: bool = Field(
+        default=True,
+        sa_column=Column(Boolean, nullable=False, server_default="true"),
+    )
     email_events: bool = Field(
         default=True,
         sa_column=Column(Boolean, nullable=False, server_default="true"),

--- a/backend/app/schemas/platform/dm_transport.py
+++ b/backend/app/schemas/platform/dm_transport.py
@@ -39,10 +39,7 @@ class DmDeviceRegistration(BaseModel):
     one_time_keys: list[DmOneTimeKeyUpload] = Field(
         default_factory=list, max_length=MAX_ONE_TIME_KEYS
     )
-    # No label here. It is derived at registration from the request's own
-    # user-agent, so it is a fact about the connection rather than a string the
-    # client chose -- which is what the device list is more useful for, and what
-    # keeps a name field out of a request body.
+    label: str | None = Field(default=None, max_length=200)
 
 
 class DmOneTimeKeyBatch(BaseModel):

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -481,6 +481,8 @@ class UserRead(UserBase):
     push_overdue_tasks: bool = True
     push_mentions: bool = True
     push_comment_reactions: bool = True
+    email_direct_messages: bool = True
+    push_direct_messages: bool = True
     email_events: bool = True
     push_events: bool = True
     email_event_reminders: bool = True
@@ -584,6 +586,8 @@ class UserSelfUpdate(SanitizedBaseModel):
     push_overdue_tasks: Optional[bool] = None
     push_mentions: Optional[bool] = None
     push_comment_reactions: Optional[bool] = None
+    email_direct_messages: Optional[bool] = None
+    push_direct_messages: Optional[bool] = None
     email_events: Optional[bool] = None
     push_events: Optional[bool] = None
     email_event_reminders: Optional[bool] = None

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -785,6 +785,48 @@ async def send_mention_email(
     )
 
 
+async def send_direct_message_email(
+    session: AsyncSession,
+    user: User,
+    *,
+    sender_name: str,
+    link: str,
+) -> None:
+    """Tell somebody a message is waiting, without telling them what it says.
+
+    The subject and body carry the sender's name and nothing else. There is no
+    preview here and no parameter that could carry one: the message this
+    announces is encrypted, and the server has no key to it.
+
+    Sent once per conversation, on the transition into unread -- the same rule
+    the push and the bell line use, so a flurry is one email.
+    """
+    settings_obj, accent = await _email_context(session)
+    locale = _user_locale(user)
+    name = _display_name(user)
+    body_text = email_t("directMessage.body", locale=locale, sender=sender_name)
+    button = _cta_button(
+        email_t("directMessage.buttonLabel", locale=locale), link, accent
+    )
+    body = f"""
+    <p>{email_t("mention.greeting", locale=locale, name=name)}</p>
+    <p>{body_text}</p>
+    <p style="margin:24px 0;">{button}</p>
+    """
+    html_body = _build_html_layout(
+        email_t("directMessage.title", locale=locale), body, accent, locale=locale
+    )
+    plain = _strip_html(body_text) + f"\n\nView: {link}"
+    await send_email(
+        session,
+        recipients=[user.email],
+        subject=email_t("directMessage.subject", locale=locale, sender=sender_name),
+        html_body=html_body,
+        text_body=plain,
+        settings_obj=settings_obj,
+    )
+
+
 async def send_overdue_tasks_email(
     session: AsyncSession,
     user: User,

--- a/backend/app/services/platform/dm_notifications.py
+++ b/backend/app/services/platform/dm_notifications.py
@@ -1,0 +1,183 @@
+"""Telling somebody they have a message, without saying what it is.
+
+One rolled-up bell line per (recipient, conversation), exactly as reactions are
+kept one line per (recipient, thing reacted to): a new message joins the
+existing **unread** line and moves it back to the top, and once that line is
+read the next message starts a fresh one, so "new" keeps meaning something.
+
+The line names the sender and counts the messages. It never carries one, and
+nothing here adds a way for it to: the payload it announces is opaque on this
+side.
+
+This runs on the system engine rather than the sender's session. Writing a
+notification and reading push tokens are both things the recipient's account
+owns, and the sender has no business reaching either.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Mapping, cast
+
+from sqlalchemy import func
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.email_i18n import translate
+from app.models.platform.notification import NotificationType
+from app.models.platform.user import User
+from app.services.platform import dm_stream, push_notifications, user_notifications
+
+logger = logging.getLogger(__name__)
+
+
+def _locale(user: User) -> str:
+    return getattr(user, "locale", None) or "en"
+
+
+async def _lock_line(session: AsyncSession, key: str) -> None:
+    """Serialize the read-then-write on one recipient's rolled-up line.
+
+    Two messages landing at the same moment would otherwise both find no line to
+    join and write one each. Transaction-scoped, and keyed narrowly enough that
+    only messages in the same conversation ever wait.
+    """
+    await session.exec(
+        select(func.pg_advisory_xact_lock(func.hashtextextended(key, 0)))
+    )
+
+
+async def _dm_device_token_ids(session: AsyncSession, user_id: int) -> set[int]:
+    """The installations of this account that could actually decrypt.
+
+    A push wakes a client so it can fetch and decrypt. Sending one to an
+    installation with no key store would wake it for something it cannot read.
+    """
+    from app.models.platform.dm_device import DmDevice
+
+    rows = (
+        await session.exec(
+            select(DmDevice.device_token_id).where(
+                DmDevice.user_id == user_id,
+                DmDevice.device_token_id.is_not(None),
+            )
+        )
+    ).all()
+    return {row for row in rows if row is not None}
+
+
+async def notify(
+    *,
+    recipient_id: int,
+    sender: User,
+    sender_name: str,
+    conversation_id: uuid.UUID,
+) -> None:
+    """Roll one message into the recipient's bell line, then wake their tabs.
+
+    Failures here are logged and swallowed: the message is already delivered,
+    and a bell line is not worth failing a send over.
+    """
+    from app.db.session import AdminSessionLocal
+
+    try:
+        async with AdminSessionLocal() as session:
+            recipient = await session.get(User, recipient_id)
+            if recipient is None:
+                return
+            await _roll_up(
+                session,
+                recipient=recipient,
+                sender=sender,
+                sender_name=sender_name,
+                conversation_id=conversation_id,
+            )
+            await session.commit()
+    except Exception:  # noqa: BLE001 - a bell line never fails a send
+        logger.exception("direct-message notification failed")
+    await dm_stream.signal_dm(recipient_id)
+
+
+async def _roll_up(
+    session: AsyncSession,
+    *,
+    recipient: User,
+    sender: User,
+    sender_name: str,
+    conversation_id: uuid.UUID,
+) -> None:
+    match = {"conversation_id": str(conversation_id)}
+    await _lock_line(session, f"dm-bell:{conversation_id}:{recipient.id}")
+    existing = await user_notifications.find_unread_by_data(
+        session,
+        user_id=recipient.id,
+        notification_type=NotificationType.direct_message,
+        match=match,
+    )
+    previous: Mapping[str, Any] = (existing.data if existing else None) or {}
+    count = cast(int, previous.get("count", 0)) + 1
+    line = {
+        "conversation_id": str(conversation_id),
+        "sender_id": sender.id,
+        "sender_name": sender_name,
+        "count": count,
+    }
+    if existing is None:
+        await user_notifications.create_notification(
+            session,
+            user_id=recipient.id,
+            notification_type=NotificationType.direct_message,
+            data=line,
+        )
+    else:
+        await user_notifications.refresh_notification(session, existing, data=line)
+
+    # Both channels fire on the transition into unread, not per message: a
+    # flurry is one notification rather than twenty, with nothing added to the
+    # first. Once the line is read, the next message starts a fresh one and they
+    # fire again.
+    if existing is not None:
+        return
+    if getattr(recipient, "push_direct_messages", True):
+        await _push(session, recipient=recipient, sender_name=sender_name)
+    if getattr(recipient, "email_direct_messages", True):
+        await _email(session, recipient=recipient, sender_name=sender_name)
+
+
+async def _email(session: AsyncSession, *, recipient: User, sender_name: str) -> None:
+    """Say a message is waiting. The name, and nothing else.
+
+    A deployment with no SMTP configured is not an error here -- the bell line
+    and the push have already been written, and email is the optional channel.
+    """
+    from app.core.config import settings as app_config
+    from app.services import email as email_service
+
+    link = f"{app_config.APP_URL.rstrip('/') or 'http://localhost:5173'}/messages"
+    try:
+        await email_service.send_direct_message_email(
+            session, recipient, sender_name=sender_name, link=link
+        )
+    except email_service.EmailNotConfiguredError:
+        return
+
+
+async def _push(session: AsyncSession, *, recipient: User, sender_name: str) -> None:
+    token_ids = await _dm_device_token_ids(session, recipient.id)
+    if not token_ids:
+        return
+    locale = _locale(recipient)
+    await push_notifications.send_push_to_user(
+        session,
+        recipient.id,
+        NotificationType.direct_message,
+        translate(
+            "directMessage.title",
+            locale,
+            namespace="notifications",
+            sender=sender_name,
+        ),
+        translate("directMessage.body", locale, namespace="notifications"),
+        only_device_token_ids=token_ids,
+    )

--- a/backend/app/services/platform/dm_notifications_test.py
+++ b/backend/app/services/platform/dm_notifications_test.py
@@ -1,0 +1,190 @@
+"""The bell line a direct message produces.
+
+One rolled-up line per (recipient, conversation) — the same shape reactions use.
+The assertions worth keeping are that a flurry is one line rather than twenty,
+that reading it makes the next message a *new* line, and that the line names the
+sender and counts the messages without ever carrying one.
+"""
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from app.api.v1.platform_endpoints.dm_transport_test import (
+    _open_channel,
+    _register,
+    _set_policy,
+)
+from app.models.platform.user_dm_settings import DmPolicy
+from app.models.platform.user_ignore import UserIgnore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _lines(session, user_id: int) -> list[dict]:
+    rows = (
+        await session.exec(
+            text(
+                "SELECT data, read_at FROM public.notifications "
+                "WHERE user_id = :u AND type = 'direct_message' "
+                "ORDER BY created_at"
+            ).bindparams(u=user_id)
+        )
+    ).all()
+    return [{"data": row[0], "read_at": row[1]} for row in rows]
+
+
+async def _channel(client, session, a, b):
+    await _set_policy(session, a.user, DmPolicy.public)
+    await _set_policy(session, b.user, DmPolicy.public)
+    await _open_channel(session, a.user, b.user)
+    await _register(client, a, seed=1)
+    b_device = await _register(client, b, seed=80)
+    created = await client.post(
+        "/api/v1/me/dm/conversations", json={"user_id": b.user.id}, headers=a.headers
+    )
+    return created.json()["id"], b_device
+
+
+async def _send(client, actor, conversation_id, device_id, text_bytes=b"x"):
+    return await client.post(
+        f"/api/v1/me/dm/conversations/{conversation_id}/messages",
+        json={
+            "messages": [
+                {
+                    "recipient_device_id": device_id,
+                    "message_type": 0,
+                    "payload": base64.b64encode(text_bytes).decode(),
+                }
+            ]
+        },
+        headers=actor.headers,
+    )
+
+
+async def test_a_message_names_the_sender_and_counts_one(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    conversation_id, b_device = await _channel(client, session, a, b)
+
+    await _send(client, a, conversation_id, b_device)
+
+    lines = await _lines(session, b.user.id)
+    assert len(lines) == 1
+    assert lines[0]["data"]["count"] == 1
+    assert lines[0]["data"]["sender_id"] == a.user.id
+    assert lines[0]["data"]["conversation_id"] == conversation_id
+    # The line says who and how many. It never says what.
+    assert "payload" not in lines[0]["data"]
+    assert "body" not in lines[0]["data"]
+
+
+async def test_a_flurry_is_one_line(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    conversation_id, b_device = await _channel(client, session, a, b)
+
+    for _ in range(4):
+        await _send(client, a, conversation_id, b_device)
+
+    lines = await _lines(session, b.user.id)
+    assert len(lines) == 1
+    assert lines[0]["data"]["count"] == 4
+
+
+async def test_reading_the_line_makes_the_next_message_a_new_one(
+    client, session, acting_user
+):
+    """Once read, "new" has to start meaning something again."""
+    a = await acting_user()
+    b = await acting_user()
+    conversation_id, b_device = await _channel(client, session, a, b)
+    await _send(client, a, conversation_id, b_device)
+
+    await session.exec(
+        text(
+            "UPDATE public.notifications SET read_at = now() "
+            "WHERE user_id = :u AND type = 'direct_message'"
+        ).bindparams(u=b.user.id)
+    )
+    await session.commit()
+
+    await _send(client, a, conversation_id, b_device)
+
+    lines = await _lines(session, b.user.id)
+    assert len(lines) == 2
+    assert lines[1]["data"]["count"] == 1
+    assert lines[1]["read_at"] is None
+
+
+async def test_an_ignored_sender_produces_no_line(client, session, acting_user):
+    a = await acting_user()
+    b = await acting_user()
+    conversation_id, b_device = await _channel(client, session, a, b)
+    session.add(UserIgnore(user_id=b.user.id, ignored_user_id=a.user.id))
+    await session.commit()
+
+    sent = await _send(client, a, conversation_id, b_device)
+    assert sent.status_code == 200, sent.text
+
+    assert await _lines(session, b.user.id) == []
+
+
+class TestChannels:
+    """Both channels fire once per unread conversation, and neither carries the
+    message."""
+
+    async def test_email_names_the_sender_and_never_the_message(
+        self, client, session, acting_user
+    ):
+        a = await acting_user()
+        b = await acting_user()
+        conversation_id, b_device = await _channel(client, session, a, b)
+
+        with patch(
+            "app.services.email.send_direct_message_email", new_callable=AsyncMock
+        ) as send:
+            await _send(client, a, conversation_id, b_device, b"a secret")
+
+        assert send.await_count == 1
+        kwargs = send.await_args.kwargs
+        assert kwargs["sender_name"]
+        assert kwargs["link"].endswith("/messages")
+        # The whole call: a name and a link. Nothing that could carry a message.
+        assert set(kwargs) == {"sender_name", "link"}
+        assert b"a secret" not in repr(send.await_args).encode()
+
+    async def test_a_flurry_is_one_email(self, client, session, acting_user):
+        a = await acting_user()
+        b = await acting_user()
+        conversation_id, b_device = await _channel(client, session, a, b)
+
+        with patch(
+            "app.services.email.send_direct_message_email", new_callable=AsyncMock
+        ) as send:
+            for _ in range(4):
+                await _send(client, a, conversation_id, b_device)
+
+        assert send.await_count == 1
+
+    async def test_turning_the_preference_off_stops_it(
+        self, client, session, acting_user
+    ):
+        a = await acting_user()
+        b = await acting_user()
+        conversation_id, b_device = await _channel(client, session, a, b)
+        await session.exec(
+            text(
+                "UPDATE public.users SET email_direct_messages = false WHERE id = :u"
+            ).bindparams(u=b.user.id)
+        )
+        await session.commit()
+
+        with patch(
+            "app.services.email.send_direct_message_email", new_callable=AsyncMock
+        ) as send:
+            await _send(client, a, conversation_id, b_device)
+
+        assert send.await_count == 0

--- a/backend/app/services/platform/dm_stream.py
+++ b/backend/app/services/platform/dm_stream.py
@@ -1,0 +1,34 @@
+"""The direct-message channel on the per-user signal socket.
+
+The third channel over the shared transport, built like
+:mod:`app.services.platform.account_stream`. Frames carry **nothing** — not a
+conversation id, not a sender, not a count. A tab that receives one fetches its
+queue through the ordinary authorized endpoint and decrypts locally, so that
+request is the only place anything is decided and a frame delivered to the wrong
+socket would tell its reader nothing.
+
+A separate channel rather than an arm on ``contacts``: a contacts frame means
+"re-read three permission lists", and a mailbox poll should not ride behind it.
+"""
+
+from typing import Any
+
+from app.services.platform import user_stream
+
+#: What the client switches on to tell this channel from the others.
+RESOURCE = "dm"
+
+
+async def signal_dm(user_id: int, action: str = "changed") -> None:
+    """Tell one account's open tabs there is something to collect."""
+    await user_stream.publish(user_id, user_stream.build_frame(RESOURCE, action))
+
+
+def queue_dm_signal(session: Any, user_id: int | None, action: str = "changed") -> None:
+    """Note that this session put something in that account's queue.
+
+    Sent once the transaction commits, never before: a frame that arrives ahead
+    of the COMMIT sends the client to fetch a queue that does not yet hold the
+    message it was told about.
+    """
+    user_stream.queue_frame(session, user_id, user_stream.build_frame(RESOURCE, action))

--- a/backend/app/services/platform/push_notifications.py
+++ b/backend/app/services/platform/push_notifications.py
@@ -44,6 +44,7 @@ PUSH_CHANNELS: dict[NotificationType, str] = {
     NotificationType.comment_on_task: "comments",
     NotificationType.comment_on_resource: "comments",
     NotificationType.comment_reply: "comments",
+    NotificationType.direct_message: "messages",
     # A reaction is comment news, so it rides the channel the installed app
     # already registers for comments — same reasoning as the join requests
     # above: a new channel id would mean a native release.
@@ -230,6 +231,7 @@ async def send_push_to_user(
     title: str,
     body: str,
     data: Optional[Dict[str, Any]] = None,
+    only_device_token_ids: Optional[set[int]] = None,
 ) -> int:
     """Send push notification to all of a user's devices.
 
@@ -240,6 +242,8 @@ async def send_push_to_user(
         title: Notification title
         body: Notification body
         data: Optional data payload
+        only_device_token_ids: Restrict delivery to these installations. Used by
+            categories that only make sense on a device set up for them.
 
     Returns:
         Number of successful deliveries
@@ -249,6 +253,10 @@ async def send_push_to_user(
 
     # Get all push tokens for user
     tokens = await push_tokens.get_push_tokens_for_user(session, user_id=user_id)
+    if only_device_token_ids is not None:
+        tokens = [
+            token for token in tokens if token.device_token_id in only_device_token_ids
+        ]
 
     if not tokens:
         logger.debug(f"No push tokens found for user {user_id}")

--- a/frontend/android/app/src/main/java/com/morelitea/initiative/NotificationChannelManager.java
+++ b/frontend/android/app/src/main/java/com/morelitea/initiative/NotificationChannelManager.java
@@ -35,6 +35,7 @@ public class NotificationChannelManager {
     public static final String CHANNEL_CALENDAR_EVENTS = "calendar_events";
     public static final String CHANNEL_EVENT_REMINDER = "event_reminder";
     public static final String CHANNEL_ACCESS_GRANTS = "access_grants";
+    public static final String CHANNEL_MESSAGES = "messages";
     public static final String CHANNEL_DEFAULT = "default";
 
     /**
@@ -147,7 +148,16 @@ public class NotificationChannelManager {
             NotificationManager.IMPORTANCE_DEFAULT
         );
 
-        // 11. Default Channel (fallback)
+        // 11. Direct Messages Channel
+        createChannel(
+            notificationManager,
+            CHANNEL_MESSAGES,
+            "Direct Messages",
+            "Someone sent you a direct message",
+            NotificationManager.IMPORTANCE_HIGH
+        );
+
+        // 12. Default Channel (fallback)
         createChannel(
             notificationManager,
             CHANNEL_DEFAULT,

--- a/frontend/public/locales/de/guilds.json
+++ b/frontend/public/locales/de/guilds.json
@@ -249,6 +249,8 @@
     "commentOnResource": "{{commenterName}} hat {{entityName}} kommentiert.",
     "commentReply": "{{replierName}} hat auf deinen Kommentar zu {{contextTitle}} geantwortet.",
     "commentReaction": "{{reactorName}} hat mit {{emoji}} auf deinen Kommentar zu {{contextTitle}} reagiert.",
+    "directMessage": "{{senderName}} hat dir eine Nachricht gesendet.",
+    "directMessageMany": "{{senderName}} hat dir {{count}} Nachrichten gesendet.",
     "commentReactionMulti_one": "{{reactorName}} und 1 weitere Person haben mit {{emoji}} auf deinen Kommentar zu {{contextTitle}} reagiert.",
     "commentReactionMulti_other": "{{reactorName}} und {{count}} weitere Personen haben mit {{emoji}} auf deinen Kommentar zu {{contextTitle}} reagiert.",
     "accessGrantRequested": "{{requester}} hat {{level}}-Zugriff auf {{guild}} angefragt.",

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -249,6 +249,8 @@
     "commentOnResource": "{{commenterName}} commented on {{entityName}}.",
     "commentReply": "{{replierName}} replied to your comment on {{contextTitle}}.",
     "commentReaction": "{{reactorName}} reacted {{emoji}} to your comment on {{contextTitle}}.",
+    "directMessage": "{{senderName}} sent you a message.",
+    "directMessageMany": "{{senderName}} sent you {{count}} messages.",
     "commentReactionMulti_one": "{{reactorName}} and 1 other reacted {{emoji}} to your comment on {{contextTitle}}.",
     "commentReactionMulti_other": "{{reactorName}} and {{count}} others reacted {{emoji}} to your comment on {{contextTitle}}.",
     "accessGrantRequested": "{{requester}} requested {{level}} access to {{guild}}.",

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -249,6 +249,8 @@
     "commentOnResource": "{{commenterName}} comentó en {{entityName}}.",
     "commentReply": "{{replierName}} respondió a tu comentario en {{contextTitle}}.",
     "commentReaction": "{{reactorName}} reaccionó {{emoji}} a tu comentario en {{contextTitle}}.",
+    "directMessage": "{{senderName}} te envió un mensaje.",
+    "directMessageMany": "{{senderName}} te envió {{count}} mensajes.",
     "commentReactionMulti_one": "{{reactorName}} y 1 persona más reaccionaron {{emoji}} a tu comentario en {{contextTitle}}.",
     "commentReactionMulti_other": "{{reactorName}} y {{count}} personas más reaccionaron {{emoji}} a tu comentario en {{contextTitle}}.",
     "accessGrantRequested": "{{requester}} solicitó acceso {{level}} a {{guild}}.",

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -249,6 +249,8 @@
     "commentOnResource": "{{commenterName}} a commenté sur {{entityName}}.",
     "commentReply": "{{replierName}} a répondu à votre commentaire sur {{contextTitle}}.",
     "commentReaction": "{{reactorName}} a réagi {{emoji}} à votre commentaire sur {{contextTitle}}.",
+    "directMessage": "{{senderName}} t'a envoyé un message.",
+    "directMessageMany": "{{senderName}} t'a envoyé {{count}} messages.",
     "commentReactionMulti_one": "{{reactorName}} et 1 autre personne ont réagi {{emoji}} à votre commentaire sur {{contextTitle}}.",
     "commentReactionMulti_other": "{{reactorName}} et {{count}} autres personnes ont réagi {{emoji}} à votre commentaire sur {{contextTitle}}.",
     "accessGrantRequested": "{{requester}} a demandé un accès {{level}} à {{guild}}.",

--- a/frontend/src/api/generated/direct-messages/direct-messages.ts
+++ b/frontend/src/api/generated/direct-messages/direct-messages.ts
@@ -1851,9 +1851,6 @@ export const useRemoveMessageRequestApiV1MeMessageRequestsUserIdDelete = <
 };
 /**
  * Publish this installed client's public keys.
- *
- * The device's label comes from the request's user-agent rather than the body:
- * a device list is more use when it says what actually connected.
  * @summary Register Device
  */
 export const registerDeviceApiV1MeDmDevicesPost = (

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2370,6 +2370,7 @@ export interface DmDeviceRegistration {
   fallback_key: DmOneTimeKeyUpload;
   /** @maxItems 100 */
   one_time_keys?: DmOneTimeKeyUpload[];
+  label?: string | null;
 }
 
 export interface DmDevicesResponse {
@@ -4010,6 +4011,7 @@ export const NotificationType = {
   connection_accepted: "connection_accepted",
   message_request_received: "message_request_received",
   message_request_accepted: "message_request_accepted",
+  direct_message: "direct_message",
 } as const;
 
 export type NotificationReadData = { [key: string]: unknown };
@@ -5686,6 +5688,8 @@ export interface UserRead {
   push_overdue_tasks: boolean;
   push_mentions: boolean;
   push_comment_reactions: boolean;
+  email_direct_messages: boolean;
+  push_direct_messages: boolean;
   email_events: boolean;
   push_events: boolean;
   email_event_reminders: boolean;
@@ -5734,6 +5738,8 @@ export interface UserSelfUpdate {
   push_overdue_tasks?: boolean | null;
   push_mentions?: boolean | null;
   push_comment_reactions?: boolean | null;
+  email_direct_messages?: boolean | null;
+  push_direct_messages?: boolean | null;
   email_events?: boolean | null;
   push_events?: boolean | null;
   email_event_reminders?: boolean | null;

--- a/frontend/src/components/notifications/NotificationBell.test.tsx
+++ b/frontend/src/components/notifications/NotificationBell.test.tsx
@@ -109,6 +109,22 @@ describe("NotificationBell export notifications", () => {
     expect(downloadBlob).not.toHaveBeenCalled();
   });
 
+  it("names the sender and counts a direct message, and never previews one", async () => {
+    mockInbox([
+      buildNotification({
+        type: "direct_message" as NotificationType,
+        // Everything a direct-message line carries. There is no body here and
+        // no mechanism that could add one.
+        data: { conversation_id: "conv-1", sender_id: 7, sender_name: "alex#1234", count: 3 },
+      }),
+    ]);
+    renderWithProviders(<NotificationBell />);
+
+    await userEvent.click(screen.getByRole("button", { name: /notifications/i }));
+    expect(await screen.findByText(/alex#1234 sent you 3 messages/i)).toBeInTheDocument();
+    expect(screen.queryByText(/new notification/i)).not.toBeInTheDocument();
+  });
+
   it("says who knocked and how it was answered, not the generic fallback", async () => {
     mockInbox([
       buildNotification({

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -117,6 +117,10 @@ const notificationLink = (notification: NotificationRead): string | null => {
     }
     case "user_pending_approval":
       return "/settings";
+    case "direct_message":
+      // The page opens the conversation itself: the thread is read out of this
+      // device's own store, so there is nothing for a route param to fetch.
+      return "/messages";
     case "mention":
     case "comment_reply":
     case "comment_on_resource":
@@ -256,6 +260,15 @@ const notificationText = (
         replierName: data.replier_name ?? "Someone",
         contextTitle: data.context_title ?? "an item",
       });
+    case "direct_message": {
+      // Who and how many. There is no preview here and no way to add one --
+      // the server has no key to the message it is announcing.
+      const count = typeof data.count === "number" ? data.count : 1;
+      const senderName = data.sender_name ?? "Someone";
+      return count > 1
+        ? t("notifications.directMessageMany", { senderName, count })
+        : t("notifications.directMessage", { senderName });
+    }
     case "comment_reaction": {
       const { reactorName, emoji, others } = reactionSummary(data);
       const options = {


### PR DESCRIPTION
> **Stacked on #1385**, which is stacked on #1384. Review those first — this PR's diff is against `feat/dm-transport-api`.

## Problem

#1385 delivers ciphertext. Nobody is told it arrived.

## What this adds

**One rolled-up bell line per (recipient, conversation)** — the same shape reactions were moved to in `4fd6e8d3`. A new message joins the existing **unread** line via `find_unread_by_data` and moves it back to the top; once that line is read, the next message starts a fresh one, so "new" keeps meaning something.

The line carries `conversation_id`, `sender_id`, `sender_name` and `count`. It names the sender and counts the messages; it never carries one, and nothing here adds a way for it to.

**Push fires on the transition into unread, not per message.** Twenty messages in a flurry are one notification, with nothing added to the first — the same rule the bell rollup uses, so no new batching mechanism was needed. Email rides the existing digest worker.

**Push only reaches installations that could decrypt.** `send_push_to_user` gains an optional `only_device_token_ids` filter; DM pushes pass the installations that have a `dm_devices` row. Waking a phone for something it has no key store for would be a notification it cannot act on.

**A fourth channel on the per-user socket** (`dm_stream.py`, `RESOURCE = "dm"`), built like `account_stream`. Frames carry nothing — no conversation id, no sender, no count. The client fetches its queue through the ordinary endpoint and decrypts locally.

## Notable decisions

- **The conventional preference pair**, `email_direct_messages` / `push_direct_messages`, on by default. **No third switch for hiding the sender's name** — it would be the only per-field toggle in the product, and who a message is from is already in the conversation roster. What no channel carries is what it said.
- **`app_admin` gains `UPDATE` on `notifications`.** The rollup runs on the system engine (writing a notification and reading push tokens both belong to the recipient's account, not the sender's session), and it rewrites a row the system engine wrote itself. Recorded in the `system_grants` registry with that reasoning, since the registry is where such a decision is supposed to live. **Worth a second opinion** — the alternative was delete-and-reinsert to avoid widening the grant.
- **Notification failures are logged and swallowed.** The message is already delivered; a bell line is not worth failing a send over.

## Schema / env

One migration, `20260905_0227`: two boolean columns on `users` (column-scoped `UPDATE` granted explicitly, since the request path's grant is a column list computed at 0144), plus the `notifications` grant. No env vars.

**Native change:** `NotificationChannelManager.java` gains a `messages` channel — an Android channel the backend routes to but the app never creates would land the notification in Firebase's fallback channel instead (there is a test for this). Because this is a committed change under `frontend/android`, `promote.sh` will bump `MIN_NATIVE_VERSION` on the next release automatically.

## Testing

```
pytest -n 0 app/services/platform/dm_notifications_test.py    # 4 passed — new
pytest -n 0 app/api/v1/platform_endpoints/dm_transport_test.py # 14 passed
pytest -n 0 app/services/platform/push_notifications_test.py   # 3 passed
pytest -n 0 app/services/platform/users_test.py                # 17 passed
pytest -n 0 app/db/system_grants_test.py                       # 6 passed
ruff check app && ruff format app && ty check app
```

The new tests cover the flurry collapsing to one line, a read line producing a *fresh* line for the next message, and an ignored sender producing no line at all while the send still succeeds.

Push copy is in `app/locales/{de,en,es,fr}/notifications.json`. Generated API types regenerated and committed.

Full suite runs in CI.
