### PR TITLE
Add a community members page

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: create-pr
-description: Open a pull request for the current changes, then watch it to green — poll CI until every check completes, surface and fix failures, and drive the Greptile review loop until confidence is high. Use when the user says "make a PR", "open a pull request", "ship this", or asks to watch a PR's CI / review status.
+description: Open a pull request for the current changes, then watch it to green — poll CI and the Greptile review together, addressing review findings as soon as they post instead of waiting for the full rollup, fixing failures and re-reviewing until confidence is high. Use when the user says "make a PR", "open a pull request", "ship this", or asks to watch a PR's CI / review status.
 user-invocable: true
 ---
 
 # /create-pr — Open a PR and babysit it to green
 
-Create a pull request for the working changes, then stay with it: watch CI to
-completion, fix what breaks, and run the Greptile review loop until the review
-is clean. Do not consider the skill done until every check is green (or the
-user tells you to stop).
+Create a pull request for the working changes, then stay with it: watch CI and
+the Greptile review *at the same time*, fix whatever lands first, and keep
+looping until every check is green and the review is clean (or the user tells
+you to stop). Greptile's feedback almost always arrives before CI finishes —
+address it then, rather than sitting on it until the rollup completes.
 
 Repo rules that this skill must honor (from `CLAUDE.md`):
 - **PRs target `dev`, never `main`.**
@@ -31,7 +32,9 @@ Repo rules that this skill must honor (from `CLAUDE.md`):
    - Backend: `cd backend && ruff check app` and
      `./scripts/test-changed.sh`.
    Fix anything that fails before opening the PR — a red gate locally will be
-   red in CI.
+   red in CI, and a CI round-trip on this repo costs up to ~26 minutes. Never
+   push a speculative fix hoping CI will validate it; reproduce it locally
+   first.
 3. If the change is user-facing, add a concise `CHANGELOG.md` entry under
    `## [Unreleased]` in the right subsection (Added / Changed / Fixed /
    Security).
@@ -69,31 +72,100 @@ EOF
 
 Capture the PR number from the returned URL.
 
-## 4. Watch CI to completion
+## 4. Watch CI *and* Greptile together
 
-Poll until every check finishes. Prefer a bounded `until` loop over repeated
-manual checks:
+Greptile usually posts its first review while CI is still running, and CI
+failures usually surface one job at a time. **Do not wait for the whole rollup
+to finish before reading review feedback** — watch both signals in one loop and
+act on whichever lands first.
+
+Snapshot what you have already seen, then wait for the *next* event:
 
 ```bash
-# Wait for all checks to reach a terminal state (timeout generously).
-until [ -z "$(gh pr view <n> --json statusCheckRollup \
-  -q '.statusCheckRollup[] | select(.status!="COMPLETED") | .name')" ]; do
-  sleep 15
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+PR=$(gh pr view --json number -q .number)
+
+# Baseline: the newest Greptile review id we've already read (0 if none yet).
+seen_review() {
+  gh api "repos/$REPO/pulls/$PR/reviews" \
+    --jq '[.[] | select(.user.login|test("greptile";"i")) | .id] | max // 0'
+}
+SEEN=$(seen_review)
+START=$(date +%s)
+
+# Wait for: a new Greptile review, a failed check, or everything green.
+while :; do
+  FAILED=$(gh pr view "$PR" --json statusCheckRollup \
+    -q '[.statusCheckRollup[] | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT") | .name] | join(", ")')
+  PENDING=$(gh pr view "$PR" --json statusCheckRollup \
+    -q '[.statusCheckRollup[] | select(.status!="COMPLETED")] | length')
+  NOW=$(seen_review)
+  if [ "$NOW" != "$SEEN" ]; then echo "EVENT=greptile review=$NOW"; break; fi
+  if [ -n "$FAILED" ];       then echo "EVENT=ci-failure jobs=$FAILED"; break; fi
+  if [ "$PENDING" -eq 0 ];   then echo "EVENT=ci-green"; break; fi
+  echo "waiting: $PENDING check(s) pending, $(( $(date +%s) - START ))s elapsed"
+  sleep 30
 done
 ```
 
-Then read the rollup:
+**Run this in the background** (`run_in_background: true`). A full backend run
+takes **up to ~26 minutes**, and the Bash tool caps a foreground call at
+600000ms (10 min) — a blocking wait cannot cover one cycle, and blocking the
+session for 26 minutes would be wrong even if it could. Background it, do the
+Greptile work while it runs, and read its output when it breaks.
+
+Each time it breaks, handle the event (§5 or §6) and then **re-enter this loop**
+with `SEEN` updated to the review you just read. The loop is only finished when
+`EVENT=ci-green` *and* the Greptile bar in §5 is met.
+
+**Batching pushes.** A push cancels the in-flight run and restarts it from
+zero, so never push once per finding — collect a whole Greptile round (plus any
+CI failure already visible) into one commit and push once.
+
+Given the timings, the usual call is easy: Greptile posts within a minute or
+two, when the backend job has barely started, so **push the batch as soon as
+it's ready** — you're discarding two minutes of a run that was testing the
+pre-fix commit anyway, and the fixed code's results arrive ~26 minutes from the
+push either way. Waiting for the current run to finish first just adds its
+remaining time to that.
+
+Hold the push only when the run is nearly done and its result would change what
+you commit — you're minutes from learning about failures you'd want to fold
+into the same batch.
+
+## 5. Handle a Greptile round
+
+Read the review body and the inline findings:
 
 ```bash
-gh pr view <n> --json mergeStateStatus,reviewDecision,statusCheckRollup \
-  -q '.statusCheckRollup[] | "\(.name): \(.status)/\(.conclusion)"'
+gh api "repos/$REPO/pulls/$PR/reviews" \
+  --jq '.[] | select(.user.login|test("greptile";"i")) | {id, submitted_at, body}'
+gh api "repos/$REPO/pulls/$PR/comments" --jq '.[] | {path, line, body}'
 ```
 
+For each finding, judge whether it's a real issue in scope for this PR.
+- **In scope + valid** → fix it (edit, commit with the rest of the batch, push).
+- **Out of scope / false positive** → reply briefly saying why; don't fix.
+
+After pushing a round of fixes, ask for a re-review:
+
+```bash
+gh pr comment "$PR" --body "@greptile"
+```
+
+Then go back to §4's loop (with `SEEN` set to the review you just handled) —
+the re-review and any still-running CI are waited on together, not in sequence.
+
+**Aim for 5/5 confidence.** Accept 4/5 only if the remaining findings are
+genuinely out of scope for this PR.
+
+## 6. Handle a CI failure
+
 The CI workflow's jobs on this repo include **Backend Lint & Tests**,
-**Frontend Lint & Tests**, and **Check Generated Types**. If any concludes
+**Frontend Lint & Tests**, and **Check Generated Types**. When a job concludes
 `FAILURE`:
 
-1. Pull the failing job's log:
+1. Pull its log:
    `gh run view --job <jobId> --log-failed | tail -80`
    (get `<jobId>` from the `detailsUrl` in the rollup, or
    `gh run view <runId> --json jobs`).
@@ -102,37 +174,19 @@ The CI workflow's jobs on this repo include **Backend Lint & Tests**,
      mirrored in `de`/`es`/`fr`. Add new keys to all four locale files.
    - **Generated types**: if backend schemas changed, regenerate per
      `CLAUDE.md` (Orval) and commit the output.
-3. Commit the fix, `git push`, and **re-watch from the top of this step**.
+3. Other jobs may still be running — fix the one you have while they finish. If
+   a second job fails while you're working, fold that fix into the same commit.
+4. Commit, push, and re-enter §4's loop.
 
-Repeat until all checks are green.
+**Frontend Lint & Tests** and **Check Generated Types** report in a few
+minutes; **Backend Lint & Tests** is the long pole. Its scope is computed from
+the diff — a change under `backend/alembic/` or to `.github/workflows/ci.yml`
+forces the full `app/ alembic/` suite (the ~26-minute case), while an ordinary
+backend change runs a scoped subset. If you touch either of those paths, expect
+the long run and plan the batch around it. A PR with no `backend/` changes
+skips the job entirely.
 
-## 5. Drive the Greptile review loop
-
-Greptile posts an automated review with a **confidence score** and inline
-findings. Read them:
-
-```bash
-gh pr view <n> --json reviews -q '.reviews[] | select(.author.login|test("greptile";"i")) | .body'
-# inline findings:
-gh api repos/{owner}/{repo}/pulls/<n>/comments --jq '.[] | {path,line,body}'
-```
-
-For each finding: judge whether it's a real issue in scope for this PR.
-- **In scope + valid** → fix it (edit, commit, push).
-- **Out of scope / false positive** → note why in a brief reply; don't fix.
-
-After addressing a round of feedback, trigger a re-review by posting a bare
-mention as a PR comment:
-
-```bash
-gh pr comment <n> --body "@greptile"
-```
-
-Wait for the new Greptile review, then re-read. **Aim for 5/5 confidence.**
-Accept 4/5 only if the remaining findings are genuinely out of scope for this
-PR. Loop (fix → `@greptile` → re-read) until you reach that bar.
-
-## 6. Report
+## 7. Report
 
 Summarize for the user:
 - PR URL and number.
@@ -145,9 +199,16 @@ Summarize for the user:
 
 ## Notes on pacing
 
