### PR TITLE
Send a contact row to the conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A conversation lives on your devices, not on a server.** A message is delivered and then deleted, which means each device keeps its own copy and a device that has never been in a conversation starts empty. Signing out takes this device's messages with it, which is the right answer on a shared computer — and the wrong one if you wanted them back, so keep the conversations you care about open on a device you stay signed in to.
 
-- **Act on somebody where you find them.** A menu on a profile, and on every row of My Contacts: connect, ask to message, ignore — and remove a connection, which confirms first. Ignoring used to mean knowing an account's exact handle and opening Settings, which is not where anybody reaches for it.
+- **Act on somebody where you find them.** A menu on a profile, and on every row of My Contacts: view their profile, connect, ask to message, ignore — and remove a connection, which confirms first. Ignoring used to mean knowing an account's exact handle and opening Settings, which is not where anybody reaches for it.
+
+- **A contact row opens the conversation with that person.** My Contacts names people you might say something to, so clicking one goes where saying it happens rather than to their profile — the profile is in the menu at the end of the row. Somebody you have never messaged lands on a panel that offers the one thing that leads somewhere: asking them for permission. Everyone on the page wears whatever they have put around their picture, the way they do everywhere else.
+
+- **A mark on My Messages when something is waiting.** A red dot beside it in the sidebar for a message you have not read, or somebody asking to message you. Unread is per device, because a conversation is: your messages live on the device that collected them, so what you have read is a fact about that device and nothing else could answer it.
+
+- **Anyone is its own group on My Contacts, under the communities.** Being open to anyone cannot be listed — it would be everybody here — so the group holds the part of it that means something: the people you are already messaging who no community you are in accounts for.
 
 ### Changed
 

--- a/backend/app/api/v1/platform_endpoints/contacts_test.py
+++ b/backend/app/api/v1/platform_endpoints/contacts_test.py
@@ -193,6 +193,40 @@ async def test_guild_ids_narrows_to_one_section(
     assert [s["guild_id"] for s in response.json()["sections"]] == [second.id]
 
 
+# --- how a person is drawn ---------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_a_roster_row_carries_what_the_person_wears(
+    client: AsyncClient, session: AsyncSession
+):
+    """A row draws somebody the way every other surface does."""
+    user = await create_user(session)
+    guild = await create_guild(session)
+    await create_guild_membership(session, user=user, guild=guild)
+    other = await create_user(
+        session, profile_decorations={"frame": "core.gold", "trophies": []}
+    )
+    await create_guild_membership(session, user=other, guild=guild)
+
+    response = await client.get(SECTIONS, headers=get_auth_headers(user))
+    row = _section(response.json(), guild.id)["items"][0]
+    assert row["profile_decorations"]["frame"] == "core.gold"
+
+
+@pytest.mark.integration
+async def test_a_starred_row_carries_it_too(client: AsyncClient, session: AsyncSession):
+    """Favorites come from the profile view, not the walk, so they are their
+    own path to the same answer."""
+    user = await create_user(session)
+    other = await create_user(session, profile_decorations={"frame": "core.gold"})
+    session.add(ProfileFavorite(user_id=user.id, favorite_user_id=other.id))
+    await session.commit()
+
+    response = await client.get(FAVORITES, headers=get_auth_headers(user))
+    assert response.json()["items"][0]["profile_decorations"]["frame"] == "core.gold"
+
+
 # --- names, per guild -------------------------------------------------------
 
 

--- a/backend/app/api/v1/platform_endpoints/dm_test.py
+++ b/backend/app/api/v1/platform_endpoints/dm_test.py
@@ -222,6 +222,22 @@ async def test_a_connection_is_addressed_by_handle(client, session, acting_user)
     assert [r["user_id"] for r in incoming.json()["incoming"]] == [a.user.id]
 
 
+async def test_a_grant_row_carries_what_the_person_wears(client, session, acting_user):
+    """A grant is listed as a contact row, and a row draws the whole person."""
+    a = await acting_user()
+    b = await acting_user()
+    b.user.profile_decorations = {"frame": "core.gold"}
+    session.add(b.user)
+    await session.commit()
+
+    await client.post(
+        "/api/v1/me/connections", json=await _handle(session, b.user), headers=a.headers
+    )
+    listed = await client.get("/api/v1/me/connections", headers=a.headers)
+    row = listed.json()["outgoing"][0]
+    assert row["profile_decorations"]["frame"] == "core.gold"
+
+
 async def test_an_unknown_handle_answers_like_an_unreachable_one(
     client, session, acting_user
 ):

--- a/backend/app/schemas/platform/contact.py
+++ b/backend/app/schemas/platform/contact.py
@@ -2,7 +2,7 @@
 
 A contact is a person the reader can already see — someone in one of their
 guilds, or someone they starred. ``ContactRead`` is ``UserSummary`` plus the
-two things only this page asks for, kept off the shared picker projection so
+few things only this page asks for, kept off the shared picker projection so
 every other caller of that shape is untouched.
 """
 
@@ -12,7 +12,7 @@ from pydantic import ConfigDict, Field
 
 from app.schemas.base import SanitizedBaseModel
 from app.models.platform.user import Presence
-from app.schemas.platform.user import UserSummary
+from app.schemas.platform.user import ProfileDecorations, UserSummary
 
 
 class ContactRead(UserSummary):
@@ -29,6 +29,9 @@ class ContactRead(UserSummary):
 
     #: How this person appears right now, from the one roll that decides it.
     presence: Presence = Presence.offline
+    #: What they have put around their picture, so a row draws them the way
+    #: every other surface does. Public, like the profile it comes from.
+    profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
     #: The reader's *own* guilds this person is also in, in the same order the
     #: sections come in. Never names a guild the reader is not in — it is built
     #: from their own guild list. The section a row sits in is included; the

--- a/backend/app/schemas/platform/dm.py
+++ b/backend/app/schemas/platform/dm.py
@@ -8,11 +8,12 @@ state the screen can render.
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from app.models.platform.user import Presence, UserStatus
 from app.models.platform.user_dm_settings import DmPolicy
 from app.schemas.base import SanitizedBaseModel
+from app.schemas.platform.user import ProfileDecorations
 
 
 class CommunityDmToggle(SanitizedBaseModel):
@@ -105,6 +106,9 @@ class ContactGrantRead(SanitizedBaseModel):
     #: grant may name somebody the reader shares no community with.
     status: UserStatus = UserStatus.active
     presence: Presence = Presence.offline
+    #: What they wear around their picture, for the same reason: a grant row is
+    #: a contact row, and a person looks the same wherever they are listed.
+    profile_decorations: ProfileDecorations = Field(default_factory=ProfileDecorations)
     state: str
     #: True when the reader is the one who asked, which is what tells a
     #: cancellable request from one waiting on them.

--- a/backend/app/services/platform/contact_grants.py
+++ b/backend/app/services/platform/contact_grants.py
@@ -426,7 +426,8 @@ async def to_reads(
         for row in (
             await session.exec(
                 text(
-                    "SELECT id, username, discriminator, avatar_url, status "
+                    "SELECT id, username, discriminator, avatar_url, status, "
+                    "profile_decorations "
                     "FROM public.user_profiles WHERE id = ANY(:ids)"
                 ).bindparams(ids=list(others))
             )
@@ -447,6 +448,7 @@ async def to_reads(
             discriminator=profile[2],
             avatar_url=profile[3],
             status=profile[4],
+            profile_decorations=profile[5] or {},
             presence=presence_service.online.presence_of(other),
             state=grant.state.value,
             outgoing=grant.requested_by == user_id,

--- a/backend/app/services/platform/contacts.py
+++ b/backend/app/services/platform/contacts.py
@@ -253,6 +253,7 @@ async def favorites(
             user_profiles.c.discriminator,
             user_profiles.c.avatar_url,
             user_profiles.c.status,
+            user_profiles.c.profile_decorations,
         )
         .join(
             ProfileFavorite,
@@ -289,6 +290,7 @@ async def favorites(
             discriminator=row.discriminator,
             avatar_url=row.avatar_url,
             status=row.status,
+            profile_decorations=row.profile_decorations or {},
             presence=presence_service.online.presence_of(row.id),
         )
         for row in rows

--- a/frontend/public/locales/de/contacts.json
+++ b/frontend/public/locales/de/contacts.json
@@ -3,7 +3,7 @@
   "subtitle": "Alle, mit denen du eine Community teilst, und alle, die du markiert hast.",
   "favorites": "Favoriten",
   "connections": "Verbindungen",
-  "directMessages": "Direktnachrichten",
+  "anyone": "Alle",
   "requests": "Anfragen",
   "searchPlaceholder": "Kontakte durchsuchen",
   "searchLabel": "Alle auf dieser Seite durchsuchen",
@@ -51,6 +51,7 @@
   },
   "actions": {
     "label": "Aktionen für {{handle}}",
+    "viewProfile": "Profil ansehen",
     "connect": "Verbinden",
     "ask": "Um Nachricht bitten",
     "askSent": "Anfrage gesendet.",

--- a/frontend/public/locales/de/messages.json
+++ b/frontend/public/locales/de/messages.json
@@ -23,5 +23,7 @@
     "denied": "Du kannst ihnen gerade nicht schreiben."
   },
   "unreadHere_one": "{{count}} ungelesene Nachricht",
-  "unreadHere_other": "{{count}} ungelesene Nachrichten"
+  "unreadHere_other": "{{count}} ungelesene Nachrichten",
+  "openFailed": "Diese Unterhaltung konnte nicht geöffnet werden.",
+  "tryAgain": "Erneut versuchen"
 }

--- a/frontend/public/locales/de/messages.json
+++ b/frontend/public/locales/de/messages.json
@@ -15,5 +15,13 @@
   "recipientHasNoDevice": "{{name}} hat verschlüsselte Nachrichten noch nicht eingerichtet, deshalb konnte dies nicht zugestellt werden.",
   "deviceFailed": "Verschlüsselte Nachrichten konnten auf diesem Gerät nicht eingerichtet werden.",
   "loading": "Wird geladen …",
-  "unsupportedBrowser": "Verschlüsselte Nachrichten brauchen eine sichere Verbindung und einen Browser, der sie ausführen kann. Prüfe, ob die Adresse mit https beginnt (oder localhost ist), oder nutze die App."
+  "unsupportedBrowser": "Verschlüsselte Nachrichten brauchen eine sichere Verbindung und einen Browser, der sie ausführen kann. Prüfe, ob die Adresse mit https beginnt (oder localhost ist), oder nutze die App.",
+  "start": {
+    "waiting": "Warten auf die Zusage. Danach könnt ihr euch schreiben.",
+    "asksToMessage": "Sie möchten dir schreiben. Nimm an, dann könnt ihr reden.",
+    "mayAsk": "Du hast ihnen noch nicht geschrieben. Frag zuerst — sie können annehmen oder ablehnen, und bis dahin wird nichts gesendet.",
+    "denied": "Du kannst ihnen gerade nicht schreiben."
+  },
+  "unreadHere_one": "{{count}} ungelesene Nachricht",
+  "unreadHere_other": "{{count}} ungelesene Nachrichten"
 }

--- a/frontend/public/locales/de/nav.json
+++ b/frontend/public/locales/de/nav.json
@@ -77,5 +77,7 @@
     "goHome": "Zurück zur Startseite"
   },
   "adminDashboard": "Administrator-Dashboard",
-  "pastAnnouncements": "Frühere Ankündigungen"
+  "pastAnnouncements": "Frühere Ankündigungen",
+  "requestsWaiting_one": "{{count}} Sache wartet",
+  "requestsWaiting_other": "{{count}} Sachen warten"
 }

--- a/frontend/public/locales/en/contacts.json
+++ b/frontend/public/locales/en/contacts.json
@@ -3,7 +3,7 @@
   "subtitle": "Everyone you share a community with, plus anyone you starred.",
   "favorites": "Favorites",
   "connections": "Connections",
-  "directMessages": "Direct messages",
+  "anyone": "Anyone",
   "requests": "Requests",
   "searchPlaceholder": "Search contacts",
   "searchLabel": "Search everyone on this page",
@@ -51,6 +51,7 @@
   },
   "actions": {
     "label": "Actions for {{handle}}",
+    "viewProfile": "View profile",
     "connect": "Connect",
     "ask": "Ask to message",
     "askSent": "Request sent.",

--- a/frontend/public/locales/en/messages.json
+++ b/frontend/public/locales/en/messages.json
@@ -15,5 +15,13 @@
   "recipientHasNoDevice": "{{name}} has not set up encrypted messages yet, so this could not be delivered.",
   "deviceFailed": "Encrypted messages could not be set up on this device.",
   "loading": "Loading…",
-  "unsupportedBrowser": "Encrypted messages need a secure connection and a browser that can run them. Check the address starts with https (or is localhost), or try the app."
+  "unsupportedBrowser": "Encrypted messages need a secure connection and a browser that can run them. Check the address starts with https (or is localhost), or try the app.",
+  "start": {
+    "waiting": "Waiting for them to accept. You can message each other once they do.",
+    "asksToMessage": "They asked to message you. Accept, and the two of you can talk.",
+    "mayAsk": "You haven't messaged them yet. Ask first — they can accept or decline, and nothing is sent until they do.",
+    "denied": "You can't message them right now."
+  },
+  "unreadHere_one": "{{count}} unread message",
+  "unreadHere_other": "{{count}} unread messages"
 }

--- a/frontend/public/locales/en/messages.json
+++ b/frontend/public/locales/en/messages.json
@@ -23,5 +23,7 @@
     "denied": "You can't message them right now."
   },
   "unreadHere_one": "{{count}} unread message",
-  "unreadHere_other": "{{count}} unread messages"
+  "unreadHere_other": "{{count}} unread messages",
+  "openFailed": "That conversation could not be opened.",
+  "tryAgain": "Try again"
 }

--- a/frontend/public/locales/en/nav.json
+++ b/frontend/public/locales/en/nav.json
@@ -77,5 +77,7 @@
     "goHome": "Go back home"
   },
   "adminDashboard": "Admin dashboard",
-  "pastAnnouncements": "Past announcements"
+  "pastAnnouncements": "Past announcements",
+  "requestsWaiting_one": "{{count}} thing waiting",
+  "requestsWaiting_other": "{{count}} things waiting"
 }

--- a/frontend/public/locales/es/contacts.json
+++ b/frontend/public/locales/es/contacts.json
@@ -3,7 +3,7 @@
   "subtitle": "Todas las personas con las que compartes una comunidad, y las que hayas marcado.",
   "favorites": "Favoritos",
   "connections": "Conexiones",
-  "directMessages": "Mensajes directos",
+  "anyone": "Cualquiera",
   "requests": "Solicitudes",
   "searchPlaceholder": "Buscar contactos",
   "searchLabel": "Buscar a todos en esta página",
@@ -51,6 +51,7 @@
   },
   "actions": {
     "label": "Acciones para {{handle}}",
+    "viewProfile": "Ver perfil",
     "connect": "Conectar",
     "ask": "Pedir escribir",
     "askSent": "Solicitud enviada.",

--- a/frontend/public/locales/es/messages.json
+++ b/frontend/public/locales/es/messages.json
@@ -15,5 +15,13 @@
   "recipientHasNoDevice": "{{name}} todavía no ha configurado los mensajes cifrados, así que no se pudo entregar.",
   "deviceFailed": "No se pudieron configurar los mensajes cifrados en este dispositivo.",
   "loading": "Cargando…",
-  "unsupportedBrowser": "Los mensajes cifrados necesitan una conexión segura y un navegador capaz de ejecutarlos. Comprueba que la dirección empiece por https (o sea localhost), o prueba con la aplicación."
+  "unsupportedBrowser": "Los mensajes cifrados necesitan una conexión segura y un navegador capaz de ejecutarlos. Comprueba que la dirección empiece por https (o sea localhost), o prueba con la aplicación.",
+  "start": {
+    "waiting": "Esperando a que acepten. Cuando lo hagan, podréis escribiros.",
+    "asksToMessage": "Te han pedido escribirte. Acepta y podréis hablar.",
+    "mayAsk": "Todavía no les has escrito. Pídelo primero: pueden aceptar o rechazar, y no se envía nada hasta entonces.",
+    "denied": "Ahora mismo no puedes escribirles."
+  },
+  "unreadHere_one": "{{count}} mensaje sin leer",
+  "unreadHere_other": "{{count}} mensajes sin leer"
 }

--- a/frontend/public/locales/es/messages.json
+++ b/frontend/public/locales/es/messages.json
@@ -23,5 +23,7 @@
     "denied": "Ahora mismo no puedes escribirles."
   },
   "unreadHere_one": "{{count}} mensaje sin leer",
-  "unreadHere_other": "{{count}} mensajes sin leer"
+  "unreadHere_other": "{{count}} mensajes sin leer",
+  "openFailed": "No se pudo abrir esa conversación.",
+  "tryAgain": "Inténtalo de nuevo"
 }

--- a/frontend/public/locales/es/nav.json
+++ b/frontend/public/locales/es/nav.json
@@ -77,5 +77,7 @@
   "createCounterGroup": "Nuevo grupo de contadores",
   "createExternally": "Se crea en {{name}}",
   "adminDashboard": "Panel de administración",
-  "pastAnnouncements": "Anuncios anteriores"
+  "pastAnnouncements": "Anuncios anteriores",
+  "requestsWaiting_one": "{{count}} cosa esperando",
+  "requestsWaiting_other": "{{count}} cosas esperando"
 }

--- a/frontend/public/locales/fr/contacts.json
+++ b/frontend/public/locales/fr/contacts.json
@@ -3,7 +3,7 @@
   "subtitle": "Toutes les personnes avec qui vous partagez une communauté, ainsi que vos favoris.",
   "favorites": "Favoris",
   "connections": "Connexions",
-  "directMessages": "Messages directs",
+  "anyone": "Tout le monde",
   "requests": "Demandes",
   "searchPlaceholder": "Rechercher des contacts",
   "searchLabel": "Rechercher parmi tout le monde sur cette page",
@@ -51,6 +51,7 @@
   },
   "actions": {
     "label": "Actions pour {{handle}}",
+    "viewProfile": "Voir le profil",
     "connect": "Se connecter",
     "ask": "Demander à écrire",
     "askSent": "Demande envoyée.",

--- a/frontend/public/locales/fr/messages.json
+++ b/frontend/public/locales/fr/messages.json
@@ -23,5 +23,7 @@
     "denied": "Tu ne peux pas lui écrire pour le moment."
   },
   "unreadHere_one": "{{count}} message non lu",
-  "unreadHere_other": "{{count}} messages non lus"
+  "unreadHere_other": "{{count}} messages non lus",
+  "openFailed": "Cette conversation n'a pas pu être ouverte.",
+  "tryAgain": "Réessayer"
 }

--- a/frontend/public/locales/fr/messages.json
+++ b/frontend/public/locales/fr/messages.json
@@ -15,5 +15,13 @@
   "recipientHasNoDevice": "{{name}} n'a pas encore configuré les messages chiffrés, ceci n'a donc pas pu être remis.",
   "deviceFailed": "Les messages chiffrés n'ont pas pu être configurés sur cet appareil.",
   "loading": "Chargement…",
-  "unsupportedBrowser": "Les messages chiffrés ont besoin d'une connexion sécurisée et d'un navigateur capable de les exécuter. Vérifie que l'adresse commence par https (ou est localhost), ou utilise l'application."
+  "unsupportedBrowser": "Les messages chiffrés ont besoin d'une connexion sécurisée et d'un navigateur capable de les exécuter. Vérifie que l'adresse commence par https (ou est localhost), ou utilise l'application.",
+  "start": {
+    "waiting": "En attente de leur acceptation. Ensuite, vous pourrez vous écrire.",
+    "asksToMessage": "Cette personne a demandé à t'écrire. Accepte et vous pourrez discuter.",
+    "mayAsk": "Tu ne lui as pas encore écrit. Demande d'abord : elle peut accepter ou refuser, et rien n'est envoyé avant.",
+    "denied": "Tu ne peux pas lui écrire pour le moment."
+  },
+  "unreadHere_one": "{{count}} message non lu",
+  "unreadHere_other": "{{count}} messages non lus"
 }

--- a/frontend/public/locales/fr/nav.json
+++ b/frontend/public/locales/fr/nav.json
@@ -77,5 +77,7 @@
   "createCounterGroup": "Nouveau groupe de compteurs",
   "createExternally": "Créé dans {{name}}",
   "adminDashboard": "Tableau de bord admin",
-  "pastAnnouncements": "Annonces passées"
+  "pastAnnouncements": "Annonces passées",
+  "requestsWaiting_one": "{{count}} chose en attente",
+  "requestsWaiting_other": "{{count}} choses en attente"
 }

--- a/frontend/src/__tests__/myContactsRoute.test.tsx
+++ b/frontend/src/__tests__/myContactsRoute.test.tsx
@@ -420,12 +420,15 @@ describe("My Contacts", () => {
     expect(await screen.findByText("Nobody here yet")).toBeInTheDocument();
   });
 
-  it("links a row to that person's profile by handle", async () => {
+  it("links a row at the conversation with that person, by handle", async () => {
+    // Not their profile: a contacts page names people you might say something
+    // to, so the row goes where saying it happens. The profile is in the menu
+    // at the end of the row.
     answer([section({ items: [contact({ username: "ada", discriminator: 42 })] })]);
     await renderContacts();
 
     const row = (await screen.findByText("ada")).closest("a");
-    expect(row).toHaveAttribute("href", "/u/ada0042");
+    expect(row).toHaveAttribute("href", "/messages?with=ada0042");
   });
 
   it("counts a community by its whole roster, not the page on screen", async () => {

--- a/frontend/src/__tests__/myMessagesRoute.test.tsx
+++ b/frontend/src/__tests__/myMessagesRoute.test.tsx
@@ -26,12 +26,18 @@ const MESSAGES_ROUTE_ID = "/_serverRequired/_authenticated/messages";
 
 const mocks = vi.hoisted(() => ({
   ensureDevice: vi.fn(),
+  registeredDevice: vi.fn(),
   collect: vi.fn(),
   sendText: vi.fn(),
   logGet: vi.fn(),
+  unreadIn: vi.fn(),
+  markRead: vi.fn(),
   conversations: vi.fn(),
   createConversation: vi.fn(),
   messageRequests: vi.fn(),
+  dmPermission: vi.fn(),
+  requestMessage: vi.fn(),
+  userProfile: vi.fn(),
 }));
 
 // The ratchet is exercised for real in src/crypto/ratchet.test.ts. Here it is
@@ -42,10 +48,15 @@ vi.mock("@/crypto/messaging", async (importOriginal) => ({
   RecipientHasNoDeviceError: (await importOriginal<Record<string, unknown>>())
     .RecipientHasNoDeviceError,
   ensureDevice: () => mocks.ensureDevice(),
+  registeredDevice: () => mocks.registeredDevice(),
   collect: () => mocks.collect(),
   sendText: (conversationId: string, otherUserId: number, body: string) =>
     mocks.sendText(conversationId, otherUserId, body),
   messageLog: { get: (id: string) => mocks.logGet(id) },
+  // Which threads are unread, and saying one has been looked at, both read the
+  // same local log the thread does.
+  unreadIn: (id: string) => mocks.unreadIn(id),
+  markRead: (id: string) => mocks.markRead(id),
 }));
 
 vi.mock("@/api/generated/direct-messages/direct-messages", async (importOriginal) => ({
@@ -58,6 +69,15 @@ vi.mock("@/api/generated/direct-messages/direct-messages", async (importOriginal
 vi.mock("@/hooks/useDirectMessages", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useMessageRequests: () => mocks.messageRequests(),
+  useDmPermission: () => mocks.dmPermission(),
+  useRequestMessage: () => ({ mutate: mocks.requestMessage, isPending: false }),
+}));
+
+// The page resolves `?with=` to a person before it can decide anything about
+// them, so the profile is the seam that decides which pane is on trial.
+vi.mock("@/hooks/useUsers", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useUserProfile: (handle: string | null | undefined) => mocks.userProfile(handle),
 }));
 
 const router = createRouter({ routeTree });
@@ -105,11 +125,37 @@ const renderMessages = async () => {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.ensureDevice.mockResolvedValue("device-1");
+  mocks.registeredDevice.mockResolvedValue("device-1");
+  mocks.unreadIn.mockResolvedValue(0);
+  mocks.markRead.mockResolvedValue(undefined);
   mocks.collect.mockResolvedValue([]);
   mocks.sendText.mockResolvedValue({ id: "1", body: "hi", at: "", mine: true });
   mocks.logGet.mockResolvedValue([]);
   mocks.conversations.mockResolvedValue({ conversations: [] });
+  mocks.createConversation.mockResolvedValue({
+    id: "conv-new",
+    other_user_id: 0,
+    created_at: "2026-09-01T00:00:00Z",
+  });
   mocks.messageRequests.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
+  mocks.dmPermission.mockReturnValue({ data: { permission: "denied" } });
+  mocks.userProfile.mockReturnValue({ data: undefined, isLoading: false });
+});
+
+/** The person a `?with=` handle resolves to. */
+const profile = (userId: number, username: string) => ({
+  data: {
+    id: userId,
+    username,
+    discriminator: 1234,
+    avatar_url: null,
+    status: "active" as const,
+    custom_status: {},
+    profile_decorations: {},
+    presence: "offline" as const,
+    joined_at: "2026-01-01T00:00:00Z",
+  },
+  isLoading: false,
 });
 
 describe("My Messages", () => {
@@ -194,6 +240,50 @@ describe("My Messages", () => {
     expect(await screen.findByText(/has not set up encrypted messages/i)).toBeInTheDocument();
     // And the text comes back, because the composer was the only copy of it.
     expect(screen.getByLabelText(/write a message/i)).toHaveValue("hello");
+  });
+
+  it("opens the conversation the address names", async () => {
+    // A contacts row links straight here. Landing on the page is not enough —
+    // it has to land on that person's thread.
+    mocks.conversations.mockResolvedValue({
+      conversations: [{ id: "conv-1", other_user_id: 7, created_at: "2026-09-01T00:00:00Z" }],
+    });
+    mocks.messageRequests.mockReturnValue({
+      data: { accepted: [grant(7, "alex")], incoming: [], outgoing: [] },
+    });
+    mocks.userProfile.mockReturnValue(profile(7, "alex"));
+    mocks.logGet.mockResolvedValue([{ id: "m1", body: "already talking", at: "", mine: false }]);
+
+    const Page = await messagesPage();
+    renderPage(Page, { initialRoute: "/messages", routerSearch: { with: "alex1234" } });
+
+    expect(await screen.findByText("already talking")).toBeInTheDocument();
+  });
+
+  it("offers to ask, for somebody there is no channel with", async () => {
+    // The common case, because a contact is somebody you share a community
+    // with rather than somebody who agreed to hear from you.
+    mocks.userProfile.mockReturnValue(profile(9, "bram"));
+    mocks.dmPermission.mockReturnValue({ data: { permission: "may_request" } });
+
+    const Page = await messagesPage();
+    renderPage(Page, { initialRoute: "/messages", routerSearch: { with: "bram1234" } });
+
+    await userEvent.click(await screen.findByRole("button", { name: /ask to message/i }));
+    expect(mocks.requestMessage).toHaveBeenCalledWith({ data: { user_id: 9 } }, expect.anything());
+  });
+
+  it("offers nothing to ask for when the server says no", async () => {
+    // Every refusal collapses into one word, so the panel cannot tell them
+    // apart and does not pretend to — and a connection is My Contacts' business
+    // rather than this page's.
+    mocks.userProfile.mockReturnValue(profile(9, "bram"));
+
+    const Page = await messagesPage();
+    renderPage(Page, { initialRoute: "/messages", routerSearch: { with: "bram1234" } });
+
+    expect(await screen.findByText(/can't message them right now/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /connect/i })).toBeNull();
   });
 
   it("sends through the ratchet rather than posting a body", async () => {

--- a/frontend/src/__tests__/myMessagesRoute.test.tsx
+++ b/frontend/src/__tests__/myMessagesRoute.test.tsx
@@ -303,6 +303,32 @@ describe("My Messages", () => {
     await waitFor(() => expect(mocks.createConversation).toHaveBeenCalledTimes(2));
   });
 
+  it("does not hand the next person the last one's failure", async () => {
+    // One mutation, one error state — so a failure has to remember whose it
+    // was, or somebody you have never tried to reach arrives at it.
+    mocks.messageRequests.mockReturnValue({
+      data: { accepted: [grant(7, "alex")], incoming: [], outgoing: [] },
+    });
+    mocks.userProfile.mockImplementation((handle: string) =>
+      handle === "alex1234" ? profile(7, "alex") : profile(9, "bram")
+    );
+    mocks.dmPermission.mockReturnValue({ data: { permission: "may_request" } });
+    mocks.createConversation.mockRejectedValue(new Error("network"));
+
+    const Page = await messagesPage();
+    const { router } = renderPage(Page, {
+      initialRoute: "/messages",
+      routerSearch: { with: "alex1234" },
+    });
+    expect(await screen.findByRole("button", { name: /try again/i })).toBeVisible();
+
+    // Bram has no channel at all, so nothing was ever tried for him.
+    await router.navigate({ to: "/messages", search: { with: "bram1234" } });
+
+    expect(await screen.findByRole("button", { name: /ask to message/i })).toBeVisible();
+    expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+  });
+
   it("sends through the ratchet rather than posting a body", async () => {
     mocks.conversations.mockResolvedValue({
       conversations: [{ id: "conv-1", other_user_id: 7, created_at: "2026-09-01T00:00:00Z" }],

--- a/frontend/src/__tests__/myMessagesRoute.test.tsx
+++ b/frontend/src/__tests__/myMessagesRoute.test.tsx
@@ -286,6 +286,23 @@ describe("My Messages", () => {
     expect(screen.queryByRole("button", { name: /connect/i })).toBeNull();
   });
 
+  it("offers another go when a conversation could not be opened", async () => {
+    // The address does not change when the button is pressed, so nothing would
+    // re-run on its own — and a pane stuck on \"Loading…\" is a dead end.
+    mocks.messageRequests.mockReturnValue({
+      data: { accepted: [grant(7, "alex")], incoming: [], outgoing: [] },
+    });
+    mocks.userProfile.mockReturnValue(profile(7, "alex"));
+    mocks.createConversation.mockRejectedValueOnce(new Error("network"));
+
+    const Page = await messagesPage();
+    renderPage(Page, { initialRoute: "/messages", routerSearch: { with: "alex1234" } });
+
+    await userEvent.click(await screen.findByRole("button", { name: /try again/i }));
+
+    await waitFor(() => expect(mocks.createConversation).toHaveBeenCalledTimes(2));
+  });
+
   it("sends through the ratchet rather than posting a body", async () => {
     mocks.conversations.mockResolvedValue({
       conversations: [{ id: "conv-1", other_user_id: 7, created_at: "2026-09-01T00:00:00Z" }],

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1869,6 +1869,7 @@ export interface ContactGrantRead {
   avatar_url: string | null;
   status: UserStatus;
   presence: Presence;
+  profile_decorations: ProfileDecorationsOutput;
   state: string;
   outgoing: boolean;
   created_at: string;
@@ -1896,6 +1897,7 @@ export interface ContactRead {
   avatar_url: string | null;
   status: UserStatus;
   presence: Presence;
+  profile_decorations: ProfileDecorationsOutput;
   shared_guild_ids: number[];
 }
 

--- a/frontend/src/components/contacts/ContactActionsMenu.test.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.test.tsx
@@ -11,7 +11,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildContactGrant, buildIgnoredAccount } from "@/__tests__/factories";
-import { renderWithProviders } from "@/__tests__/helpers/render";
+import { renderPage } from "@/__tests__/helpers/render";
 
 const mocks = vi.hoisted(() => ({
   permission: vi.fn(),
@@ -39,9 +39,11 @@ import { ContactActionsMenu } from "./ContactActionsMenu";
 
 const ADA = { id: 7, username: "ada", discriminator: 1234 };
 
+// Through a router: one of the items is a link to the person's profile, and a
+// `Link` outside a router does not render at all.
 const open = async () => {
-  renderWithProviders(<ContactActionsMenu user={ADA} />);
-  await userEvent.click(screen.getByRole("button", { name: /Actions for ada/i }));
+  renderPage(() => <ContactActionsMenu user={ADA} />);
+  await userEvent.click(await screen.findByRole("button", { name: /Actions for ada/i }));
 };
 
 beforeEach(() => {

--- a/frontend/src/components/contacts/ContactActionsMenu.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { MoreHorizontal } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -21,6 +22,7 @@ import {
   useStopIgnoring,
 } from "@/hooks/useDirectMessages";
 import { toast } from "@/lib/chesterToast";
+import { getUrlHandle } from "@/lib/userDisplay";
 
 interface ContactActionsMenuProps {
   /** The account being acted on. The handle is what a connection is addressed
@@ -28,6 +30,8 @@ interface ContactActionsMenuProps {
   user: { id: number; username: string; discriminator: number };
   /** Rendered inside a link or a row that is itself clickable. */
   className?: string;
+  /** Off on the profile itself, which is the one place the link goes nowhere. */
+  showProfile?: boolean;
 }
 
 /**
@@ -43,7 +47,11 @@ interface ContactActionsMenuProps {
  * — and because every refusal collapses into that one word, a menu built from
  * it says nothing about which refusal it is.
  */
-export const ContactActionsMenu = ({ user, className }: ContactActionsMenuProps) => {
+export const ContactActionsMenu = ({
+  user,
+  className,
+  showProfile = true,
+}: ContactActionsMenuProps) => {
   const { t } = useTranslation(["contacts", "settings"]);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
 
@@ -77,6 +85,16 @@ export const ContactActionsMenu = ({ user, className }: ContactActionsMenuProps)
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          {/* First, because it is the only item that goes somewhere rather than
+              doing something — and because the row itself now opens the
+              conversation, this is what still reaches the person behind it. */}
+          {showProfile && (
+            <DropdownMenuItem asChild>
+              <Link to="/u/$handle" params={{ handle: getUrlHandle(user) }}>
+                {t("actions.viewProfile")}
+              </Link>
+            </DropdownMenuItem>
+          )}
           {!isConnection && !isPending && (
             <DropdownMenuItem
               onSelect={() =>

--- a/frontend/src/components/contacts/ContactPersonRow.tsx
+++ b/frontend/src/components/contacts/ContactPersonRow.tsx
@@ -1,10 +1,20 @@
 import type { ReactNode } from "react";
 
+import type { ProfileDecorationsOutput } from "@/api/generated/initiativeAPI.schemas";
 import { UserHandle } from "@/components/UserHandle";
 import { ProfileAvatar } from "@/components/user/ProfileAvatar";
 
 interface ContactPersonRowProps {
-  user: { id: number; username: string; discriminator: number; avatar_url?: string | null };
+  /** Decorations travel on the person rather than as a prop of their own, so a
+   *  caller that already holds a grant row spreads it and the picture is
+   *  dressed. A shape without them — the ignore list — draws a bare one. */
+  user: {
+    id: number;
+    username: string;
+    discriminator: number;
+    avatar_url?: string | null;
+    profile_decorations?: ProfileDecorationsOutput | null;
+  };
   /** One line under the handle — when they connected, what they asked for. */
   detail?: ReactNode;
   /** The row's own controls. */
@@ -16,12 +26,12 @@ interface ContactPersonRowProps {
  * accounts — wherever that ledger is rendered.
  *
  * Distinct from `ContactRow`, which is the directory row on My Contacts: that
- * one sits on the page's shared column template and links to a profile. This
+ * one sits on the page's shared column template and opens a conversation. This
  * is a list item with buttons, and the two are not the same shape.
  */
 export const ContactPersonRow = ({ user, detail, children }: ContactPersonRowProps) => (
   <li className="flex items-center gap-3 py-2">
-    <ProfileAvatar user={user} className="size-8 shrink-0" />
+    <ProfileAvatar user={user} decorations={user.profile_decorations} className="size-8 shrink-0" />
     <div className="min-w-0 flex-1">
       <UserHandle user={user} className="text-sm" nameClassName="min-w-0 truncate" />
       {detail ? <p className="truncate text-muted-foreground text-xs">{detail}</p> : null}

--- a/frontend/src/components/contacts/ContactRow.tsx
+++ b/frontend/src/components/contacts/ContactRow.tsx
@@ -26,6 +26,10 @@ interface ContactRowProps {
  * in both places and the only difference is which guild the chip drops. Its
  * cells sit on the page's shared column template; the link covers all of them
  * and the star sits outside it, in the one column the link does not reach.
+ *
+ * The link goes to the conversation with them, because that is what a contacts
+ * page is for: the row names somebody you might say something to. Their
+ * profile is a click further, in the menu at the end of the row.
  */
 export const ContactRow = ({
   contact,
@@ -39,11 +43,16 @@ export const ContactRow = ({
   return (
     <li className={cn(CONTACT_ROW_OUTER, "rounded-md px-2 hover:bg-muted/50")}>
       <Link
-        to="/u/$handle"
-        params={{ handle: getUrlHandle(contact) }}
+        to="/messages"
+        search={{ with: getUrlHandle(contact) }}
         className={cn(CONTACT_ROW_GRID, "py-1.5")}
       >
-        <ProfileAvatar user={contact} presence={contact.presence} className="size-8" />
+        <ProfileAvatar
+          user={contact}
+          decorations={contact.profile_decorations}
+          presence={contact.presence}
+          className="size-8"
+        />
         <span className="flex min-w-0 text-sm">
           <UserHandle
             user={contact}
@@ -63,7 +72,7 @@ export const ContactRow = ({
       </Link>
       <FavoriteToggle starred={starred} name={name} onToggle={() => onToggleFavorite(contact)} />
       {/* Outside the link, like the star: acting on somebody is not the same
-          gesture as going to look at them. */}
+          gesture as opening a conversation with them. */}
       <ContactActionsMenu
         user={{
           id: contact.id,

--- a/frontend/src/components/contacts/GrantContactSection.tsx
+++ b/frontend/src/components/contacts/GrantContactSection.tsx
@@ -23,6 +23,7 @@ export const grantAsContact = (grant: ContactGrantRead): ContactRead => ({
   avatar_url: grant.avatar_url,
   status: grant.status,
   presence: grant.presence,
+  profile_decorations: grant.profile_decorations,
   shared_guild_ids: [],
 });
 

--- a/frontend/src/components/messages/StartWithPerson.tsx
+++ b/frontend/src/components/messages/StartWithPerson.tsx
@@ -1,0 +1,92 @@
+import { useTranslation } from "react-i18next";
+
+import type { UserProfile } from "@/api/generated/initiativeAPI.schemas";
+import { UserHandle } from "@/components/UserHandle";
+import { Button } from "@/components/ui/button";
+import { ProfileAvatar } from "@/components/user/ProfileAvatar";
+import {
+  useAcceptMessageRequest,
+  useDmPermission,
+  useMessageRequests,
+  useRequestMessage,
+} from "@/hooks/useDirectMessages";
+import { toast } from "@/lib/chesterToast";
+
+/**
+ * Somebody you were sent here to talk to, and cannot yet.
+ *
+ * My Contacts links every row straight at this page, which means most people it
+ * lists arrive with no channel open — a contact is somebody you *share a
+ * community with*, not somebody who has agreed to hear from you. So the
+ * destination is not an error: it is where the asking happens, and the panel's
+ * whole job is to offer the one gesture that leads somewhere.
+ *
+ * That gesture is only ever about messages. A connection is a different
+ * agreement between two accounts, made and unmade on My Contacts, and it does
+ * not belong on a page about a conversation — even though accepting one happens
+ * to open a channel as well.
+ *
+ * Which gesture to offer comes from ``dm_permission`` and the pending list,
+ * never from a guess about why. The server collapses every refusal into
+ * ``denied``, so a panel built from it cannot tell the reasons apart either,
+ * and the copy below does not try to.
+ */
+export const StartWithPerson = ({ person }: { person: UserProfile }) => {
+  const { t } = useTranslation(["messages", "contacts", "settings"]);
+
+  const { data: permission } = useDmPermission(person.id);
+  const { data: requests } = useMessageRequests();
+
+  const requestMessage = useRequestMessage();
+  const acceptMessage = useAcceptMessageRequest();
+
+  const pendingIn = (list?: { user_id: number }[]) =>
+    (list ?? []).some((grant) => grant.user_id === person.id);
+
+  const waiting = pendingIn(requests?.outgoing);
+  // Answered here rather than sent back to the list it also appears in: the
+  // reader came looking for this one person, and it is the same answer.
+  const theirs = pendingIn(requests?.incoming);
+  const mayAsk = permission?.permission === "may_request";
+
+  const body = () => {
+    if (waiting) return t("messages:start.waiting");
+    if (theirs) return t("messages:start.asksToMessage");
+    return mayAsk ? t("messages:start.mayAsk") : t("messages:start.denied");
+  };
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-8 text-center">
+      <div className="max-w-sm space-y-3">
+        <ProfileAvatar
+          user={person}
+          decorations={person.profile_decorations}
+          presence={person.presence}
+          className="mx-auto size-16"
+        />
+        <UserHandle user={person} className="text-base" />
+        <p className="text-muted-foreground text-sm">{body()}</p>
+        {theirs ? (
+          <Button
+            disabled={acceptMessage.isPending}
+            onClick={() => acceptMessage.mutate({ userId: person.id })}
+          >
+            {t("settings:privacy.requests.accept")}
+          </Button>
+        ) : !waiting && mayAsk ? (
+          <Button
+            disabled={requestMessage.isPending}
+            onClick={() =>
+              requestMessage.mutate(
+                { data: { user_id: person.id } },
+                { onSuccess: () => toast.success(t("contacts:actions.askSent")) }
+              )
+            }
+          >
+            {t("contacts:actions.ask")}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/sidebar/HomeSidebarContent.tsx
+++ b/frontend/src/components/sidebar/HomeSidebarContent.tsx
@@ -19,10 +19,19 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { usePendingMessageRequests } from "@/hooks/useDirectMessages";
+import { useConversations, useUnreadMessages } from "@/hooks/useMyMessages";
 
 export const HomeSidebarContent = () => {
   const { t } = useTranslation("nav");
   const location = useLocation();
+  // Two things put a mark on My Messages, and they mean the same thing to the
+  // person seeing it: something is there that you have not dealt with. One is
+  // somebody asking to message you; the other is a message you have not read.
+  const pendingRequests = usePendingMessageRequests();
+  const conversations = useConversations();
+  const unread = useUnreadMessages((conversations.data?.conversations ?? []).map((row) => row.id));
+  const unreadTotal = [...(unread.data?.values() ?? [])].reduce((total, count) => total + count, 0);
 
   const navItems = [
     { to: "/", label: t("myTasks"), icon: SquareCheckBig, exact: true },
@@ -30,7 +39,12 @@ export const HomeSidebarContent = () => {
     { to: "/my-calendar", label: t("myCalendar"), icon: CalendarDays },
     { to: "/my-tools", label: t("myTools"), icon: LayoutGrid },
     { to: "/contacts", label: t("myContacts"), icon: Users },
-    { to: "/messages", label: t("myMessages"), icon: MessageSquare },
+    {
+      to: "/messages",
+      label: t("myMessages"),
+      icon: MessageSquare,
+      waiting: pendingRequests + unreadTotal,
+    },
     { to: "/user-stats", label: t("myStats"), icon: ChartColumn },
   ];
 
@@ -60,6 +74,19 @@ export const HomeSidebarContent = () => {
                       <Link to={item.to} className="flex items-center gap-2">
                         <item.icon className="h-4 w-4" />
                         <span>{item.label}</span>
+                        {/* A dot carries no text, so the count it stands for
+                            is written out for anyone not looking at it. */}
+                        {item.waiting ? (
+                          <span className="ms-auto flex shrink-0 items-center">
+                            <span className="sr-only">
+                              {t("requestsWaiting", { count: item.waiting })}
+                            </span>
+                            <span
+                              aria-hidden="true"
+                              className="size-2 rounded-full bg-destructive"
+                            />
+                          </span>
+                        ) : null}
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>

--- a/frontend/src/crypto/messaging.test.ts
+++ b/frontend/src/crypto/messaging.test.ts
@@ -427,6 +427,26 @@ describe("unread", () => {
     expect(await unreadIn(CONVERSATION)).toBe(0);
   });
 
+  it("counts two that landed in the same millisecond", async () => {
+    // A burst arrives with one timestamp on all of it. Counted by time, the
+    // second one would already be behind the marker the first one set.
+    await messageLog.append(CONVERSATION, {
+      id: "m1",
+      body: "first",
+      at: "2026-09-01T10:00:00Z",
+      mine: false,
+    });
+    await markRead(CONVERSATION);
+    await messageLog.append(CONVERSATION, {
+      id: "m2",
+      body: "second, same instant",
+      at: "2026-09-01T10:00:00Z",
+      mine: false,
+    });
+
+    expect(await unreadIn(CONVERSATION)).toBe(1);
+  });
+
   it("survives a browser clock running ahead of the server", async () => {
     // The message this device wrote is stamped from a clock hours ahead. A
     // marker taken from it would swallow everything that arrives next.

--- a/frontend/src/crypto/messaging.test.ts
+++ b/frontend/src/crypto/messaging.test.ts
@@ -95,8 +95,10 @@ import {
   collect,
   ensureDevice,
   forgetMessagesOnThisDevice,
+  markRead,
   RecipientHasNoDeviceError,
   sendText,
+  unreadIn,
 } from "./messaging";
 import {
   accountPickle,
@@ -383,5 +385,65 @@ describe("the prekey pool", () => {
     await collect();
 
     expect(await accountPickle.get()).toBe("account+50");
+  });
+});
+
+/**
+ * What counts as unread, on a device that keeps the only copy of the thread.
+ *
+ * The two sides stamp their messages from two clocks — theirs by the server,
+ * mine by this browser — so the marker has to be taken from one of them or the
+ * count is a guess about which clock is right.
+ */
+describe("unread", () => {
+  const CONVERSATION = "conv-1";
+
+  it("counts what arrived after the thread was last looked at", async () => {
+    await messageLog.append(CONVERSATION, {
+      id: "m1",
+      body: "first",
+      at: "2026-09-01T10:00:00Z",
+      mine: false,
+    });
+    await markRead(CONVERSATION);
+    await messageLog.append(CONVERSATION, {
+      id: "m2",
+      body: "second",
+      at: "2026-09-01T11:00:00Z",
+      mine: false,
+    });
+
+    expect(await unreadIn(CONVERSATION)).toBe(1);
+  });
+
+  it("does not count your own", async () => {
+    await messageLog.append(CONVERSATION, {
+      id: "m1",
+      body: "mine",
+      at: "2026-09-01T10:00:00Z",
+      mine: true,
+    });
+
+    expect(await unreadIn(CONVERSATION)).toBe(0);
+  });
+
+  it("survives a browser clock running ahead of the server", async () => {
+    // The message this device wrote is stamped from a clock hours ahead. A
+    // marker taken from it would swallow everything that arrives next.
+    await messageLog.append(CONVERSATION, {
+      id: "m1",
+      body: "sent from a fast clock",
+      at: "2099-01-01T00:00:00Z",
+      mine: true,
+    });
+    await markRead(CONVERSATION);
+    await messageLog.append(CONVERSATION, {
+      id: "m2",
+      body: "their reply, stamped by the server",
+      at: "2026-09-01T11:00:00Z",
+      mine: false,
+    });
+
+    expect(await unreadIn(CONVERSATION)).toBe(1);
   });
 });

--- a/frontend/src/crypto/messaging.ts
+++ b/frontend/src/crypto/messaging.ts
@@ -240,19 +240,23 @@ export async function unreadIn(conversationId: string): Promise<number> {
 }
 
 /**
- * This thread has been looked at, as of now.
+ * This thread has been looked at, up to the newest message in it.
  *
- * Or as of its newest message, whichever is later: the other side stamps its
- * messages from its own clock, and one running ahead would otherwise leave a
- * message unread the moment after it was read.
+ * Marked against the newest message *from the other side*, and deliberately
+ * not against the clock. Their messages are stamped by the server and mine by
+ * this browser, so a marker taken from either clock could sit ahead of a
+ * message that has not arrived yet and quietly count it as read. Comparing
+ * their messages only ever against their own newest leaves one clock in the
+ * question, which is the server's.
  */
 export async function markRead(conversationId: string): Promise<void> {
   const log = await messageLog.get(conversationId);
   const newest = log.reduce((latest, message) => {
+    if (message.mine) return latest;
     const at = Date.parse(message.at);
     return Number.isNaN(at) ? latest : Math.max(latest, at);
   }, 0);
-  await lastRead.set(conversationId, Math.max(Date.now(), newest));
+  await lastRead.set(conversationId, newest);
 }
 
 /**

--- a/frontend/src/crypto/messaging.ts
+++ b/frontend/src/crypto/messaging.ts
@@ -228,35 +228,33 @@ export async function registeredDevice(): Promise<string | undefined> {
 /**
  * How much of one thread arrived after this device last looked at it.
  *
- * Only the other side counts: your own message is not news to you, and it
- * lands in the same log as theirs because the log is the whole thread.
+ * Counted by position in the log rather than by time: the log is append-only
+ * and in the order this device learned of each message, which is the order the
+ * thread is read in. A marker whose message is not in the log — a device whose
+ * history was cleared under it — leaves everything unread, which is the side to
+ * be wrong on.
+ *
+ * Only the other side counts: your own message is not news to you, and it lands
+ * in the same log as theirs because the log is the whole thread.
  */
 export async function unreadIn(conversationId: string): Promise<number> {
   const [log, seen] = await Promise.all([
     messageLog.get(conversationId),
     lastRead.get(conversationId),
   ]);
-  return log.filter((message) => !message.mine && Date.parse(message.at) > (seen ?? 0)).length;
+  const read = seen ? log.findIndex((message) => message.id === seen) : -1;
+  return log.slice(read + 1).filter((message) => !message.mine).length;
 }
 
-/**
- * This thread has been looked at, up to the newest message in it.
- *
- * Marked against the newest message *from the other side*, and deliberately
- * not against the clock. Their messages are stamped by the server and mine by
- * this browser, so a marker taken from either clock could sit ahead of a
- * message that has not arrived yet and quietly count it as read. Comparing
- * their messages only ever against their own newest leaves one clock in the
- * question, which is the server's.
- */
+/** This thread has been looked at, up to the last message the other side sent. */
 export async function markRead(conversationId: string): Promise<void> {
   const log = await messageLog.get(conversationId);
-  const newest = log.reduce((latest, message) => {
-    if (message.mine) return latest;
-    const at = Date.parse(message.at);
-    return Number.isNaN(at) ? latest : Math.max(latest, at);
-  }, 0);
-  await lastRead.set(conversationId, newest);
+  for (let index = log.length - 1; index >= 0; index -= 1) {
+    if (!log[index].mine) {
+      await lastRead.set(conversationId, log[index].id);
+      return;
+    }
+  }
 }
 
 /**

--- a/frontend/src/crypto/messaging.ts
+++ b/frontend/src/crypto/messaging.ts
@@ -31,6 +31,7 @@ import {
   allSessions,
   deviceClaim,
   forgetDevice,
+  lastRead,
   messageLog,
   type SessionOrigin,
   type StoredMessage,
@@ -217,6 +218,41 @@ async function ensureDeviceContext(): Promise<{ id: string; devices: DmDeviceRea
  */
 export async function ensureDevice(): Promise<string> {
   return (await ensureDeviceContext()).id;
+}
+
+/** Whether this browser has already been set up, without setting it up. */
+export async function registeredDevice(): Promise<string | undefined> {
+  return storedDeviceId.get();
+}
+
+/**
+ * How much of one thread arrived after this device last looked at it.
+ *
+ * Only the other side counts: your own message is not news to you, and it
+ * lands in the same log as theirs because the log is the whole thread.
+ */
+export async function unreadIn(conversationId: string): Promise<number> {
+  const [log, seen] = await Promise.all([
+    messageLog.get(conversationId),
+    lastRead.get(conversationId),
+  ]);
+  return log.filter((message) => !message.mine && Date.parse(message.at) > (seen ?? 0)).length;
+}
+
+/**
+ * This thread has been looked at, as of now.
+ *
+ * Or as of its newest message, whichever is later: the other side stamps its
+ * messages from its own clock, and one running ahead would otherwise leave a
+ * message unread the moment after it was read.
+ */
+export async function markRead(conversationId: string): Promise<void> {
+  const log = await messageLog.get(conversationId);
+  const newest = log.reduce((latest, message) => {
+    const at = Date.parse(message.at);
+    return Number.isNaN(at) ? latest : Math.max(latest, at);
+  }, 0);
+  await lastRead.set(conversationId, Math.max(Date.now(), newest));
 }
 
 /**

--- a/frontend/src/crypto/store.ts
+++ b/frontend/src/crypto/store.ts
@@ -280,20 +280,22 @@ export const deviceId = {
 };
 
 /**
- * When this device last looked at a conversation, as epoch milliseconds.
+ * The last message this device has looked at, per conversation, by its id.
  *
  * Kept here rather than on the server for the same reason the log is: nobody
  * else can see inside a thread, so nobody else can say what has been read. It
  * is per device by consequence — reading a thread on a phone leaves it unread
  * on a laptop, which matches a history that is also per device.
  *
- * A number, not the timestamp of the last message: the two sides stamp their
- * messages from different clocks and in different formats, and comparing
- * instants sidesteps both.
+ * An id rather than a time. The two sides stamp their messages from two clocks
+ * — theirs by the server, mine by this browser — and two messages can land in
+ * the same millisecond, so neither the instant nor the ordering of instants is
+ * something to count against. A place in the log is exact.
  */
 export const lastRead = {
-  get: (conversationId: string) => read<number>(READ_PREFIX + conversationId),
-  set: (conversationId: string, at: number) => write(READ_PREFIX + conversationId, at),
+  get: (conversationId: string) => read<string>(READ_PREFIX + conversationId),
+  set: (conversationId: string, messageId: string) =>
+    write(READ_PREFIX + conversationId, messageId),
 };
 
 /**

--- a/frontend/src/crypto/store.ts
+++ b/frontend/src/crypto/store.ts
@@ -24,6 +24,7 @@ const PICKLE_KEY = "pickle-key";
 const ACCOUNT = "account";
 const DEVICE_ID = "device-id";
 const SESSION_PREFIX = "session:";
+const READ_PREFIX = "last-read:";
 
 function open(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -276,6 +277,23 @@ export const accountPickle = {
 export const deviceId = {
   get: () => read<string>(DEVICE_ID),
   set: (id: string) => write(DEVICE_ID, id),
+};
+
+/**
+ * When this device last looked at a conversation, as epoch milliseconds.
+ *
+ * Kept here rather than on the server for the same reason the log is: nobody
+ * else can see inside a thread, so nobody else can say what has been read. It
+ * is per device by consequence — reading a thread on a phone leaves it unread
+ * on a laptop, which matches a history that is also per device.
+ *
+ * A number, not the timestamp of the last message: the two sides stamp their
+ * messages from different clocks and in different formats, and comparing
+ * instants sidesteps both.
+ */
+export const lastRead = {
+  get: (conversationId: string) => read<number>(READ_PREFIX + conversationId),
+  set: (conversationId: string, at: number) => write(READ_PREFIX + conversationId, at),
 };
 
 /**

--- a/frontend/src/hooks/useDirectMessages.ts
+++ b/frontend/src/hooks/useDirectMessages.ts
@@ -119,6 +119,18 @@ export const parseHandle = (raw: string): { username: string; discriminator: num
   return { username: match[1], discriminator: Number(match[2]) };
 };
 
+/**
+ * How many people have asked to message this account and are still waiting.
+ *
+ * Message requests only. A connection is a separate agreement between two
+ * accounts — made, answered and unmade on My Contacts — and counting it here
+ * would put a mark about connections on a page about conversations.
+ */
+export const usePendingMessageRequests = (): number => {
+  const { data } = useMessageRequests();
+  return data?.incoming?.length ?? 0;
+};
+
 /** Whether this account has answered the age question, which gates everything. */
 export const useCanUseDirectMessages = (): boolean => {
   const { data } = useDmSettings();

--- a/frontend/src/hooks/useMyMessages.test.tsx
+++ b/frontend/src/hooks/useMyMessages.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * The two questions this hook file asks about a browser's device.
+ *
+ * *Is there one* is asked app-wide, so mail is collected wherever you are.
+ * *Make sure there is one* is asked by My Messages. They have different
+ * answers, and the app asks the first one first — so what matters is that one
+ * cannot decide the other, and that registering turns collection on without
+ * waiting for a reload.
+ */
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestQueryClient } from "@/__tests__/helpers/render";
+
+const mocks = vi.hoisted(() => ({
+  ensureDevice: vi.fn(),
+  registeredDevice: vi.fn(),
+  collect: vi.fn(),
+}));
+
+vi.mock("@/crypto/messaging", () => ({
+  ensureDevice: () => mocks.ensureDevice(),
+  registeredDevice: () => mocks.registeredDevice(),
+  collect: () => mocks.collect(),
+  markRead: vi.fn(),
+  unreadIn: vi.fn(),
+  sendText: vi.fn(),
+  messageLog: { get: vi.fn() },
+}));
+
+import { useCollectMessagesWhereRegistered, useDmDevice } from "./useMyMessages";
+
+const wrapper = (client = createTestQueryClient()) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.collect.mockResolvedValue([]);
+  mocks.ensureDevice.mockResolvedValue("device-1");
+});
+
+describe("this browser's device", () => {
+  it("registers one even though the app already asked whether there was one", async () => {
+    // A browser that has never opened Messages. Both hooks under one cache, in
+    // the order the app mounts them.
+    mocks.registeredDevice.mockResolvedValue(undefined);
+    const Wrapper = wrapper();
+
+    const { result } = renderHook(
+      () => {
+        useCollectMessagesWhereRegistered();
+        return useDmDevice();
+      },
+      { wrapper: Wrapper }
+    );
+
+    await waitFor(() => expect(result.current.data).toBe("device-1"));
+    expect(mocks.ensureDevice).toHaveBeenCalled();
+  });
+
+  it("starts collecting as soon as one is registered", async () => {
+    mocks.registeredDevice.mockResolvedValue(undefined);
+    const Wrapper = wrapper();
+
+    renderHook(
+      () => {
+        useCollectMessagesWhereRegistered();
+        useDmDevice();
+      },
+      { wrapper: Wrapper }
+    );
+
+    await waitFor(() => expect(mocks.collect).toHaveBeenCalled());
+  });
+
+  it("collects on a browser that was already set up, without registering", async () => {
+    mocks.registeredDevice.mockResolvedValue("device-1");
+    const Wrapper = wrapper();
+
+    renderHook(() => useCollectMessagesWhereRegistered(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(mocks.collect).toHaveBeenCalled());
+    expect(mocks.ensureDevice).not.toHaveBeenCalled();
+  });
+
+  it("collects nothing on a browser that has never been set up", async () => {
+    mocks.registeredDevice.mockResolvedValue(undefined);
+    const Wrapper = wrapper();
+
+    renderHook(() => useCollectMessagesWhereRegistered(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(mocks.registeredDevice).toHaveBeenCalled());
+    expect(mocks.collect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useMyMessages.ts
+++ b/frontend/src/hooks/useMyMessages.ts
@@ -13,13 +13,22 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
 
 import {
   createConversationApiV1MeDmConversationsPost as createConversation,
   listConversationsApiV1MeDmConversationsGet as listConversations,
 } from "@/api/generated/direct-messages/direct-messages";
 import type { StoredMessage } from "@/crypto/messaging";
-import { collect, ensureDevice, messageLog, sendText } from "@/crypto/messaging";
+import {
+  collect,
+  ensureDevice,
+  markRead,
+  messageLog,
+  registeredDevice,
+  sendText,
+  unreadIn,
+} from "@/crypto/messaging";
 
 export const messageKeys = {
   conversations: ["dm", "conversations"] as const,
@@ -29,6 +38,9 @@ export const messageKeys = {
   device: ["dm-device"] as const,
   inbox: ["dm", "inbox"] as const,
   thread: (conversationId: string) => ["dm", "thread", conversationId] as const,
+  // Keyed on the conversations it counts, so a new one is a new question
+  // rather than a stale answer waiting for something to invalidate it.
+  unread: (conversationIds: string[]) => ["dm", "unread", conversationIds.join(",")] as const,
 };
 
 /** Register this browser's device, once, before anything else can work. */
@@ -116,6 +128,7 @@ export function useCollectMessages(enabled: boolean) {
       }
       if (touched.length > 0) {
         void queryClient.invalidateQueries({ queryKey: messageKeys.conversations });
+        void queryClient.invalidateQueries({ queryKey: ["dm", "unread"] });
       }
       return touched;
     },
@@ -126,4 +139,55 @@ export function useCollectMessages(enabled: boolean) {
     staleTime: 0,
     gcTime: 0,
   });
+}
+
+/**
+ * Collect anywhere in the app, but only for a browser already set up.
+ *
+ * What makes a mark on My Messages mean anything is that the mail is fetched
+ * while you are somewhere else — otherwise nothing new is ever noticed until
+ * you go and look, which is the one thing the mark is there to save you. It
+ * deliberately does *not* register a device: setting one up is what visiting
+ * the page does, and a browser that never has stays as it was.
+ */
+export function useCollectMessagesWhereRegistered() {
+  const registered = useQuery({
+    queryKey: messageKeys.device,
+    queryFn: () => registeredDevice().then((id) => id ?? null),
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: false,
+  });
+  return useCollectMessages(Boolean(registered.data));
+}
+
+/**
+ * How many messages are waiting in each conversation, on this device.
+ *
+ * Read from the local log, because that is where a thread is — the server
+ * deletes a message once it has been collected and could not answer this even
+ * if it were asked.
+ */
+export function useUnreadMessages(conversationIds: string[]) {
+  return useQuery({
+    queryKey: messageKeys.unread(conversationIds),
+    queryFn: async () => {
+      const counts = new Map<string, number>();
+      for (const id of conversationIds) {
+        counts.set(id, await unreadIn(id));
+      }
+      return counts;
+    },
+    enabled: conversationIds.length > 0,
+    staleTime: 0,
+  });
+}
+
+/** Mark a thread as looked at, whenever what is in it changes. */
+export function useMarkThreadRead(conversationId: string, messageCount: number) {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    void markRead(conversationId).then(() =>
+      queryClient.invalidateQueries({ queryKey: ["dm", "unread"] })
+    );
+  }, [conversationId, messageCount, queryClient]);
 }

--- a/frontend/src/hooks/useMyMessages.ts
+++ b/frontend/src/hooks/useMyMessages.ts
@@ -12,7 +12,7 @@
  *   nothing; it says there is something to fetch.
  */
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { skipToken, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 import {
@@ -36,6 +36,10 @@ export const messageKeys = {
   // registering is a once-per-browser answer, and re-asking it on every frame
   // would cost a round trip to be told the same device id again.
   device: ["dm-device"] as const,
+  // A separate key from `device`, because it is a different question with a
+  // different answer: *is* there one, versus make sure there is. Sharing one
+  // would let whichever asked first decide what the other one got back.
+  registered: ["dm-device-registered"] as const,
   inbox: ["dm", "inbox"] as const,
   thread: (conversationId: string) => ["dm", "thread", conversationId] as const,
   // Keyed on the conversations it counts, so a new one is a new question
@@ -152,12 +156,16 @@ export function useCollectMessages(enabled: boolean) {
  */
 export function useCollectMessagesWhereRegistered() {
   const registered = useQuery({
-    queryKey: messageKeys.device,
+    queryKey: messageKeys.registered,
     queryFn: () => registeredDevice().then((id) => id ?? null),
     staleTime: Number.POSITIVE_INFINITY,
     retry: false,
   });
-  return useCollectMessages(Boolean(registered.data));
+  // Watching the answer to the *other* question rather than fetching anything:
+  // this browser may be set up while the app is running, by the one page that
+  // does it, and collection should start then rather than on the next load.
+  const device = useQuery({ queryKey: messageKeys.device, queryFn: skipToken });
+  return useCollectMessages(Boolean(registered.data ?? device.data));
 }
 
 /**

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -110,6 +110,7 @@ export const UserProfilePage = () => {
                   username: profile.username,
                   discriminator: profile.discriminator,
                 }}
+                showProfile={false}
                 className="mb-1"
               />
             )}

--- a/frontend/src/pages/user/MyContactsPage.tsx
+++ b/frontend/src/pages/user/MyContactsPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { Link2, MessageSquare, SearchX, Users } from "lucide-react";
+import { Globe, Link2, SearchX, Users } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -33,7 +33,7 @@ import { cn } from "@/lib/utils";
 
 const COLLAPSE_SCOPE = "my-contacts-sections";
 const CONNECTIONS_VALUE = "connections";
-const OPEN_CHANNELS_VALUE = "open-channels";
+const ANYONE_VALUE = "anyone";
 
 /** Which sections the reader has closed. Everything else is open. */
 type CollapseState = { closed: string[] };
@@ -102,11 +102,11 @@ export const MyContactsPage = () => {
     [connectionsQuery.data, matches]
   );
 
-  // Accepting a connection opens the channel with it, so every connection also
-  // holds a message grant. Listing those again here would make this section a
-  // near-copy of the one above it; what is left is the people this section
-  // exists for — the ones an agreement to message is the *only* thing the
-  // reader shares with, who appear nowhere else on the page.
+  // Being open to anyone is the one bucket that cannot be listed — it would be
+  // everybody on the deployment — so this holds the only part of it that means
+  // anything: the people already being messaged. Connections are dropped
+  // because accepting one opens a channel too, and they have a section of their
+  // own; without that this would be a near-copy of it.
   const openChannels = useMemo(() => {
     const connected = new Set((connectionsQuery.data?.accepted ?? []).map((g) => g.user_id));
     return (messagesQuery.data?.accepted ?? []).filter(
@@ -141,8 +141,8 @@ export const MyContactsPage = () => {
     () => [
       FAVORITES_VALUE,
       CONNECTIONS_VALUE,
-      OPEN_CHANNELS_VALUE,
       ...sections.map((s) => `guild-${s.guild_id}`),
+      ANYONE_VALUE,
     ],
     [sections]
   );
@@ -284,24 +284,6 @@ export const MyContactsPage = () => {
                 emptyLabel={t("noMatches.section")}
               />
             ) : null}
-            {openChannels.length > 0 ? (
-              <GrantContactSection
-                key={`open-channels:${search}`}
-                value={OPEN_CHANNELS_VALUE}
-                label={t("directMessages")}
-                title={
-                  <>
-                    <MessageSquare className="size-4 text-muted-foreground" />
-                    <span>{t("directMessages")}</span>
-                  </>
-                }
-                items={openChannels}
-                starredIds={starredIds}
-                onToggleFavorite={toggleFavorite}
-                guilds={guilds}
-                emptyLabel={t("noMatches.section")}
-              />
-            ) : null}
             {sections.map((section) => (
               <GuildContactSection
                 key={`${section.guild_id}:${search}`}
@@ -312,6 +294,27 @@ export const MyContactsPage = () => {
                 guilds={guilds}
               />
             ))}
+            {/* Last, under every community: the communities are the places the
+                reader is in, and this is what is left over — people no place in
+                common accounts for. */}
+            {openChannels.length > 0 ? (
+              <GrantContactSection
+                key={`anyone:${search}`}
+                value={ANYONE_VALUE}
+                label={t("anyone")}
+                title={
+                  <>
+                    <Globe className="size-4 text-muted-foreground" />
+                    <span>{t("anyone")}</span>
+                  </>
+                }
+                items={openChannels}
+                starredIds={starredIds}
+                onToggleFavorite={toggleFavorite}
+                guilds={guilds}
+                emptyLabel={t("noMatches.section")}
+              />
+            ) : null}
           </Accordion>
           {/* Under the communities, which are the sections a policy empties.
               Favorites above it are the reader's own list and stay. */}

--- a/frontend/src/pages/user/MyMessagesPage.tsx
+++ b/frontend/src/pages/user/MyMessagesPage.tsx
@@ -1,10 +1,13 @@
-import { MessageSquare, Send, ShieldCheck } from "lucide-react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { MessageSquare, Send, ShieldCheck, UserX } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { StartWithPerson } from "@/components/messages/StartWithPerson";
 import { StatusMessage } from "@/components/StatusMessage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { ProfileAvatar } from "@/components/user/ProfileAvatar";
 import { ratchetSupported } from "@/crypto/client";
 import { RecipientHasNoDeviceError } from "@/crypto/messaging";
 import { useMessageRequests } from "@/hooks/useDirectMessages";
@@ -12,10 +15,14 @@ import {
   useCollectMessages,
   useConversations,
   useDmDevice,
+  useMarkThreadRead,
   useSendMessage,
   useStartConversation,
   useThread,
+  useUnreadMessages,
 } from "@/hooks/useMyMessages";
+import { useUserProfile } from "@/hooks/useUsers";
+import { getUrlHandle, getUserHandle } from "@/lib/userDisplay";
 import { cn } from "@/lib/utils";
 
 /**
@@ -28,6 +35,12 @@ import { cn } from "@/lib/utils";
  *   is what this device decrypted and wrote down.
  * * **A device that has never been here has no history.** That is what forward
  *   secrecy costs, and the page says so rather than looking broken.
+ *
+ * It is also the page a contacts row points at, via `?with=<handle>`. Most of
+ * the people it can be opened for have no channel yet — a contact is somebody
+ * you share a community with, not somebody who agreed to hear from you — so the
+ * handle is a request to open a conversation, and what comes back may be the
+ * offer to ask for one instead.
  */
 export function MyMessagesPage() {
   const { t } = useTranslation("messages");
@@ -37,25 +50,97 @@ export function MyMessagesPage() {
   const startConversation = useStartConversation();
   const [selected, setSelected] = useState<string | null>(null);
 
+  // Who the URL asked for, resolved to a person. The profile is what a panel
+  // for somebody with no channel has to draw, and the id is what everything
+  // else here is keyed on.
+  const { with: withHandle } = useSearch({ strict: false }) as { with?: string };
+  const target = useUserProfile(withHandle);
+
   useCollectMessages(device.isSuccess);
 
   /** Everyone with an accepted channel, whether or not it has been opened. */
   const reachable = useMemo(() => requests.data?.accepted ?? [], [requests.data?.accepted]);
-  const nameFor = useMemo(() => {
-    const names = new Map<number, string>();
-    for (const grant of reachable) {
-      names.set(grant.user_id, `${grant.username}#${grant.discriminator}`);
-    }
-    return names;
-  }, [reachable]);
+  // The whole grant rather than a name: a row in this list draws a person, and
+  // a person is their picture and what they wear on it as much as their handle.
+  const personFor = useMemo(
+    () => new Map(reachable.map((grant) => [grant.user_id, grant])),
+    [reachable]
+  );
+
+  /** What to call the other side of a conversation, wherever it is named. */
+  const nameOf = (userId: number) => {
+    const person = personFor.get(userId);
+    return person ? getUserHandle(person) : t("unknownAccount");
+  };
 
   const rows = conversations.data?.conversations ?? [];
   const current = rows.find((row) => row.id === selected) ?? null;
+
+  // What has arrived since this device last opened each thread. Local, because
+  // the thread is: the server deletes a message once it has been collected.
+  const unread = useUnreadMessages(rows.map((row) => row.id));
 
   // Somebody you may message but have not opened a channel with yet.
   const unopened = reachable.filter(
     (grant) => !rows.some((row) => row.other_user_id === grant.user_id)
   );
+
+  const targetId = target.data?.id;
+  const targetConversation = rows.find((row) => row.other_user_id === targetId);
+  const channelOpen = targetId !== undefined && personFor.has(targetId);
+
+  // Acting on the handle in the URL, once per handle: select their thread, or
+  // open one where the channel is already there. A conversation is one per
+  // pair server-side, so asking for one that exists returns it rather than a
+  // second — which is what makes this safe to fire from an effect.
+  //
+  // Not before the list has arrived, though: until then every conversation
+  // looks missing, and opening one that is already there is a round trip to be
+  // told what was on its way.
+  const opened = useRef<string | null>(null);
+  const startMessages = startConversation.mutate;
+  const conversationsLoaded = conversations.isSuccess;
+  useEffect(() => {
+    if (!withHandle || targetId === undefined || !conversationsLoaded) return;
+    if (opened.current === withHandle) return;
+    if (targetConversation) {
+      opened.current = withHandle;
+      setSelected(targetConversation.id);
+      return;
+    }
+    if (channelOpen) {
+      opened.current = withHandle;
+      startMessages(targetId, {
+        onSuccess: (conversation) => setSelected(conversation.id),
+        // Left unclaimed so a retry — a click on the same row — tries again.
+        onError: () => {
+          opened.current = null;
+        },
+      });
+    }
+  }, [withHandle, targetId, targetConversation, channelOpen, conversationsLoaded, startMessages]);
+
+  const navigate = useNavigate();
+
+  /**
+   * Open a thread, and address it in the URL.
+   *
+   * Everything the sidebar lists is somebody whose handle is known, so picking
+   * one is the same gesture as arriving from a contacts row and the address
+   * bar says the same thing either way. A conversation whose grant is gone has
+   * no handle left to write, and clears it instead.
+   */
+  const open = (
+    conversationId: string | null,
+    person?: { username: string; discriminator: number }
+  ) => {
+    setSelected(conversationId);
+    void navigate({
+      to: ".",
+      search: person ? { with: getUrlHandle(person) } : {},
+      replace: true,
+    });
+  };
 
   // A runtime with no web workers cannot hold a ratchet at all, and saying so
   // is more use than the generic failure it would otherwise reach.
@@ -99,34 +184,59 @@ export function MyMessagesPage() {
             <p className="p-4 text-muted-foreground text-sm">{t("nobodyYet")}</p>
           ) : (
             <ul>
-              {rows.map((row) => (
-                <li key={row.id}>
-                  <button
-                    type="button"
-                    onClick={() => setSelected(row.id)}
-                    className={cn(
-                      "w-full px-4 py-3 text-left text-sm hover:bg-accent",
-                      row.id === selected && "bg-accent"
-                    )}
-                  >
-                    {nameFor.get(row.other_user_id) ?? t("unknownAccount")}
-                  </button>
-                </li>
-              ))}
+              {rows.map((row) => {
+                const person = personFor.get(row.other_user_id);
+                return (
+                  <li key={row.id}>
+                    <button
+                      type="button"
+                      onClick={() => open(row.id, person)}
+                      className={cn(
+                        "flex w-full items-center gap-3 px-4 py-3 text-left text-sm hover:bg-accent",
+                        row.id === selected && "bg-accent"
+                      )}
+                    >
+                      {person ? (
+                        <ProfileAvatar
+                          user={person}
+                          decorations={person.profile_decorations}
+                          presence={person.presence}
+                          className="size-8"
+                        />
+                      ) : null}
+                      <span className="min-w-0 flex-1 truncate">{nameOf(row.other_user_id)}</span>
+                      {/* The same mark the sidebar puts on My Messages, saying
+                          which thread put it there. */}
+                      {unread.data?.get(row.id) ? (
+                        <span className="flex shrink-0 items-center">
+                          <span className="sr-only">
+                            {t("unreadHere", { count: unread.data.get(row.id) })}
+                          </span>
+                          <span aria-hidden="true" className="size-2 rounded-full bg-destructive" />
+                        </span>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
               {unopened.map((grant) => (
                 <li key={grant.user_id}>
                   <button
                     type="button"
                     disabled={startConversation.isPending}
-                    onClick={() =>
-                      startConversation.mutate(grant.user_id, {
-                        onSuccess: (conversation) => setSelected(conversation.id),
-                      })
-                    }
-                    className="w-full px-4 py-3 text-left text-muted-foreground text-sm hover:bg-accent"
+                    onClick={() => open(null, grant)}
+                    className="flex w-full items-center gap-3 px-4 py-3 text-left text-muted-foreground text-sm hover:bg-accent"
                   >
-                    {grant.username}#{grant.discriminator}
-                    <span className="ml-2 text-xs">{t("startHint")}</span>
+                    <ProfileAvatar
+                      user={grant}
+                      decorations={grant.profile_decorations}
+                      presence={grant.presence}
+                      className="size-8"
+                    />
+                    <span className="min-w-0 truncate">
+                      {getUserHandle(grant)}
+                      <span className="ml-2 text-xs">{t("startHint")}</span>
+                    </span>
                   </button>
                 </li>
               ))}
@@ -141,8 +251,25 @@ export function MyMessagesPage() {
             key={current.id}
             conversationId={current.id}
             otherUserId={current.other_user_id}
-            name={nameFor.get(current.other_user_id) ?? t("unknownAccount")}
+            name={nameOf(current.other_user_id)}
           />
+        ) : withHandle ? (
+          // Somebody was asked for. Either their thread is on its way, or there
+          // is no channel and the panel says what would open one.
+          target.isLoading || !conversationsLoaded || channelOpen ? (
+            <div className="flex flex-1 items-center justify-center p-8">
+              <p className="text-muted-foreground text-sm">{t("loading")}</p>
+            </div>
+          ) : target.data ? (
+            <StartWithPerson person={target.data} />
+          ) : (
+            <div className="flex flex-1 items-center justify-center p-8">
+              <StatusMessage
+                icon={<UserX className="size-6" aria-hidden />}
+                title={t("unknownAccount")}
+              />
+            </div>
+          )
         ) : (
           <div className="flex flex-1 items-center justify-center p-8 text-center">
             <div className="max-w-sm space-y-2">
@@ -173,6 +300,9 @@ function Thread({
   const bottom = useRef<HTMLDivElement | null>(null);
 
   const messages = thread.data ?? [];
+  // An open thread is a read thread — including whatever arrives while it is
+  // open, which is why the count is what re-runs it.
+  useMarkThreadRead(conversationId, messages.length);
   useEffect(() => {
     bottom.current?.scrollIntoView({ block: "end" });
   }, [messages.length]);

--- a/frontend/src/pages/user/MyMessagesPage.tsx
+++ b/frontend/src/pages/user/MyMessagesPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { MessageSquare, Send, ShieldCheck, UserX } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { StartWithPerson } from "@/components/messages/StartWithPerson";
@@ -100,6 +100,24 @@ export function MyMessagesPage() {
   const opened = useRef<string | null>(null);
   const startMessages = startConversation.mutate;
   const conversationsLoaded = conversations.isSuccess;
+
+  // Whose open failed, not merely that one did: a mutation has one error state
+  // and the reader moves on to somebody else, who would otherwise arrive at a
+  // failure that was never theirs.
+  const [failedFor, setFailedFor] = useState<string | null>(null);
+
+  const openWith = useCallback(
+    (userId: number, handle: string) =>
+      startMessages(userId, {
+        onSuccess: (conversation) => {
+          setFailedFor(null);
+          setSelected(conversation.id);
+        },
+        onError: () => setFailedFor(handle),
+      }),
+    [startMessages]
+  );
+
   useEffect(() => {
     if (!withHandle || targetId === undefined || !conversationsLoaded) return;
     if (opened.current === withHandle) return;
@@ -110,22 +128,9 @@ export function MyMessagesPage() {
     }
     if (channelOpen) {
       opened.current = withHandle;
-      startMessages(targetId, { onSuccess: (conversation) => setSelected(conversation.id) });
+      openWith(targetId, withHandle);
     }
-  }, [withHandle, targetId, targetConversation, channelOpen, conversationsLoaded, startMessages]);
-
-  /**
-   * Try again, after one of those failed.
-   *
-   * A button rather than the effect having another go on its own: the address
-   * has not changed, so nothing would re-run it, and a state change that did
-   * would keep re-running it against whatever is refusing.
-   */
-  const retryOpen = () => {
-    if (targetId === undefined) return;
-    startConversation.reset();
-    startMessages(targetId, { onSuccess: (conversation) => setSelected(conversation.id) });
-  };
+  }, [withHandle, targetId, targetConversation, channelOpen, conversationsLoaded, openWith]);
 
   const navigate = useNavigate();
 
@@ -263,11 +268,18 @@ export function MyMessagesPage() {
         ) : withHandle ? (
           // Somebody was asked for. Either their thread is on its way, or there
           // is no channel and the panel says what would open one.
-          startConversation.isError ? (
+          failedFor === withHandle ? (
             <div className="flex flex-1 items-center justify-center p-8 text-center">
               <div className="max-w-sm space-y-3">
                 <p className="text-muted-foreground text-sm">{t("openFailed")}</p>
-                <Button variant="outline" onClick={retryOpen}>
+                {/* A button rather than the effect having another go on its
+                    own: the address has not changed, so nothing would re-run
+                    it, and a state change that did would keep re-running it
+                    against whatever is refusing. */}
+                <Button
+                  variant="outline"
+                  onClick={() => targetId !== undefined && openWith(targetId, withHandle)}
+                >
                   {t("tryAgain")}
                 </Button>
               </div>

--- a/frontend/src/pages/user/MyMessagesPage.tsx
+++ b/frontend/src/pages/user/MyMessagesPage.tsx
@@ -110,15 +110,22 @@ export function MyMessagesPage() {
     }
     if (channelOpen) {
       opened.current = withHandle;
-      startMessages(targetId, {
-        onSuccess: (conversation) => setSelected(conversation.id),
-        // Left unclaimed so a retry — a click on the same row — tries again.
-        onError: () => {
-          opened.current = null;
-        },
-      });
+      startMessages(targetId, { onSuccess: (conversation) => setSelected(conversation.id) });
     }
   }, [withHandle, targetId, targetConversation, channelOpen, conversationsLoaded, startMessages]);
+
+  /**
+   * Try again, after one of those failed.
+   *
+   * A button rather than the effect having another go on its own: the address
+   * has not changed, so nothing would re-run it, and a state change that did
+   * would keep re-running it against whatever is refusing.
+   */
+  const retryOpen = () => {
+    if (targetId === undefined) return;
+    startConversation.reset();
+    startMessages(targetId, { onSuccess: (conversation) => setSelected(conversation.id) });
+  };
 
   const navigate = useNavigate();
 
@@ -256,7 +263,16 @@ export function MyMessagesPage() {
         ) : withHandle ? (
           // Somebody was asked for. Either their thread is on its way, or there
           // is no channel and the panel says what would open one.
-          target.isLoading || !conversationsLoaded || channelOpen ? (
+          startConversation.isError ? (
+            <div className="flex flex-1 items-center justify-center p-8 text-center">
+              <div className="max-w-sm space-y-3">
+                <p className="text-muted-foreground text-sm">{t("openFailed")}</p>
+                <Button variant="outline" onClick={retryOpen}>
+                  {t("tryAgain")}
+                </Button>
+              </div>
+            </div>
+          ) : target.isLoading || !conversationsLoaded || channelOpen ? (
             <div className="flex flex-1 items-center justify-center p-8">
               <p className="text-muted-foreground text-sm">{t("loading")}</p>
             </div>

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -27,6 +27,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useBackButton } from "@/hooks/useBackButton";
 import { useBillingPortal } from "@/hooks/useBillingPortal";
 import { useGuilds } from "@/hooks/useGuilds";
+import { useCollectMessagesWhereRegistered } from "@/hooks/useMyMessages";
 import { useNotificationStream } from "@/hooks/useNotificationStream";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { useRealtimeUpdates } from "@/hooks/useRealtimeUpdates";
@@ -91,6 +92,10 @@ function AppLayout() {
   useNotificationStream();
   usePushNotifications();
   useBackButton();
+  // Mail is fetched wherever you are, so a message that arrives while you are
+  // on another page is noticed rather than waiting to be discovered. Only for a
+  // browser that has already been set up for messages — this never sets one up.
+  useCollectMessagesWhereRegistered();
 
   // No cross-tab guild convergence: each tab keeps the guild from its own URL,
   // so two tabs can sit in two different guilds at once.

--- a/frontend/src/routes/_serverRequired/_authenticated/messages.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/messages.tsx
@@ -1,6 +1,20 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
+/**
+ * Who the page should open a conversation with, as a URL handle —
+ * `/messages?with=jordan1234`. It is what a contacts row links to, so somebody
+ * you have never messaged is reachable in one click and the page decides what
+ * that means: an open channel, or an offer to ask for one.
+ */
+interface MessagesSearch {
+  with?: string;
+}
+
 export const Route = createFileRoute("/_serverRequired/_authenticated/messages")({
+  validateSearch: (search: Record<string, unknown>): MessagesSearch => {
+    const handle = typeof search.with === "string" ? search.with.trim() : "";
+    return handle ? { with: handle } : {};
+  },
   // No loader: a thread is read out of this device's own store, which the page
   // itself unlocks. There is nothing for the router to prefetch.
   component: lazyRouteComponent(() =>


### PR DESCRIPTION
## Problem

My Contacts listed people but did not lead anywhere: a row went to a profile, pictures were drawn bare while every other surface wears its decorations, and there was no mark anywhere saying a message was waiting. Landing on My Messages for somebody you have never messaged had nothing to offer, and the page mixed connections — a separate agreement, controlled on My Contacts — into a page about conversations.

## Changes

**A row goes to the conversation**

- [ContactRow.tsx](frontend/src/components/contacts/ContactRow.tsx) links at `/messages?with=<handle>`; the profile moves into the row's menu ([ContactActionsMenu.tsx](frontend/src/components/contacts/ContactActionsMenu.tsx), which already held *remove connection*). The profile page passes `showProfile={false}`, being the one place the link goes nowhere.
- [messages.tsx](frontend/src/routes/_serverRequired/_authenticated/messages.tsx) validates a `with` search param. [MyMessagesPage.tsx](frontend/src/pages/user/MyMessagesPage.tsx) resolves it to a profile, selects that thread or opens one where the channel already exists, and addresses the open thread in the URL as you switch between them.
- [StartWithPerson.tsx](frontend/src/components/messages/StartWithPerson.tsx) is what somebody with no channel lands on: *Ask to message* when the server says you may, *Accept* when they asked you, and a plain line otherwise. Messages only — a connection is made and unmade on My Contacts, and does not appear here.

**Pictures wear their frames**

- `ContactRead` and `ContactGrantRead` carry `profile_decorations` ([contact.py](backend/app/schemas/platform/contact.py), [dm.py](backend/app/schemas/platform/dm.py)), fed by both paths that build them — the guild projection in [contacts.py](backend/app/services/platform/contacts.py) and `public.user_profiles` in [contact_grants.py](backend/app/services/platform/contact_grants.py). Regenerated Orval output committed.

**A mark when something is waiting**

- A red dot beside My Messages ([HomeSidebarContent.tsx](frontend/src/components/sidebar/HomeSidebarContent.tsx)) for unread messages or a pending message request, and one per conversation row in the messages sidebar.
- Unread is per device, because a thread is: a per-conversation last-read marker in the ratchet store ([store.ts](frontend/src/crypto/store.ts)), with `unreadIn`/`markRead` in [messaging.ts](frontend/src/crypto/messaging.ts). The server deletes a message once it has been collected, so nothing else could answer this.
- Mail is now collected wherever you are in the app ([_authenticated.tsx](frontend/src/routes/_serverRequired/_authenticated.tsx)), **only** in a browser that already has a device — this never registers one, so an account that has never opened Messages generates no key material.

**Anyone is its own group**

- [MyContactsPage.tsx](frontend/src/pages/user/MyContactsPage.tsx) moves the open-channels group below every community section and titles it *Anyone*, matching the privacy setting's own word. It cannot list everybody, so it holds the people you are already messaging.

New keys added to all four locales (`en`/`de`/`es`/`fr`).

## Testing

- `cd backend && pytest -n 0 app/api/v1/platform_endpoints/contacts_test.py app/api/v1/platform_endpoints/dm_test.py app/services/platform/contact_grants_test.py` — 57 passed (two new cases assert decorations survive on the roster path and the grant path).
- `cd backend && ruff check app && ruff format app && ty check` — clean.
- `cd frontend && npx vitest run` — 230 files, 2559 tests passed. Four new cases in `myMessagesRoute.test.tsx` cover opening the address, the ask panel, and the refusal offering nothing.
- `cd frontend && npx tsc --noEmit && npx biome check ./src` — clean (one pre-existing warning in `useNotificationStream.ts`, untouched).