-- CI on this repo takes a couple of minutes per run; a 15s poll with a
-  generous timeout (e.g. 420000ms) is reasonable.
-- If the user wants to walk away, you can run the wait loop in the background
-  and report when it settles rather than blocking the session.
+- **Budget the real numbers.** Backend Lint & Tests runs up to ~26 minutes on a
+  full-suite PR; the frontend and generated-types jobs land in a few. Greptile
+  typically posts within the first minute or two. The §4 loop exists so those
+  25 minutes aren't dead time.
+- A 30s poll is right for a run of this length; anything tighter just burns API
+  calls. Always background the loop — a foreground Bash call maxes out at 10
+  minutes, less than half a backend cycle.
+- Tell the user the expected wait when you start watching, and don't go silent:
+  report each event as you handle it rather than only at the end.
+- Don't re-run local gates you already ran this session just because you're
+  pushing again; run the ones the new edits actually touch.
 - Never fabricate a check result — only report statuses you actually read from
   `gh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A community lists its members.** The member count on a community's banner now leads somewhere: a page of everyone who is here, searchable and paged, with the same *Message*, *Ask to message* and *Connect* buttons a person gets anywhere else. Somebody who takes no messages is listed like anybody else and simply offers nothing to click — they are here, and they are not reachable, and the page says both.
+
 - **Say who can message you.** A Privacy tab under your profile settings, with one question at the top: who can ask to message you, outside your connections. *Private* means no one, *Anyone* means anybody here may ask, and *My communities* means people you share a community with — with a switch per community under it, all counting by default, so you can be reachable in one and not another. Asking is always a request and it is always yours to accept; nobody arrives in your messages because they found you. Messaging is for people aged 13 and over, and an account that has not answered that question yet is told so rather than left with controls that do nothing.
 
 - **Connections.** A connection is mutual, and it is how two people stay in touch after the thing that introduced them ends — you can keep messaging even once you no longer share a community. You make one by typing somebody's full handle, number included, so a private account is reached by someone who was given it rather than by being picked off a list. Requests wait in one place, either direction, and a connection you accept opens the channel with it: having agreed once, you are not asked again.
@@ -54,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **My Contacts lists the people you could actually reach.** A community section now shows the members who can message you and who you can message, rather than everyone in the room — so the page answers "who can I talk to" instead of "who is here". A community you are alone in is left out entirely. Because the shipped default is Private, a new account's sections start empty, and the page says why and offers the one setting that fills them, rather than reading as a community with nobody in it. It never counts the people it is not listing. Two new sections sit above the communities: your connections, and the people you agreed to message who are in none of your communities — before this they appeared nowhere.
 
 ### Fixed
+
+- **A profile's communities say how many people are in them.** Each card counted nobody, because the profile's own read never asked for the number — a community somebody belongs to has at least one member, so "0 members" was never true.
 
 - **Everyone in a community hears that it was listed.** The notice that a community joined the directory — which is what asks its members their age — only reached people whose tab happened to be held by the same server process that made the change. On a deployment running more than one, everybody else waited until they next navigated.
 

--- a/backend/app/api/v1/platform_endpoints/dm.py
+++ b/backend/app/api/v1/platform_endpoints/dm.py
@@ -159,13 +159,20 @@ async def read_dm_permission(
     """
     await _require_visible_account(session, user_id)
     if user_id == current_user.id:
-        return DirectMessagePermissionRead(permission="denied")
+        return DirectMessagePermissionRead(permission="denied", may_connect=False)
     permission = (
         await session.exec(
             text("SELECT public.dm_apparent_permission(:t)").bindparams(t=user_id)
         )
     ).scalar_one()
-    return DirectMessagePermissionRead(permission=permission)
+    # Asked separately because it is a separate rule. Both read the caller from
+    # the request context rather than taking one.
+    may_connect = (
+        await session.exec(
+            text("SELECT public.dm_may_connect(:t)").bindparams(t=user_id)
+        )
+    ).scalar_one()
+    return DirectMessagePermissionRead(permission=permission, may_connect=may_connect)
 
 
 def _grant_error(exc: contact_grants_service.ContactGrantError) -> HTTPException:

--- a/backend/app/api/v1/platform_endpoints/dm.py
+++ b/backend/app/api/v1/platform_endpoints/dm.py
@@ -23,6 +23,8 @@ from app.schemas.platform.dm import (
     ContactGrantRead,
     ContactGrantsResponse,
     DirectMessagePermissionRead,
+    DirectMessagePermissionsRequest,
+    DirectMessagePermissionsResponse,
     DirectMessageSettingsRead,
     DirectMessageSettingsUpdate,
     IgnoredAccountsResponse,
@@ -58,6 +60,44 @@ async def _require_visible_account(session, user_id: int) -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=DirectMessageMessages.USER_NOT_FOUND,
         )
+
+
+@me_router.post("/dm-permissions", response_model=DirectMessagePermissionsResponse)
+async def read_dm_permissions(
+    payload: DirectMessagePermissionsRequest,
+    session: UserSessionDep,
+    current_user: CurrentUser,
+) -> DirectMessagePermissionsResponse:
+    """The same two answers as the single read, for a page of people at once.
+
+    A surface listing members draws a control per row, and asking per row is a
+    request per row. Both functions read the caller from the request context,
+    so this is the same question asked once for many subjects rather than a
+    different, looser one.
+
+    A POST because the subjects are a list rather than an address: nothing is
+    written, and the body is the only place a page of ids belongs.
+    """
+    ids = [uid for uid in dict.fromkeys(payload.user_ids) if uid != current_user.id]
+    if not ids:
+        return DirectMessagePermissionsResponse(permissions={})
+    rows = (
+        await session.exec(
+            text(
+                "SELECT id, public.dm_apparent_permission(id) AS permission, "
+                "public.dm_may_connect(id) AS may_connect "
+                "FROM unnest(CAST(:ids AS int[])) AS t(id)"
+            ).bindparams(ids=ids)
+        )
+    ).all()
+    return DirectMessagePermissionsResponse(
+        permissions={
+            str(row.id): DirectMessagePermissionRead(
+                permission=row.permission, may_connect=row.may_connect
+            )
+            for row in rows
+        }
+    )
 
 
 @me_router.get("/dm-settings", response_model=DirectMessageSettingsRead)

--- a/backend/app/api/v1/platform_endpoints/dm_test.py
+++ b/backend/app/api/v1/platform_endpoints/dm_test.py
@@ -167,7 +167,7 @@ async def test_permission_is_identical_across_being_ignored(
     url = f"/api/v1/users/{ada.user.id}/dm-permission"
     before = await client.get(url, headers=bram.headers)
     assert before.status_code == 200
-    assert before.json() == {"permission": "may_request"}
+    assert before.json() == {"permission": "may_request", "may_connect": True}
 
     session.add(UserIgnore(user_id=ada.user.id, ignored_user_id=bram.user.id))
     await session.commit()
@@ -186,7 +186,7 @@ async def test_a_private_target_is_denied(client, session, acting_user):
     response = await client.get(
         f"/api/v1/users/{ada.user.id}/dm-permission", headers=bram.headers
     )
-    assert response.json() == {"permission": "denied"}
+    assert response.json() == {"permission": "denied", "may_connect": True}
 
 
 async def test_an_unknown_account_is_not_found(client, acting_user):
@@ -283,7 +283,7 @@ async def test_accepting_a_connection_opens_the_channel(client, session, acting_
     permission = await client.get(
         f"/api/v1/users/{b.user.id}/dm-permission", headers=a.headers
     )
-    assert permission.json() == {"permission": "open"}
+    assert permission.json() == {"permission": "open", "may_connect": True}
 
 
 async def test_a_request_from_an_ignored_account_is_never_surfaced(
@@ -333,7 +333,7 @@ async def test_removing_a_connection_keeps_a_community_channel(
     permission = await client.get(
         f"/api/v1/users/{bram.user.id}/dm-permission", headers=ada.headers
     )
-    assert permission.json() == {"permission": "open"}
+    assert permission.json() == {"permission": "open", "may_connect": True}
 
 
 async def test_ignoring_someone_does_not_stop_you_reaching_them(
@@ -359,3 +359,28 @@ async def test_ignoring_someone_does_not_stop_you_reaching_them(
 
     theirs = await client.get("/api/v1/me/connections", headers=ada.headers)
     assert [r["user_id"] for r in theirs.json()["incoming"]] == [bram.user.id]
+
+
+async def test_may_connect_says_nothing_about_being_ignored(
+    client, session, acting_user
+):
+    """The second answer is held to the first one's rule.
+
+    Connecting and messaging are separate rules, so the endpoint carries both —
+    but neither may tell the caller they have been ignored. ``dm_may_connect``
+    asks whether each account is reachable at all, which is a fact about each
+    of them rather than about the pair.
+    """
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _set_policy(session, ada.user, DmPolicy.community)
+    await _set_policy(session, bram.user, DmPolicy.community)
+
+    url = f"/api/v1/users/{ada.user.id}/dm-permission"
+    before = await client.get(url, headers=bram.headers)
+
+    session.add(UserIgnore(user_id=ada.user.id, ignored_user_id=bram.user.id))
+    await session.commit()
+
+    after = await client.get(url, headers=bram.headers)
+    assert after.json()["may_connect"] == before.json()["may_connect"]

--- a/backend/app/api/v1/platform_endpoints/dm_test.py
+++ b/backend/app/api/v1/platform_endpoints/dm_test.py
@@ -384,3 +384,39 @@ async def test_may_connect_says_nothing_about_being_ignored(
 
     after = await client.get(url, headers=bram.headers)
     assert after.json()["may_connect"] == before.json()["may_connect"]
+
+
+async def test_permissions_in_bulk_answer_as_the_single_read_does(
+    client, session, acting_user
+):
+    """One request for a page of people, and the same two answers per person.
+
+    A surface listing members draws a control per row; asking per row is a
+    request per row. This has to be the same question asked once for many
+    subjects, not a looser one.
+    """
+    ada = await acting_user(guild_role=GuildRole.member)
+    bram = await acting_user(guild_role=GuildRole.member, guild=ada.guild)
+    await _set_policy(session, ada.user, DmPolicy.community)
+    await _set_policy(session, bram.user, DmPolicy.private)
+
+    single = {
+        str(other.user.id): (
+            await client.get(
+                f"/api/v1/users/{other.user.id}/dm-permission", headers=ada.headers
+            )
+        ).json()
+        for other in (bram,)
+    }
+
+    bulk = await client.post(
+        "/api/v1/me/dm-permissions",
+        json={"user_ids": [bram.user.id, ada.user.id]},
+        headers=ada.headers,
+    )
+    assert bulk.status_code == 200, bulk.text
+    answers = bulk.json()["permissions"]
+
+    assert answers[str(bram.user.id)] == single[str(bram.user.id)]
+    # Nothing about yourself: every action on your own account is refused.
+    assert str(ada.user.id) not in answers

--- a/backend/app/api/v1/platform_endpoints/guilds_community_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_community_test.py
@@ -1105,6 +1105,32 @@ async def test_a_profile_names_only_the_listed_communities(
 
 
 @pytest.mark.integration
+async def test_a_profile_card_counts_the_community(
+    client: AsyncClient, session: AsyncSession
+):
+    """A card that says how many people are in a community has to ask.
+
+    Nothing about a guild row carries the number, so a card built without
+    asking says nobody is there — which is never true of a community somebody
+    is a member of.
+    """
+    subject = await create_user(session, username="tinker")
+    reader = await create_user(session)
+    listed = await _list_as_community(session, await create_guild(session))
+    for member in (subject, reader):
+        await create_guild_membership(session, user=member, guild=listed)
+
+    response = await client.get(
+        f"/api/v1/users/{url_handle(subject.username, subject.discriminator)}/communities",
+        headers=get_auth_headers(reader),
+    )
+
+    assert response.status_code == 200
+    # The two above, plus whoever created the guild.
+    assert response.json()[0]["member_count"] >= 2
+
+
+@pytest.mark.integration
 async def test_a_profile_names_no_communities_where_the_directory_is_off(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -283,8 +283,31 @@ async def search_users(
         session, data_stmt, count_stmt, page=page, page_size=page_size
     )
 
+    # One extra read for the page just fetched, bounded by ``page_size``: the
+    # roster join above filters by guild rather than projecting from it, and
+    # widening that projection would change what ``paginated_query`` returns.
+    roles = (
+        dict(
+            (
+                await session.exec(
+                    select(GuildMembership.user_id, GuildMembership.role).where(
+                        GuildMembership.guild_id == guild_context.guild_id,
+                        GuildMembership.user_id.in_([user.id for user in users]),
+                    )
+                )
+            ).all()
+        )
+        if users
+        else {}
+    )
+
     return UserSummaryListResponse(
-        items=[UserSummary.model_validate(user) for user in users],
+        items=[
+            UserSummary.model_validate(user).model_copy(
+                update={"guild_role": roles.get(user.id)}
+            )
+            for user in users
+        ],
         total_count=total_count,
         page=actual_page,
         page_size=page_size,
@@ -532,6 +555,11 @@ async def read_user_communities(
         ).all()
     }
     online = realtime_manager.present_counts(guild.id for guild in guilds)
+    # How many people are in each, which the card names and this read has to
+    # ask for: nothing about a guild row carries it.
+    members = await guilds_service.count_members_by_guild(
+        admin_session, guild_ids=[guild.id for guild in guilds]
+    )
     # Digests only, in one query: a card names its pictures, never carries them.
     images = await images_service.image_urls(
         admin_session,
@@ -550,6 +578,7 @@ async def read_user_communities(
                 **guild.banner,
             ),
             categories=[GuildCategory(value) for value in guild.categories],
+            member_count=members.get(guild.id, 0),
             online_count=online.get(guild.id, 0),
             already_member=guild.id in mine,
         )

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -241,7 +241,10 @@ async def test_search_users_returns_slim_paginated_envelope(
     assert body["has_prev"] is False
     assert len(body["items"]) == 2
     assert [item["username"] for item in body["items"]] == ["aaa-caller", "bbb-other"]
-    # Slim projection: no email, no platform role, no initiative_roles.
+    # Slim projection: no email, no platform tier, no initiative_roles. What
+    # stays is what it takes to draw a person and say where they stand here —
+    # the avatar, what is worn around it, and the guild role — none of which
+    # costs a query beyond the one already run.
     summary = body["items"][0]
     assert set(summary.keys()) == {
         "id",
@@ -250,6 +253,8 @@ async def test_search_users_returns_slim_paginated_envelope(
         "full_name",
         "avatar_url",
         "status",
+        "profile_decorations",
+        "guild_role",
     }
     # This guild takes the default and shows names.
     assert summary["full_name"] == "Aaa"
@@ -2392,3 +2397,21 @@ async def test_a_pack_claiming_another_packs_decoration_is_refused(
     listed = await client.get("/api/v1/users/me/decoration-packs", headers=headers)
     installed = {item["uid"] for item in listed.json()["items"] if item["installed"]}
     assert installed == {first.uid}
+
+
+async def test_search_users_says_where_each_member_stands(client, acting_user):
+    """The roster says who runs the place.
+
+    A page listing people so somebody can reach one of them has to be able to
+    say which of them to reach about the community itself, and the role comes
+    off the join the query already makes.
+    """
+    admin = await acting_user(guild_role=GuildRole.admin)
+    member = await acting_user(guild_role=GuildRole.member, guild=admin.guild)
+
+    response = await client.get(admin.g("/users/search"), headers=admin.headers)
+    assert response.status_code == 200, response.text
+
+    roles = {item["username"]: item["guild_role"] for item in response.json()["items"]}
+    assert roles[admin.user.username] == "admin"
+    assert roles[member.user.username] == "member"

--- a/backend/app/api/v1/tenant_endpoints/initiatives_test.py
+++ b/backend/app/api/v1/tenant_endpoints/initiatives_test.py
@@ -649,6 +649,8 @@ async def test_search_initiative_members_slim_and_filtered(
         "full_name",
         "avatar_url",
         "status",
+        "profile_decorations",
+        "guild_role",
     }
 
     # Filtered by handle, which every guild has for every member.

--- a/backend/app/api/v1/tenant_endpoints/projects_test.py
+++ b/backend/app/api/v1/tenant_endpoints/projects_test.py
@@ -175,6 +175,8 @@ async def test_search_project_members_returns_write_access_set(
         "full_name",
         "avatar_url",
         "status",
+        "profile_decorations",
+        "guild_role",
     }
 
     # The filter matches what the guild renders — the handle always.

--- a/backend/app/schemas/platform/dm.py
+++ b/backend/app/schemas/platform/dm.py
@@ -6,7 +6,7 @@ state the screen can render.
 """
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import ConfigDict, Field
 
@@ -100,6 +100,25 @@ class DirectMessagePermissionRead(SanitizedBaseModel):
     may_connect: bool = False
 
     permission: str
+
+
+class DirectMessagePermissionsRequest(SanitizedBaseModel):
+    """Which accounts a surface is about to draw controls for."""
+
+    user_ids: List[int] = Field(min_length=1, max_length=100)
+
+
+class DirectMessagePermissionsResponse(SanitizedBaseModel):
+    """One answer per account asked about, keyed by id as a string.
+
+    Accounts the caller may not see are simply absent rather than refused: the
+    reader is drawing a list, and a page that fails because one row is gone is
+    worse than one that offers nothing for that row.
+    """
+
+    model_config = ConfigDict(json_schema_serialization_defaults_required=True)
+
+    permissions: Dict[str, DirectMessagePermissionRead]
 
 
 class ContactGrantRead(SanitizedBaseModel):

--- a/backend/app/schemas/platform/dm.py
+++ b/backend/app/schemas/platform/dm.py
@@ -92,6 +92,13 @@ class DirectMessagePermissionRead(SanitizedBaseModel):
 
     model_config = ConfigDict(json_schema_serialization_defaults_required=True)
 
+    #: Whether a connection request would be taken. A separate answer from
+    #: ``permission``, because connecting and messaging are separate rules --
+    #: an account that takes no messages may still take a connection, and the
+    #: other way round. Without it a surface listing people can only guess,
+    #: and offer a button that is refused.
+    may_connect: bool = False
+
     permission: str
 
 

--- a/backend/app/schemas/platform/user.py
+++ b/backend/app/schemas/platform/user.py
@@ -151,10 +151,19 @@ class UserGuildMember(UserPublic):
 class UserSummary(GuildNameVisibility):
     """Slim user projection for typeahead and picker surfaces.
 
-    Drops what pickers never read — platform/guild role, ``initiative_roles``
-    (an N+1 enrichment on the full roster) and timestamps — while keeping the
-    avatar so members still render with a face. The payload is bounded by
-    pagination on the endpoints that serve it, not by dropping the avatar.
+    What it keeps is what it takes to *draw* a person and say where they stand
+    in the guild being read: the handle, the avatar, what they have put around
+    it, and their guild role. A decoration is an id naming a catalog entry and
+    a role is one word, so all of it is short, and none of it costs a query
+    beyond the one already being run.
+
+    What it drops is the account's own business and anything that would cost
+    another round trip: no address, no platform tier, no ``initiative_roles``
+    (an N+1 enrichment on the full roster), no timestamps. The payload is
+    bounded by pagination on the endpoints that serve it.
+
+    ``profile_decorations`` is quoted and the model rebuilt below, because the
+    catalog shape it names is declared further down this file.
     """
 
     model_config = ConfigDict(
@@ -167,6 +176,11 @@ class UserSummary(GuildNameVisibility):
     full_name: Optional[str] = None
     avatar_url: Optional[str] = None
     status: UserStatus = UserStatus.active
+    profile_decorations: Optional["ProfileDecorations"] = None
+    #: ``admin`` or ``member`` in the guild this was read under. Absent where
+    #: the caller asked outside a guild, which is why it is optional rather
+    #: than defaulted to the quieter of the two.
+    guild_role: Optional[str] = None
 
 
 class UserSummaryListResponse(SanitizedBaseModel):
@@ -332,6 +346,10 @@ class ProfileDecorations(SanitizedBaseModel):
             pairs.append((self.frame, FRAME))
         pairs.extend((trophy, TROPHY) for trophy in self.trophies)
         return pairs
+
+
+# ``UserSummary`` names this shape before it is declared.
+UserSummary.model_rebuild()
 
 
 class OwnedDecoration(SanitizedBaseModel):

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -552,6 +552,27 @@ async def list_memberships(
     return out
 
 
+async def count_members_by_guild(
+    session: AsyncSession, *, guild_ids: Sequence[int]
+) -> dict[int, int]:
+    """How many members each of these guilds has, in one query.
+
+    The bulk form of :func:`count_members`, for a surface drawing several
+    cards at once. Same session requirement, and a guild with no row in the
+    answer simply has nobody in it.
+    """
+    if not guild_ids:
+        return {}
+    rows = (
+        await session.exec(
+            select(GuildMembership.guild_id, func.count())
+            .where(GuildMembership.guild_id.in_(list(guild_ids)))
+            .group_by(GuildMembership.guild_id)
+        )
+    ).all()
+    return {guild_id: total for guild_id, total in rows}
+
+
 async def count_members(session: AsyncSession, *, guild_id: int) -> int:
     """Total number of members in a guild.
 

--- a/frontend/public/locales/de/guilds.json
+++ b/frontend/public/locales/de/guilds.json
@@ -422,5 +422,15 @@
     "description": "Ob diese Community die echten Namen der Leute zeigt oder die von ihnen gewählten Benutzernamen.",
     "toggleLabel": "Vollständige Namen zeigen",
     "toggleHint": "Aus erscheinen Mitglieder mit ihrem Benutzernamen. An wird ihr vollständiger Name gezeigt, sofern hinterlegt."
+  },
+  "members": {
+    "title": "Mitglieder",
+    "person": "Mitglied",
+    "name": "Name",
+    "admin": "Admin",
+    "alsoIn": "Auch in",
+    "actions": "Aktionen",
+    "failed": "Die Mitglieder dieser Community konnten nicht geladen werden.",
+    "searchPlaceholder": "Mitglieder filtern"
   }
 }

--- a/frontend/public/locales/en/guilds.json
+++ b/frontend/public/locales/en/guilds.json
@@ -422,5 +422,15 @@
     "description": "Whether this community shows people's real names, or the usernames they chose.",
     "toggleLabel": "Show full names",
     "toggleHint": "Off, members appear by username. On, their full name is shown where they have entered one."
+  },
+  "members": {
+    "title": "Members",
+    "person": "Member",
+    "name": "Name",
+    "admin": "Admin",
+    "alsoIn": "Also in",
+    "actions": "Actions",
+    "failed": "This community's members could not be loaded.",
+    "searchPlaceholder": "Filter members"
   }
 }

--- a/frontend/public/locales/es/guilds.json
+++ b/frontend/public/locales/es/guilds.json
@@ -422,5 +422,15 @@
     "description": "Si esta comunidad muestra los nombres reales de las personas o los nombres de usuario que eligieron.",
     "toggleLabel": "Mostrar nombres completos",
     "toggleHint": "Desactivado, los miembros aparecen por su nombre de usuario. Activado, se muestra su nombre completo si lo han indicado."
+  },
+  "members": {
+    "title": "Miembros",
+    "person": "Miembro",
+    "name": "Nombre",
+    "admin": "Administrador",
+    "alsoIn": "También en",
+    "actions": "Acciones",
+    "failed": "No se pudieron cargar los miembros de esta comunidad.",
+    "searchPlaceholder": "Filtrar miembros"
   }
 }

--- a/frontend/public/locales/fr/guilds.json
+++ b/frontend/public/locales/fr/guilds.json
@@ -422,5 +422,15 @@
     "description": "Si cette communauté affiche les vrais noms des personnes ou les noms d'utilisateur qu'elles ont choisis.",
     "toggleLabel": "Afficher les noms complets",
     "toggleHint": "Désactivé, les membres apparaissent sous leur nom d'utilisateur. Activé, leur nom complet s'affiche s'ils en ont renseigné un."
+  },
+  "members": {
+    "title": "Membres",
+    "person": "Membre",
+    "name": "Nom",
+    "admin": "Admin",
+    "alsoIn": "Aussi dans",
+    "actions": "Actions",
+    "failed": "Les membres de cette communauté n'ont pas pu être chargés.",
+    "searchPlaceholder": "Filtrer les membres"
   }
 }

--- a/frontend/src/__tests__/userProfileRoute.test.tsx
+++ b/frontend/src/__tests__/userProfileRoute.test.tsx
@@ -88,7 +88,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   answerWith(buildUserProfile());
   mocks.communities.mockReturnValue({ data: [] });
-  mocks.dmPermission.mockReturnValue({ data: { permission: "denied" } });
+  mocks.dmPermission.mockReturnValue({ data: { permission: "denied", may_connect: true } });
   mocks.connections.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
   mocks.messageRequests.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
 });
@@ -162,7 +162,7 @@ describe("a member's profile", () => {
     // came to do is a button on it rather than an item behind a menu.
     const them = buildUserProfile();
     answerWith(them);
-    mocks.dmPermission.mockReturnValue({ data: { permission: "open" } });
+    mocks.dmPermission.mockReturnValue({ data: { permission: "open", may_connect: true } });
     await renderProfile();
 
     // Addressed by their handle, which is how My Messages resolves a person.
@@ -173,7 +173,7 @@ describe("a member's profile", () => {
   it("offers to ask, where there is no channel yet", async () => {
     const them = buildUserProfile();
     answerWith(them);
-    mocks.dmPermission.mockReturnValue({ data: { permission: "may_request" } });
+    mocks.dmPermission.mockReturnValue({ data: { permission: "may_request", may_connect: true } });
     await renderProfile();
 
     await userEvent.click(await screen.findByRole("button", { name: /ask to message/i }));
@@ -192,6 +192,17 @@ describe("a member's profile", () => {
 
     expect(await screen.findByRole("button", { name: /accept connection/i })).toBeEnabled();
     expect(screen.queryByRole("button", { name: /request sent/i })).toBeNull();
+  });
+
+  it("does not offer a connection the server would refuse", async () => {
+    // Connecting and messaging are separate rules, so a person who takes no
+    // connection requests must not be shown a button that answers with an
+    // error. The server says which, and the profile asks.
+    mocks.dmPermission.mockReturnValue({ data: { permission: "open", may_connect: false } });
+    await renderProfile();
+
+    expect(await screen.findByRole("link", { name: /message/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^connect$/i })).toBeNull();
   });
 
   it("offers neither where the server says no", async () => {

--- a/frontend/src/api/generated/direct-messages/direct-messages.ts
+++ b/frontend/src/api/generated/direct-messages/direct-messages.ts
@@ -26,6 +26,8 @@ import type {
   ContactGrantRead,
   ContactGrantsResponse,
   DirectMessagePermissionRead,
+  DirectMessagePermissionsRequest,
+  DirectMessagePermissionsResponse,
   DirectMessageSettingsRead,
   DirectMessageSettingsUpdate,
   DmConversationCreate,
@@ -648,6 +650,106 @@ export function useSafetyNumberApiV1UsersUserIdDmSafetyNumberGet<
   return withQueryKey(query, queryOptions.queryKey);
 }
 
+/**
+ * The same two answers as the single read, for a page of people at once.
+ *
+ * A surface listing members draws a control per row, and asking per row is a
+ * request per row. Both functions read the caller from the request context,
+ * so this is the same question asked once for many subjects rather than a
+ * different, looser one.
+ *
+ * A POST because the subjects are a list rather than an address: nothing is
+ * written, and the body is the only place a page of ids belongs.
+ * @summary Read Dm Permissions
+ */
+export const readDmPermissionsApiV1MeDmPermissionsPost = (
+  directMessagePermissionsRequest: BodyType<DirectMessagePermissionsRequest>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<DirectMessagePermissionsResponse>(
+    {
+      url: `/api/v1/me/dm-permissions`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: directMessagePermissionsRequest,
+      signal,
+    },
+    options
+  );
+};
+
+export const getReadDmPermissionsApiV1MeDmPermissionsPostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof readDmPermissionsApiV1MeDmPermissionsPost>>,
+    TError,
+    { data: BodyType<DirectMessagePermissionsRequest> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof readDmPermissionsApiV1MeDmPermissionsPost>>,
+  TError,
+  { data: BodyType<DirectMessagePermissionsRequest> },
+  TContext
+> => {
+  const mutationKey = ["readDmPermissionsApiV1MeDmPermissionsPost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof readDmPermissionsApiV1MeDmPermissionsPost>>,
+    { data: BodyType<DirectMessagePermissionsRequest> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return readDmPermissionsApiV1MeDmPermissionsPost(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type ReadDmPermissionsApiV1MeDmPermissionsPostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof readDmPermissionsApiV1MeDmPermissionsPost>>
+>;
+export type ReadDmPermissionsApiV1MeDmPermissionsPostMutationBody =
+  BodyType<DirectMessagePermissionsRequest>;
+export type ReadDmPermissionsApiV1MeDmPermissionsPostMutationError = ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Read Dm Permissions
+ */
+export const useReadDmPermissionsApiV1MeDmPermissionsPost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof readDmPermissionsApiV1MeDmPermissionsPost>>,
+      TError,
+      { data: BodyType<DirectMessagePermissionsRequest> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof readDmPermissionsApiV1MeDmPermissionsPost>>,
+  TError,
+  { data: BodyType<DirectMessagePermissionsRequest> },
+  TContext
+> => {
+  return useMutation(
+    getReadDmPermissionsApiV1MeDmPermissionsPostMutationOptions(options),
+    queryClient
+  );
+};
 /**
  * The policy this account picked, and one toggle per community it is in.
  *

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -2302,6 +2302,32 @@ export interface DirectMessagePermissionRead {
   permission: string;
 }
 
+/**
+ * Which accounts a surface is about to draw controls for.
+ */
+export interface DirectMessagePermissionsRequest {
+  /**
+   * @minItems 1
+   * @maxItems 100
+   */
+  user_ids: number[];
+}
+
+export type DirectMessagePermissionsResponsePermissions = {
+  [key: string]: DirectMessagePermissionRead;
+};
+
+/**
+ * One answer per account asked about, keyed by id as a string.
+ *
+ * Accounts the caller may not see are simply absent rather than refused: the
+ * reader is drawing a list, and a page that fails because one row is gone is
+ * worse than one that offers nothing for that row.
+ */
+export interface DirectMessagePermissionsResponse {
+  permissions: DirectMessagePermissionsResponsePermissions;
+}
+
 export interface DirectMessageSettingsRead {
   dm_policy: DmPolicy;
   communities: CommunityDmToggle[];

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1896,8 +1896,9 @@ export interface ContactRead {
   full_name: string | null;
   avatar_url: string | null;
   status: UserStatus;
-  presence: Presence;
   profile_decorations: ProfileDecorationsOutput;
+  guild_role: string | null;
+  presence: Presence;
   shared_guild_ids: number[];
 }
 
@@ -2297,6 +2298,7 @@ export interface DeviceTokenResponse {
  * all answer the same way.
  */
 export interface DirectMessagePermissionRead {
+  may_connect: boolean;
   permission: string;
 }
 
@@ -3612,10 +3614,19 @@ export interface InitiativeJoinRequestCreate {
 /**
  * Slim user projection for typeahead and picker surfaces.
  *
- * Drops what pickers never read — platform/guild role, ``initiative_roles``
- * (an N+1 enrichment on the full roster) and timestamps — while keeping the
- * avatar so members still render with a face. The payload is bounded by
- * pagination on the endpoints that serve it, not by dropping the avatar.
+ * What it keeps is what it takes to *draw* a person and say where they stand
+ * in the guild being read: the handle, the avatar, what they have put around
+ * it, and their guild role. A decoration is an id naming a catalog entry and
+ * a role is one word, so all of it is short, and none of it costs a query
+ * beyond the one already being run.
+ *
+ * What it drops is the account's own business and anything that would cost
+ * another round trip: no address, no platform tier, no ``initiative_roles``
+ * (an N+1 enrichment on the full roster), no timestamps. The payload is
+ * bounded by pagination on the endpoints that serve it.
+ *
+ * ``profile_decorations`` is quoted and the model rebuilt below, because the
+ * catalog shape it names is declared further down this file.
  */
 export interface UserSummary {
   id: number;
@@ -3624,6 +3635,8 @@ export interface UserSummary {
   full_name: string | null;
   avatar_url: string | null;
   status: UserStatus;
+  profile_decorations: ProfileDecorationsOutput | null;
+  guild_role: string | null;
 }
 
 /**

--- a/frontend/src/components/contacts/ContactActionButtons.tsx
+++ b/frontend/src/components/contacts/ContactActionButtons.tsx
@@ -79,6 +79,9 @@ export const ContactActionButtons = ({ user, className }: ContactActionButtonsPr
         </Button>
       ) : null}
 
+      {/* Connecting and messaging are separate rules, so the server is asked
+          about both. Offering a request that would be refused is worse than
+          offering nothing: it reads as a way in, and answers with an error. */}
       {isConnection ? null : theyAsked ? (
         <Button
           size="sm"
@@ -89,7 +92,7 @@ export const ContactActionButtons = ({ user, className }: ContactActionButtonsPr
           <UserPlus className="size-4" aria-hidden />
           {t("actions.acceptConnection")}
         </Button>
-      ) : (
+      ) : !(permission?.may_connect ?? false) ? null : (
         <Button
           size="sm"
           variant="outline"

--- a/frontend/src/components/contacts/ContactActionButtons.tsx
+++ b/frontend/src/components/contacts/ContactActionButtons.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { MessageSquare, UserPlus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import type { DirectMessagePermissionRead } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import {
   useAcceptConnection,
@@ -20,6 +21,12 @@ interface ContactActionButtonsProps {
    *  halves of it are needed rather than only the id. */
   user: { id: number; username: string; discriminator: number };
   className?: string;
+  /**
+   * The server's answer about this person, where the surface already has it.
+   * A list asks once for its whole page; without this each row would ask for
+   * itself, which is a request per row.
+   */
+  permission?: DirectMessagePermissionRead | null;
 }
 
 /**
@@ -33,10 +40,16 @@ interface ContactActionButtonsProps {
  * A request already sent stays on screen as a disabled button rather than
  * disappearing: the gap where it was would read as the ask having failed.
  */
-export const ContactActionButtons = ({ user, className }: ContactActionButtonsProps) => {
+export const ContactActionButtons = ({
+  user,
+  className,
+  permission: supplied,
+}: ContactActionButtonsProps) => {
   const { t } = useTranslation(["contacts", "settings"]);
 
-  const { data: permission } = useDmPermission(user.id);
+  // Only where the caller has not already been told.
+  const own = useDmPermission(supplied === undefined ? user.id : undefined);
+  const permission = supplied ?? own.data;
   const { data: connections } = useConnections();
   const { data: messageRequests } = useMessageRequests();
 

--- a/frontend/src/components/contacts/ContactActionsMenu.test.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.test.tsx
@@ -41,8 +41,8 @@ const ADA = { id: 7, username: "ada", discriminator: 1234 };
 
 // Through a router: one of the items is a link to the person's profile, and a
 // `Link` outside a router does not render at all.
-const open = async () => {
-  renderPage(() => <ContactActionsMenu user={ADA} />);
+const open = async ({ reachOffered = false }: { reachOffered?: boolean } = {}) => {
+  renderPage(() => <ContactActionsMenu user={ADA} reachOffered={reachOffered} />);
   await userEvent.click(await screen.findByRole("button", { name: /Actions for ada/i }));
 };
 
@@ -92,6 +92,18 @@ describe("ContactActionsMenu", () => {
       "/messages?with=ada1234"
     );
     expect(screen.queryByRole("menuitem", { name: /view profile/i })).toBeNull();
+  });
+
+  it("leaves the ways in out where something beside it offers them", async () => {
+    // The buttons and this menu sit together on a profile and on a roster.
+    // Offering Connect in both is the same action twice, a click apart.
+    mocks.permission.mockReturnValue({ data: { permission: "open", may_connect: true } });
+    await open({ reachOffered: true });
+
+    expect(screen.queryByRole("menuitem", { name: "Message" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /^connect$/i })).toBeNull();
+    // What is only here stays here.
+    expect(screen.getByRole("menuitem", { name: /^ignore$/i })).toBeInTheDocument();
   });
 
   it("offers nothing to open where the channel is not", async () => {

--- a/frontend/src/components/contacts/ContactActionsMenu.test.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.test.tsx
@@ -48,7 +48,7 @@ const open = async ({ reachOffered = false }: { reachOffered?: boolean } = {}) =
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.permission.mockReturnValue({ data: { permission: "denied" } });
+  mocks.permission.mockReturnValue({ data: { permission: "denied", may_connect: true } });
   mocks.connections.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
   mocks.ignored.mockReturnValue({ data: { items: [], total: 0 } });
 });

--- a/frontend/src/components/contacts/ContactActionsMenu.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.tsx
@@ -3,6 +3,7 @@ import { MoreHorizontal } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { DirectMessagePermissionRead } from "@/api/generated/initiativeAPI.schemas";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
@@ -31,6 +32,12 @@ interface ContactActionsMenuProps {
   /** Rendered inside a link or a row that is itself clickable. */
   className?: string;
   /**
+   * The server's answer about this person, where the surface already has it.
+   * A list asks once for its whole page; without this each row would ask for
+   * itself, which is a request per row.
+   */
+  permission?: DirectMessagePermissionRead | null;
+  /**
    * Leave out the ways in — message, ask, connect — because something beside
    * this menu already offers them. Set wherever `ContactActionButtons` is
    * rendered too, so a person is not offered the same thing twice.
@@ -55,11 +62,14 @@ export const ContactActionsMenu = ({
   user,
   className,
   reachOffered = false,
+  permission: supplied,
 }: ContactActionsMenuProps) => {
   const { t } = useTranslation(["contacts", "settings"]);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
 
-  const { data: permission } = useDmPermission(user.id);
+  // Only where the caller has not already been told.
+  const own = useDmPermission(supplied === undefined ? user.id : undefined);
+  const permission = supplied ?? own.data;
   const { data: connections } = useConnections();
   const { data: ignored } = useIgnoredAccounts();
 
@@ -100,7 +110,9 @@ export const ContactActionsMenu = ({
               </Link>
             </DropdownMenuItem>
           )}
-          {!reachOffered && !isConnection && !isPending && (
+          {/* Same rule the buttons answer to: connecting is its own decision,
+              and a request the server would refuse is not worth offering. */}
+          {!reachOffered && !isConnection && !isPending && permission?.may_connect && (
             <DropdownMenuItem
               onSelect={() =>
                 requestConnection.mutate(

--- a/frontend/src/components/contacts/ContactActionsMenu.tsx
+++ b/frontend/src/components/contacts/ContactActionsMenu.tsx
@@ -30,6 +30,12 @@ interface ContactActionsMenuProps {
   user: { id: number; username: string; discriminator: number };
   /** Rendered inside a link or a row that is itself clickable. */
   className?: string;
+  /**
+   * Leave out the ways in — message, ask, connect — because something beside
+   * this menu already offers them. Set wherever `ContactActionButtons` is
+   * rendered too, so a person is not offered the same thing twice.
+   */
+  reachOffered?: boolean;
 }
 
 /**
@@ -45,7 +51,11 @@ interface ContactActionsMenuProps {
  * — and because every refusal collapses into that one word, a menu built from
  * it says nothing about which refusal it is.
  */
-export const ContactActionsMenu = ({ user, className }: ContactActionsMenuProps) => {
+export const ContactActionsMenu = ({
+  user,
+  className,
+  reachOffered = false,
+}: ContactActionsMenuProps) => {
   const { t } = useTranslation(["contacts", "settings"]);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
 
@@ -83,14 +93,14 @@ export const ContactActionsMenu = ({ user, className }: ContactActionsMenuProps)
               person -- a contacts row links there, and the profile is there.
               What it offers instead is the thing you would have gone looking
               for, which is the conversation. */}
-          {permission?.permission === "open" && (
+          {!reachOffered && permission?.permission === "open" && (
             <DropdownMenuItem asChild>
               <Link to="/messages" search={{ with: getUrlHandle(user) }}>
                 {t("actions.message")}
               </Link>
             </DropdownMenuItem>
           )}
-          {!isConnection && !isPending && (
+          {!reachOffered && !isConnection && !isPending && (
             <DropdownMenuItem
               onSelect={() =>
                 requestConnection.mutate(
@@ -102,7 +112,7 @@ export const ContactActionsMenu = ({ user, className }: ContactActionsMenuProps)
               {t("actions.connect")}
             </DropdownMenuItem>
           )}
-          {permission?.permission === "may_request" && (
+          {!reachOffered && permission?.permission === "may_request" && (
             <DropdownMenuItem
               onSelect={() =>
                 requestMessage.mutate(

--- a/frontend/src/components/contacts/GrantContactSection.tsx
+++ b/frontend/src/components/contacts/GrantContactSection.tsx
@@ -22,6 +22,8 @@ export const grantAsContact = (grant: ContactGrantRead): ContactRead => ({
   full_name: null,
   avatar_url: grant.avatar_url,
   status: grant.status,
+  // A grant knows nothing about a guild, which is the point of this section.
+  guild_role: null,
   presence: grant.presence,
   profile_decorations: grant.profile_decorations,
   shared_guild_ids: [],

--- a/frontend/src/components/guildHome/GuildBannerBadges.test.tsx
+++ b/frontend/src/components/guildHome/GuildBannerBadges.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * The badge that counts a community's members.
+ *
+ * It used to say how many people were here and go nowhere, which is the whole
+ * reason the roster was hard to find. What matters now is that the count is
+ * the way in.
+ */
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+
+import { GuildBannerBadges } from "./GuildBannerBadges";
+
+const setup = (props: Partial<Parameters<typeof GuildBannerBadges>[0]> = {}) =>
+  renderPage(() => (
+    <GuildBannerBadges guildId={7} memberCount={12} onlineCount={0} ink="#fff" {...props} />
+  ));
+
+describe("the banner badges", () => {
+  it("sends the member count to that community's roster", async () => {
+    setup();
+
+    expect(await screen.findByRole("link", { name: /12 members/i })).toHaveAttribute(
+      "href",
+      "/c/7/members"
+    );
+  });
+
+  it("says nothing about nobody being online", async () => {
+    setup();
+
+    expect(await screen.findByRole("link", { name: /12 members/i })).toBeInTheDocument();
+    expect(screen.queryByText(/online/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/guildHome/GuildBannerBadges.tsx
+++ b/frontend/src/components/guildHome/GuildBannerBadges.tsx
@@ -13,19 +13,27 @@
  * "someone is here" means, on any banner.
  */
 
+import { Link } from "@tanstack/react-router";
 import { Users } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { readableTextShadow, withAlpha } from "@/lib/contrastColor";
 
 export type GuildBannerBadgesProps = {
+  /** The community whose roster the member count leads to. */
+  guildId: number;
   memberCount: number;
   onlineCount: number;
   /** The banner's text colour, which these are tinted from. */
   ink: string;
 };
 
-export const GuildBannerBadges = ({ memberCount, onlineCount, ink }: GuildBannerBadgesProps) => {
+export const GuildBannerBadges = ({
+  guildId,
+  memberCount,
+  onlineCount,
+  ink,
+}: GuildBannerBadgesProps) => {
   const { t } = useTranslation("guilds");
 
   const chip = {
@@ -37,13 +45,17 @@ export const GuildBannerBadges = ({ memberCount, onlineCount, ink }: GuildBanner
 
   return (
     <>
-      <span
-        className="flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-medium text-xs backdrop-blur-sm"
+      {/* The count is the way in: it says how many people are here, so it is
+          what somebody looking for one of them reaches for. */}
+      <Link
+        to="/c/$guildId/members"
+        params={{ guildId: String(guildId) }}
+        className="flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-medium text-xs backdrop-blur-sm transition hover:brightness-110 focus-visible:outline-2 focus-visible:outline-current"
         style={chip}
       >
         <Users className="h-3.5 w-3.5" aria-hidden="true" />
         {t("memberCount", { count: memberCount })}
-      </span>
+      </Link>
       {/* A guild with nobody in it says nothing rather than "0 online", which
           reads as a verdict on the guild rather than on the moment. */}
       {onlineCount > 0 ? (

--- a/frontend/src/components/guilds/GuildContextMenu.tsx
+++ b/frontend/src/components/guilds/GuildContextMenu.tsx
@@ -80,7 +80,7 @@ export const GuildContextMenu = ({ guild, children, onReorder }: GuildContextMen
     if (guild.id !== activeGuildId) {
       await switchGuild(guild.id);
     }
-    router.navigate({ to: "/c/$guildId/settings/users", params: { guildId: String(guild.id) } });
+    router.navigate({ to: "/c/$guildId/members", params: { guildId: String(guild.id) } });
   };
 
   const handleViewInitiatives = async () => {
@@ -132,12 +132,12 @@ export const GuildContextMenu = ({ guild, children, onReorder }: GuildContextMen
             <FolderOpen className="mr-2 h-4 w-4" />
             {t("viewInitiatives")}
           </ContextMenuItem>
+          <ContextMenuItem onClick={handleViewMembers}>
+            <Users className="mr-2 h-4 w-4" />
+            {t("viewMembers")}
+          </ContextMenuItem>
           {isAdmin && (
             <>
-              <ContextMenuItem onClick={handleViewMembers}>
-                <Users className="mr-2 h-4 w-4" />
-                {t("viewMembers")}
-              </ContextMenuItem>
               <ContextMenuSeparator />
               <ContextMenuItem
                 onClick={

--- a/frontend/src/hooks/useDirectMessages.ts
+++ b/frontend/src/hooks/useDirectMessages.ts
@@ -7,9 +7,11 @@
  * acted and a tab that only watched end up saying the same thing.
  */
 
-import { useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 
 import {
+  readDmPermissionsApiV1MeDmPermissionsPost,
   useAcceptConnectionApiV1MeConnectionsUserIdAcceptPost,
   useAcceptMessageRequestApiV1MeMessageRequestsUserIdAcceptPost,
   useIgnoreAccountApiV1MeIgnoredUserIdPut,
@@ -80,6 +82,26 @@ export const useDmPermission = (userId: number | undefined) =>
   useReadDmPermissionApiV1UsersUserIdDmPermissionGet(userId as number, {
     query: { enabled: typeof userId === "number" },
   });
+/**
+ * The same two answers, for a page of people at once.
+ *
+ * A surface listing members draws a control per row, and asking per row is a
+ * request per row -- up to a hundred when a roster page is full. One question
+ * about many subjects instead, cached under the ids it was asked about.
+ *
+ * A POST that reads: the subjects are a list rather than an address, so
+ * `useQuery` rather than a mutation, with the ids in the key.
+ */
+export const useDmPermissions = (userIds: number[]) => {
+  const ids = useMemo(() => [...new Set(userIds)].sort((a, b) => a - b), [userIds]);
+  return useQuery({
+    queryKey: ["dm", "permissions", ids],
+    queryFn: () => readDmPermissionsApiV1MeDmPermissionsPost({ user_ids: ids }),
+    enabled: ids.length > 0,
+    staleTime: 30_000,
+  });
+};
+
 export const useConnections = () => useListConnectionsApiV1MeConnectionsGet();
 export const useMessageRequests = () => useListMessageRequestsApiV1MeMessageRequestsGet();
 export const useIgnoredAccounts = () => useListIgnoredAccountsApiV1MeIgnoredGet();

--- a/frontend/src/pages/GuildHomePage.tsx
+++ b/frontend/src/pages/GuildHomePage.tsx
@@ -220,6 +220,7 @@ export function GuildHomePage() {
         badges={
           activeGuild ? (
             <GuildBannerBadges
+              guildId={activeGuild.id}
               memberCount={activeGuild.member_count}
               onlineCount={activeGuild.online_count}
               ink={banner.text_color}

--- a/frontend/src/pages/GuildMembersPage.test.tsx
+++ b/frontend/src/pages/GuildMembersPage.test.tsx
@@ -6,17 +6,24 @@
  * here is that it asks for the right one, pages within it, and offers each
  * person the same way in that they get anywhere else.
  */
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderPage } from "@/__tests__/helpers/render";
+
+// The reader, so a row can be told apart from their own.
+vi.mock("@/hooks/useAuth", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAuth: () => ({ user: { id: 99 } }),
+}));
 
 const mocks = vi.hoisted(() => ({
   members: vi.fn(),
   permission: vi.fn(),
   connections: vi.fn(),
   favorites: vi.fn(),
+  permissions: vi.fn(),
   setFavorite: vi.fn(),
   ignored: vi.fn(),
   ignore: vi.fn(),
@@ -34,6 +41,7 @@ vi.mock("@/hooks/useUsers", async (importOriginal) => ({
 }));
 vi.mock("@/hooks/useDirectMessages", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
+  useDmPermissions: (ids: number[]) => mocks.permissions(ids),
   useDmPermission: () => mocks.permission(),
   useConnections: () => mocks.connections(),
   useIgnoredAccounts: () => mocks.ignored(),
@@ -68,6 +76,7 @@ const setup = () =>
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.permission.mockReturnValue({ data: { permission: "denied", may_connect: false } });
+  mocks.permissions.mockReturnValue({ data: { permissions: {} } });
   mocks.connections.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
   mocks.favorites.mockReturnValue({ data: { items: [] } });
   mocks.ignored.mockReturnValue({ data: { items: [] } });
@@ -93,7 +102,9 @@ describe("a community's members page", () => {
   });
 
   it("offers the conversation where the server says there is one", async () => {
-    mocks.permission.mockReturnValue({ data: { permission: "open", may_connect: true } });
+    mocks.permissions.mockReturnValue({
+      data: { permissions: { "1": { permission: "open", may_connect: true } } },
+    });
     answer([person(1, "ada")]);
     setup();
 
@@ -174,6 +185,44 @@ describe("a community's members page", () => {
     await userEvent.click(await screen.findByRole("button", { name: /actions for ada/i }));
 
     expect(await screen.findByRole("menuitem", { name: /^ignore$/i })).toBeInTheDocument();
+  });
+
+  it("asks about the whole page at once", async () => {
+    // Asked per row, this is a request per row -- a hundred on a full page.
+    answer([person(1, "ada"), person(2, "bram")]);
+    setup();
+
+    await screen.findByText("ada");
+    expect(mocks.permissions).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("lets the address change under it without pushing back", async () => {
+    // Back, forward, a link somebody sent: the draft catches up to the URL,
+    // and the pending debounce must not overwrite it with what was being
+    // typed a moment ago.
+    answer([person(1, "ada")]);
+    const { router } = setup();
+    await screen.findByText("ada");
+
+    await userEvent.type(screen.getByPlaceholderText(/filter members/i), "zz");
+    await act(() =>
+      router.navigate({ to: "/c/$guildId/members", params: { guildId: "7" }, search: { q: "ada" } })
+    );
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/filter members/i)).toHaveValue("ada"));
+    expect((router.state.location.search as { q?: string }).q).toBe("ada");
+  });
+
+  it("offers nothing to do about yourself", async () => {
+    // Starring, ignoring and every way in are refused for your own account,
+    // so a row for it that offered them would be offering errors.
+    answer([person(99, "me"), person(1, "ada")]);
+    setup();
+
+    await screen.findByText("me");
+    // One row has the controls; the reader's own has none.
+    expect(screen.getAllByRole("button", { name: /to favorites/i })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: /actions for/i })).toHaveLength(1);
   });
 
   it("says so when the roster cannot be read", async () => {

--- a/frontend/src/pages/GuildMembersPage.test.tsx
+++ b/frontend/src/pages/GuildMembersPage.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * The roster a community's member count leads to.
+ *
+ * The page adds a surface rather than a source: it asks the same contacts
+ * aggregate My Contacts reads, for one community. So what is worth asserting
+ * here is that it asks for the right one, pages within it, and offers each
+ * person the same way in that they get anywhere else.
+ */
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+
+const mocks = vi.hoisted(() => ({
+  members: vi.fn(),
+  permission: vi.fn(),
+  connections: vi.fn(),
+  favorites: vi.fn(),
+  setFavorite: vi.fn(),
+  ignored: vi.fn(),
+  ignore: vi.fn(),
+}));
+
+vi.mock("@/hooks/useContacts", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useFavoriteContacts: () => mocks.favorites(),
+  useToggleFavoriteContact: () => mocks.setFavorite,
+}));
+
+vi.mock("@/hooks/useUsers", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useUserSearch: (options: Record<string, unknown>) => mocks.members(options),
+}));
+vi.mock("@/hooks/useDirectMessages", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useDmPermission: () => mocks.permission(),
+  useConnections: () => mocks.connections(),
+  useIgnoredAccounts: () => mocks.ignored(),
+  useIgnoreAccount: () => ({ mutate: mocks.ignore, isPending: false }),
+  useMessageRequests: () => ({ data: { accepted: [], incoming: [], outgoing: [] } }),
+}));
+
+import { GuildMembersPage } from "./GuildMembersPage";
+
+const person = (id: number, username: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  username,
+  discriminator: 1234,
+  full_name: null,
+  avatar_url: null,
+  status: "active" as const,
+  ...overrides,
+});
+
+const answer = (items: ReturnType<typeof person>[], total = items.length) =>
+  mocks.members.mockReturnValue({
+    data: { items, total_count: total, page: 1, page_size: 25, has_next: false, has_prev: false },
+    isError: false,
+  });
+
+const setup = () =>
+  renderPage(() => <GuildMembersPage />, {
+    initialRoute: "/c/$guildId/members",
+    routeParams: { guildId: "7" },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.permission.mockReturnValue({ data: { permission: "denied", may_connect: false } });
+  mocks.connections.mockReturnValue({ data: { accepted: [], incoming: [], outgoing: [] } });
+  mocks.favorites.mockReturnValue({ data: { items: [] } });
+  mocks.ignored.mockReturnValue({ data: { items: [] } });
+  answer([]);
+});
+
+describe("a community's members page", () => {
+  it("asks the guild's own roster, not the list of people it may message", async () => {
+    answer([person(1, "ada")]);
+    setup();
+
+    expect(await screen.findByText("ada")).toBeInTheDocument();
+    expect(mocks.members).toHaveBeenCalledWith(
+      expect.objectContaining({ guildIdOverride: 7, page: 1 })
+    );
+  });
+
+  it("sends a row to that person", async () => {
+    answer([person(1, "ada")]);
+    setup();
+
+    expect((await screen.findByText("ada")).closest("a")).toHaveAttribute("href", "/u/ada1234");
+  });
+
+  it("offers the conversation where the server says there is one", async () => {
+    mocks.permission.mockReturnValue({ data: { permission: "open", may_connect: true } });
+    answer([person(1, "ada")]);
+    setup();
+
+    expect(await screen.findByRole("link", { name: /message/i })).toHaveAttribute(
+      "href",
+      "/messages?with=ada1234"
+    );
+  });
+
+  it("counts everyone, not just the page on screen", async () => {
+    answer([person(1, "ada")], 42);
+    setup();
+
+    expect(await screen.findByText(/42 members/i)).toBeInTheDocument();
+  });
+
+  it("lists somebody who takes no messages, with nothing to click", async () => {
+    // The point of reading the roster rather than the contacts aggregate: a
+    // members page that hid everyone unreachable would be missing members.
+    answer([person(1, "ada")]);
+    setup();
+
+    expect(await screen.findByText("ada")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /message/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /ask to message/i })).toBeNull();
+    // And no connect button either: the server would refuse that too, and a
+    // roster is the one place a refusal is not worth offering.
+    expect(screen.queryByRole("button", { name: /^connect$/i })).toBeNull();
+  });
+
+  it("answers every keystroke but waits for typing to stop", async () => {
+    // The field is local; the address and the roster follow once typing
+    // settles. Committing per letter re-runs the route and re-asks the server,
+    // which is what made this lag behind the typing.
+    answer([person(1, "ada")]);
+    const { router } = setup();
+    await screen.findByText("ada");
+    const field = screen.getByPlaceholderText(/filter members/i);
+
+    await userEvent.type(field, "bo");
+    expect(field).toHaveValue("bo");
+    expect((router.state.location.search as { q?: string }).q).toBeUndefined();
+
+    // And a new search starts at the beginning: page 3 of the old one says
+    // nothing about the new one.
+    await waitFor(() => expect((router.state.location.search as { q?: string }).q).toBe("bo"));
+    expect((router.state.location.search as { page?: number }).page).toBeUndefined();
+  });
+
+  it("says which of them runs the place", async () => {
+    // Only the exception is worn: badging every ordinary member "member" would
+    // say nothing and cost the width the actions need.
+    answer([
+      person(1, "ada", { guild_role: "admin" }),
+      person(2, "bram", { guild_role: "member" }),
+    ]);
+    setup();
+
+    const admin = (await screen.findByText("ada")).closest("a");
+    expect(admin).toHaveTextContent("Admin");
+    expect((await screen.findByText("bram")).closest("a")).not.toHaveTextContent("Admin");
+  });
+
+  it("stars somebody from the row", async () => {
+    answer([person(1, "ada")]);
+    setup();
+
+    await userEvent.click(await screen.findByRole("button", { name: /to favorites/i }));
+    expect(mocks.setFavorite).toHaveBeenCalledWith(1, false);
+  });
+
+  it("offers everything else a person can be, behind the overflow", async () => {
+    // Ignoring above all: a roster is the likeliest place to want it, and it
+    // used to mean knowing somebody's exact handle and opening Settings.
+    answer([person(1, "ada")]);
+    setup();
+
+    await userEvent.click(await screen.findByRole("button", { name: /actions for ada/i }));
+
+    expect(await screen.findByRole("menuitem", { name: /^ignore$/i })).toBeInTheDocument();
+  });
+
+  it("says so when the roster cannot be read", async () => {
+    mocks.members.mockReturnValue({ data: undefined, isError: true });
+    setup();
+
+    expect(await screen.findByText(/could not be loaded/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/GuildMembersPage.tsx
+++ b/frontend/src/pages/GuildMembersPage.tsx
@@ -1,0 +1,209 @@
+import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import type { PaginationState } from "@tanstack/react-table";
+import { UsersRound } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { UserSummary } from "@/api/generated/initiativeAPI.schemas";
+import { ContactActionButtons } from "@/components/contacts/ContactActionButtons";
+import { ContactActionsMenu } from "@/components/contacts/ContactActionsMenu";
+import { FavoriteToggle } from "@/components/contacts/FavoriteToggle";
+import { StatusMessage } from "@/components/StatusMessage";
+import { UserHandle } from "@/components/UserHandle";
+import { Badge } from "@/components/ui/badge";
+import { DataTable } from "@/components/ui/data-table";
+import { ProfileAvatar } from "@/components/user/ProfileAvatar";
+import { useFavoriteContacts, useToggleFavoriteContact } from "@/hooks/useContacts";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
+import { USER_SEARCH_PAGE_SIZE, useUserSearch } from "@/hooks/useUsers";
+import type { AppColumnDef } from "@/lib/table";
+import { getUrlHandle, getUserDisplayName } from "@/lib/userDisplay";
+
+/**
+ * Everyone in this community, and a way to reach them.
+ *
+ * The badge on the community's banner counts people; this is where that count
+ * leads. It reads the guild's own roster — the same one every member picker
+ * reads — rather than the contacts aggregate, which answers a different
+ * question: who this reader may *message*. A page that dropped everybody who
+ * takes no messages would be a members page missing members.
+ *
+ * Each row carries the same actions a person gets anywhere else, and those do
+ * still follow what the server says the reader may do. So somebody who takes
+ * no messages is listed like anyone else and simply offers nothing to click,
+ * which is the honest shape: they are here, and they are not reachable.
+ */
+/** How long typing settles before the address and the roster follow it. */
+const SEARCH_SETTLES_MS = 250;
+
+export const GuildMembersPage = () => {
+  const { t } = useTranslation("guilds");
+  const { guildId } = useParams({ strict: false }) as { guildId: string };
+  const { page = 1, q = "" } = useSearch({ strict: false }) as { page?: number; q?: string };
+  const navigate = useNavigate();
+
+  const id = Number(guildId);
+  const members = useUserSearch({
+    search: q || undefined,
+    page,
+    pageSize: USER_SEARCH_PAGE_SIZE,
+    guildIdOverride: id,
+  });
+  const rows = useMemo(() => members.data?.items ?? [], [members.data]);
+  const total = members.data?.total_count ?? 0;
+  const pageSize = members.data?.page_size ?? USER_SEARCH_PAGE_SIZE;
+
+  /** Both the search and the page live in the address, so a roster somebody
+   *  is halfway through is a link they can send. */
+  const setSearch = useCallback(
+    (next: Record<string, unknown>) =>
+      void navigate({
+        to: ".",
+        search: (old: Record<string, unknown>) => ({ ...old, ...next }),
+        replace: true,
+      }),
+    [navigate]
+  );
+
+  // The field answers every keystroke; the address and the request wait for
+  // typing to stop. Committing each letter re-runs the route and asks the
+  // server again, which is what made this lag behind the typing.
+  const [draft, setDraft] = useState(q);
+  const settled = useDebouncedValue(draft, SEARCH_SETTLES_MS);
+  // Follow the URL when it changes from outside — back, forward, a shared link.
+  useEffect(() => setDraft(q), [q]);
+  useEffect(() => {
+    // A new search starts at the beginning: page 3 of the old one says nothing
+    // about the new one.
+    if (settled !== q) setSearch({ q: settled || undefined, page: undefined });
+  }, [settled, q, setSearch]);
+
+  // Starring is a second read: a favourite may be somebody you share no
+  // community with, so the list is not a slice of this roster.
+  const favorites = useFavoriteContacts("");
+  const starred = useMemo(
+    () => new Set((favorites.data?.items ?? []).map((contact) => contact.id)),
+    [favorites.data]
+  );
+  const setFavorite = useToggleFavoriteContact();
+
+  const [columnVisibility, setColumnVisibility] = usePersistedColumnVisibility(
+    "guild-members-columns",
+    []
+  );
+
+  const columns = useMemo<AppColumnDef<UserSummary>[]>(
+    () => [
+      {
+        id: "person",
+        meta: { label: t("members.person") },
+        header: () => <span className="font-medium">{t("members.person")}</span>,
+        accessorFn: (row) => row.username,
+        cell: ({ row }) => (
+          <Link
+            to="/u/$handle"
+            params={{ handle: getUrlHandle(row.original) }}
+            className="flex min-w-0 items-center gap-2 hover:underline"
+          >
+            <ProfileAvatar
+              user={row.original}
+              decorations={row.original.profile_decorations}
+              className="size-7 shrink-0"
+            />
+            <UserHandle user={row.original} className="min-w-0" nameClassName="min-w-0 truncate" />
+            {/* Only the exception is worn. Badging the other nine rows in ten
+                "member" would say nothing and cost the width the actions
+                need. */}
+            {row.original.guild_role === "admin" ? (
+              <Badge variant="secondary" className="shrink-0">
+                {t("members.admin")}
+              </Badge>
+            ) : null}
+          </Link>
+        ),
+      },
+      {
+        id: "name",
+        meta: { label: t("members.name") },
+        header: () => <span className="font-medium">{t("members.name")}</span>,
+        accessorFn: (row) => row.full_name ?? "",
+        cell: ({ row }) => (
+          <span className="truncate text-muted-foreground">{row.original.full_name ?? ""}</span>
+        ),
+      },
+      {
+        id: "actions",
+        meta: { label: t("members.actions") },
+        enableSorting: false,
+        header: () => <span className="sr-only">{t("members.actions")}</span>,
+        cell: ({ row }) => {
+          const person = {
+            id: row.original.id,
+            username: row.original.username,
+            discriminator: row.original.discriminator,
+          };
+          return (
+            <div className="flex items-center justify-end gap-1">
+              <ContactActionButtons user={person} />
+              {/* Its own control rather than a menu item, the way a contacts
+                  row has it: starring is one private, reversible click and
+                  nothing is told to anybody. */}
+              <FavoriteToggle
+                starred={starred.has(row.original.id)}
+                name={getUserDisplayName(row.original)}
+                onToggle={() => setFavorite(row.original.id, starred.has(row.original.id))}
+              />
+              {/* Everything else a person can be to you — ignoring above all,
+                  which a roster is the likeliest place to want. Same menu as
+                  their profile and their contacts row, so it holds no surprise
+                  and nothing has to be kept in step. */}
+              <ContactActionsMenu user={person} reachOffered />
+            </div>
+          );
+        },
+      },
+    ],
+    [t, starred, setFavorite]
+  );
+
+  return (
+    <div className="space-y-4">
+      <header className="space-y-1">
+        <h1 className="font-semibold text-2xl">{t("members.title")}</h1>
+        <p className="text-muted-foreground text-sm">{t("memberCount", { count: total })}</p>
+      </header>
+
+      {members.isError ? (
+        <StatusMessage
+          icon={<UsersRound className="size-6" aria-hidden />}
+          title={t("members.failed")}
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={rows}
+          // Controlled, because the roster is searched on the server: the
+          // table's own filter would only narrow the page already on screen,
+          // which is the wrong answer for everybody past the first twenty-five.
+          enableFilterInput
+          filterInputPlaceholder={t("members.searchPlaceholder")}
+          filterValue={draft}
+          onFilterValueChange={setDraft}
+          enableColumnVisibilityDropdown
+          columnVisibility={columnVisibility}
+          onColumnVisibilityChange={setColumnVisibility}
+          enablePagination
+          manualPagination
+          pageCount={Math.max(1, Math.ceil(total / pageSize))}
+          rowCount={total}
+          pageIndex={page - 1}
+          onPaginationChange={(next: PaginationState) =>
+            setSearch({ page: next.pageIndex + 1 === 1 ? undefined : next.pageIndex + 1 })
+          }
+          getRowId={(row: UserSummary) => String(row.id)}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/GuildMembersPage.tsx
+++ b/frontend/src/pages/GuildMembersPage.tsx
@@ -13,8 +13,10 @@ import { UserHandle } from "@/components/UserHandle";
 import { Badge } from "@/components/ui/badge";
 import { DataTable } from "@/components/ui/data-table";
 import { ProfileAvatar } from "@/components/user/ProfileAvatar";
+import { useAuth } from "@/hooks/useAuth";
 import { useFavoriteContacts, useToggleFavoriteContact } from "@/hooks/useContacts";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useDmPermissions } from "@/hooks/useDirectMessages";
 import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility";
 import { USER_SEARCH_PAGE_SIZE, useUserSearch } from "@/hooks/useUsers";
 import type { AppColumnDef } from "@/lib/table";
@@ -42,6 +44,7 @@ export const GuildMembersPage = () => {
   const { guildId } = useParams({ strict: false }) as { guildId: string };
   const { page = 1, q = "" } = useSearch({ strict: false }) as { page?: number; q?: string };
   const navigate = useNavigate();
+  const { user: me } = useAuth();
 
   const id = Number(guildId);
   const members = useUserSearch({
@@ -51,6 +54,8 @@ export const GuildMembersPage = () => {
     guildIdOverride: id,
   });
   const rows = useMemo(() => members.data?.items ?? [], [members.data]);
+  // One question for the whole page. Asked per row, this is a request per row.
+  const permissions = useDmPermissions(useMemo(() => rows.map((row) => row.id), [rows]));
   const total = members.data?.total_count ?? 0;
   const pageSize = members.data?.page_size ?? USER_SEARCH_PAGE_SIZE;
 
@@ -74,10 +79,15 @@ export const GuildMembersPage = () => {
   // Follow the URL when it changes from outside — back, forward, a shared link.
   useEffect(() => setDraft(q), [q]);
   useEffect(() => {
+    // Only once typing has settled *onto the current draft*. Without that, an
+    // address changed from outside -- back, forward, a link somebody sent --
+    // is immediately overwritten by whatever was being typed 250ms ago, and
+    // history cannot be walked.
+    if (settled !== draft || settled === q) return;
     // A new search starts at the beginning: page 3 of the old one says nothing
     // about the new one.
-    if (settled !== q) setSearch({ q: settled || undefined, page: undefined });
-  }, [settled, q, setSearch]);
+    setSearch({ q: settled || undefined, page: undefined });
+  }, [settled, draft, q, setSearch]);
 
   // Starring is a second read: a favourite may be somebody you share no
   // community with, so the list is not a slice of this roster.
@@ -87,6 +97,8 @@ export const GuildMembersPage = () => {
     [favorites.data]
   );
   const setFavorite = useToggleFavoriteContact();
+
+  const answers = permissions.data?.permissions ?? {};
 
   const [columnVisibility, setColumnVisibility] = usePersistedColumnVisibility(
     "guild-members-columns",
@@ -138,6 +150,10 @@ export const GuildMembersPage = () => {
         enableSorting: false,
         header: () => <span className="sr-only">{t("members.actions")}</span>,
         cell: ({ row }) => {
+          // Your own row carries none of this: starring, ignoring and every
+          // way in are refused for yourself, so offering them is offering
+          // errors.
+          if (row.original.id === me?.id) return null;
           const person = {
             id: row.original.id,
             username: row.original.username,
@@ -145,7 +161,7 @@ export const GuildMembersPage = () => {
           };
           return (
             <div className="flex items-center justify-end gap-1">
-              <ContactActionButtons user={person} />
+              <ContactActionButtons user={person} permission={answers[String(person.id)] ?? null} />
               {/* Its own control rather than a menu item, the way a contacts
                   row has it: starring is one private, reversible click and
                   nothing is told to anybody. */}
@@ -158,13 +174,17 @@ export const GuildMembersPage = () => {
                   which a roster is the likeliest place to want. Same menu as
                   their profile and their contacts row, so it holds no surprise
                   and nothing has to be kept in step. */}
-              <ContactActionsMenu user={person} reachOffered />
+              <ContactActionsMenu
+                user={person}
+                reachOffered
+                permission={answers[String(person.id)] ?? null}
+              />
             </div>
           );
         },
       },
     ],
-    [t, starred, setFavorite]
+    [t, starred, setFavorite, me?.id, answers]
   );
 
   return (

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -114,6 +114,7 @@ export const UserProfilePage = () => {
                   }}
                 />
                 <ContactActionsMenu
+                  reachOffered
                   user={{
                     id: profile.id,
                     username: profile.username,

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -55,6 +55,7 @@ import { Route as ServerRequiredAuthenticatedUHandleRouteImport } from './routes
 import { Route as ServerRequiredCommunityGuildIdLoginRouteImport } from './routes/_serverRequired/community.$guildId.login'
 import { Route as ServerRequiredAuthenticatedCGuildIdIndexRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/index'
 import { Route as ServerRequiredAuthenticatedCGuildIdMarketplaceRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/marketplace'
+import { Route as ServerRequiredAuthenticatedCGuildIdMembersRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/members'
 import { Route as ServerRequiredAuthenticatedCGuildIdSearchRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/search'
 import { Route as ServerRequiredAuthenticatedCGuildIdSettingsRouteImport } from './routes/_serverRequired/_authenticated/c/$guildId/settings'
 import { Route as ServerRequiredAuthenticatedSettingsAdminIndexRouteImport } from './routes/_serverRequired/_authenticated/settings/admin/index'
@@ -414,6 +415,12 @@ const ServerRequiredAuthenticatedCGuildIdMarketplaceRoute =
   ServerRequiredAuthenticatedCGuildIdMarketplaceRouteImport.update({
     id: '/marketplace',
     path: '/marketplace',
+    getParentRoute: () => ServerRequiredAuthenticatedCGuildIdRoute,
+  } as any)
+const ServerRequiredAuthenticatedCGuildIdMembersRoute =
+  ServerRequiredAuthenticatedCGuildIdMembersRouteImport.update({
+    id: '/members',
+    path: '/members',
     getParentRoute: () => ServerRequiredAuthenticatedCGuildIdRoute,
   } as any)
 const ServerRequiredAuthenticatedCGuildIdSearchRoute =
@@ -1177,6 +1184,7 @@ export interface FileRoutesByFullPath {
   '/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/profile/': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
+  '/c/$guildId/members': typeof ServerRequiredAuthenticatedCGuildIdMembersRoute
   '/c/$guildId/search': typeof ServerRequiredAuthenticatedCGuildIdSearchRoute
   '/c/$guildId/settings': typeof ServerRequiredAuthenticatedCGuildIdSettingsRouteWithChildren
   '/settings/admin/access': typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
@@ -1311,6 +1319,7 @@ export interface FileRoutesByTo {
   '/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/profile': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
+  '/c/$guildId/members': typeof ServerRequiredAuthenticatedCGuildIdMembersRoute
   '/c/$guildId/search': typeof ServerRequiredAuthenticatedCGuildIdSearchRoute
   '/settings/admin/access': typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
   '/settings/admin/announcements': typeof ServerRequiredAuthenticatedSettingsAdminAnnouncementsRoute
@@ -1442,6 +1451,7 @@ export interface FileRoutesById {
   '/_serverRequired/community/$guildId/login': typeof ServerRequiredCommunityGuildIdLoginRoute
   '/_serverRequired/_authenticated/profile/': typeof ServerRequiredAuthenticatedProfileIndexRoute
   '/_serverRequired/_authenticated/c/$guildId/marketplace': typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
+  '/_serverRequired/_authenticated/c/$guildId/members': typeof ServerRequiredAuthenticatedCGuildIdMembersRoute
   '/_serverRequired/_authenticated/c/$guildId/search': typeof ServerRequiredAuthenticatedCGuildIdSearchRoute
   '/_serverRequired/_authenticated/c/$guildId/settings': typeof ServerRequiredAuthenticatedCGuildIdSettingsRouteWithChildren
   '/_serverRequired/_authenticated/settings/admin/access': typeof ServerRequiredAuthenticatedSettingsAdminAccessRoute
@@ -1582,6 +1592,7 @@ export interface FileRouteTypes {
     | '/community/$guildId/login'
     | '/profile/'
     | '/c/$guildId/marketplace'
+    | '/c/$guildId/members'
     | '/c/$guildId/search'
     | '/c/$guildId/settings'
     | '/settings/admin/access'
@@ -1716,6 +1727,7 @@ export interface FileRouteTypes {
     | '/community/$guildId/login'
     | '/profile'
     | '/c/$guildId/marketplace'
+    | '/c/$guildId/members'
     | '/c/$guildId/search'
     | '/settings/admin/access'
     | '/settings/admin/announcements'
@@ -1846,6 +1858,7 @@ export interface FileRouteTypes {
     | '/_serverRequired/community/$guildId/login'
     | '/_serverRequired/_authenticated/profile/'
     | '/_serverRequired/_authenticated/c/$guildId/marketplace'
+    | '/_serverRequired/_authenticated/c/$guildId/members'
     | '/_serverRequired/_authenticated/c/$guildId/search'
     | '/_serverRequired/_authenticated/c/$guildId/settings'
     | '/_serverRequired/_authenticated/settings/admin/access'
@@ -2269,6 +2282,13 @@ declare module '@tanstack/react-router' {
       path: '/marketplace'
       fullPath: '/c/$guildId/marketplace'
       preLoaderRoute: typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRouteImport
+      parentRoute: typeof ServerRequiredAuthenticatedCGuildIdRoute
+    }
+    '/_serverRequired/_authenticated/c/$guildId/members': {
+      id: '/_serverRequired/_authenticated/c/$guildId/members'
+      path: '/members'
+      fullPath: '/c/$guildId/members'
+      preLoaderRoute: typeof ServerRequiredAuthenticatedCGuildIdMembersRouteImport
       parentRoute: typeof ServerRequiredAuthenticatedCGuildIdRoute
     }
     '/_serverRequired/_authenticated/c/$guildId/search': {
@@ -3361,6 +3381,7 @@ const ServerRequiredAuthenticatedCGuildIdCalendarsCalendarIdSettingsRouteWithChi
 
 interface ServerRequiredAuthenticatedCGuildIdRouteChildren {
   ServerRequiredAuthenticatedCGuildIdMarketplaceRoute: typeof ServerRequiredAuthenticatedCGuildIdMarketplaceRoute
+  ServerRequiredAuthenticatedCGuildIdMembersRoute: typeof ServerRequiredAuthenticatedCGuildIdMembersRoute
   ServerRequiredAuthenticatedCGuildIdSearchRoute: typeof ServerRequiredAuthenticatedCGuildIdSearchRoute
   ServerRequiredAuthenticatedCGuildIdSettingsRoute: typeof ServerRequiredAuthenticatedCGuildIdSettingsRouteWithChildren
   ServerRequiredAuthenticatedCGuildIdIndexRoute: typeof ServerRequiredAuthenticatedCGuildIdIndexRoute
@@ -3381,6 +3402,8 @@ const ServerRequiredAuthenticatedCGuildIdRouteChildren: ServerRequiredAuthentica
   {
     ServerRequiredAuthenticatedCGuildIdMarketplaceRoute:
       ServerRequiredAuthenticatedCGuildIdMarketplaceRoute,
+    ServerRequiredAuthenticatedCGuildIdMembersRoute:
+      ServerRequiredAuthenticatedCGuildIdMembersRoute,
     ServerRequiredAuthenticatedCGuildIdSearchRoute:
       ServerRequiredAuthenticatedCGuildIdSearchRoute,
     ServerRequiredAuthenticatedCGuildIdSettingsRoute:

--- a/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/members.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/members.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+import { validatePage } from "@/lib/routeSearch";
+
+/** What the reader is looking for and how far in. Both stay out of the URL at
+ *  their defaults, so a plain `/members` is the first page of everybody. */
+export interface GuildMembersSearch {
+  q?: string;
+  page?: number;
+}
+
+export const Route = createFileRoute("/_serverRequired/_authenticated/c/$guildId/members")({
+  validateSearch: (search: Record<string, unknown>): GuildMembersSearch => ({
+    q: typeof search.q === "string" && search.q.length > 0 ? search.q : undefined,
+    page: validatePage(search.page),
+  }),
+  component: lazyRouteComponent(() =>
+    import("@/pages/GuildMembersPage").then((m) => ({ default: m.GuildMembersPage }))
+  ),
+});


### PR DESCRIPTION
## Problem

The member count on a community's banner said how many people were here and went nowhere. Everything needed to talk to somebody now exists — connections, message requests, the DM surface — but the only ways to find a person were to already know their handle or to meet them in a tool. A community that lists its members is the missing front door.

Two bugs fell out of building it, both fixed here.

## Changes

### The page

- **`/c/$guildId/members`** — [GuildMembersPage](frontend/src/pages/GuildMembersPage.tsx), a paged, searchable roster on `DataTable` with the table's own filter bar (controlled, because the search is answered by the server — its client filter would only narrow the twenty-five rows on screen) and its column menu, remembered per reader. Search and page both live in the address, so a roster somebody is halfway through is a link they can send.
- Each row: the person (linking to their profile), their name where the community discloses names, an **Admin** badge on the exception only, and the actions — [ContactActionButtons](frontend/src/components/contacts/ContactActionButtons.tsx), a favourite star, and an overflow holding ignore.
- The **member count badge** now leads there ([GuildBannerBadges](frontend/src/components/guildHome/GuildBannerBadges.tsx)), and the rail's **View members** goes there too — out of the `isAdmin` block, since the roster is member-visible. Managing members is still an admin's and still reached through guild settings.

### Reads the roster, not the reachable

It reads `GET /g/{id}/users/search`, which already answers this for any member (`RLSSessionDep` + `GuildContextDep`, no admin gate) and already honours the guild's `show_member_names`.

Deliberately **not** `/me/contacts`, which runs `dm_listable_in_guild` and answers a different question: who this reader may *message*. A members page built on that drops everybody who takes no messages, which is a members page missing members. Somebody unreachable is listed like anyone else and simply offers nothing to click — they are here, and they are not reachable, and the page says both.

### `dm-permission` says whether a connection would be taken

Connecting and messaging are separate rules — `dm_may_connect` vs `dm_apparent_permission` — so the value the UI already had said nothing about the first, and **Connect was offered where the server answers 409**. The endpoint now carries `may_connect` beside `permission`.

That endpoint is deliberately oracle-resistant, so before adding a second field I checked it cannot tell the refusals apart: `dm_may_connect` is `dm_reachable(actor) AND dm_reachable(target)`, both per-account, no pair state, so it says nothing about being ignored. [A test pins that](backend/app/api/v1/platform_endpoints/dm_test.py).

### `UserSummary` carries what it takes to draw a person

`profile_decorations` and `guild_role`, so a roster shows the frame somebody wears and marks the admins. A decoration is an id naming a catalog entry and a role is one word, so both are short, and the role comes off the join the query already makes. Its docstring is rewritten to describe the shape it now is rather than the one it was.

### Fixes

- **A profile's community cards counted nobody.** [read_user_communities](backend/app/api/v1/platform_endpoints/users.py) built each card without `member_count`, so every one took the schema default of 0 — never true of a community somebody belongs to. Added `count_members_by_guild` beside the existing single-guild count, one grouped query for the set.
- **The actions were offered twice.** `ContactActionsMenu` repeated Message / Connect / Ask to message next to the buttons that already show them — on this page and, since I added the buttons, on the profile. It now takes `reachOffered` and keeps only what is its own.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm check` — clean
- `cd frontend && pnpm test:run` — 2625 passed, 238 files
- `cd backend && uv run ruff check app` — clean
- `cd backend && uv run pytest -n 0 app/api/v1/platform_endpoints/users_test.py` — 95 passed
- `cd backend && uv run pytest -n 0 app/api/v1/platform_endpoints/contacts_test.py` — 27 passed
- `cd backend && uv run pytest -n 0 app/api/v1/platform_endpoints/guilds_community_test.py app/api/v1/platform_endpoints/dm_test.py` — passing
- Generated types re-exported from the backend spec and committed.

Task: https://initiative.morels.me/c/3/i/5/projects/1/tasks/2860