### PR TITLE
Fit dialogs to the screen they open on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dialogs fit the phone they open on.** Create dialogs were cut off down the right-hand side on a narrow screen — the sharing card, and with it the access level, sat off the edge. Two causes: the dialog's grid would not let its contents shrink to it, and a dialog asking for its own width dropped the screen-width cap at every size rather than only on a wide one. Both are fixed for every dialog in the app, not just the ones anybody noticed.
+
 - **A profile's communities say how many people are in them.** Each card counted nobody, because the profile's own read never asked for the number — a community somebody belongs to has at least one member, so "0 members" was never true.
 
 - **Everyone in a community hears that it was listed.** The notice that a community joined the directory — which is what asks its members their age — only reached people whose tab happened to be held by the same server process that made the change. On a deployment running more than one, everybody else waited until they next navigated.

--- a/frontend/src/components/NativeUpdateRequiredDialog.tsx
+++ b/frontend/src/components/NativeUpdateRequiredDialog.tsx
@@ -31,7 +31,7 @@ export const NativeUpdateRequiredDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t("version.nativeUpdateRequiredTitle")}</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/VersionDialog.tsx
+++ b/frontend/src/components/VersionDialog.tsx
@@ -46,7 +46,7 @@ export const VersionDialog = ({
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="flex h-[80vh] max-w-2xl flex-col gap-0">
+      <DialogContent className="flex h-[80vh] flex-col gap-0 sm:max-w-2xl">
         <DialogHeader className="shrink-0">
           <DialogTitle>{t("version.versionInformation")}</DialogTitle>
           <DialogDescription>{t("version.currentVersionAndChangelog")}</DialogDescription>

--- a/frontend/src/components/access/ShareControl.tsx
+++ b/frontend/src/components/access/ShareControl.tsx
@@ -267,13 +267,17 @@ export const ShareControl = ({
   // ─────────────────────────────────────────────────────────────────────────
 
   return (
-    <div className="space-y-4">
+    <div className="min-w-0 space-y-4">
       {/* ── Share ─────────────────────────────────────────────────────── */}
       <div className="space-y-2">
         <Label className="font-medium text-sm">{t("share.title")}</Label>
         <div
           className={cn(
-            "flex items-center gap-3 rounded-lg border px-3 py-2.5",
+            // Wraps rather than overflows: the level select is a fixed 120px
+            // and the labels are translated, so on a narrow dialog the two
+            // cannot always share a line. Wrapping puts the select underneath;
+            // not wrapping put it off the side of the screen.
+            "flex flex-wrap items-center gap-3 rounded-lg border px-3 py-2.5",
             mode === "all"
               ? "border-green-200 bg-green-50 dark:border-green-900/40 dark:bg-green-950/30"
               : "bg-muted/40"
@@ -295,7 +299,7 @@ export const ShareControl = ({
               <button
                 type="button"
                 disabled={disabled}
-                className="flex min-w-0 flex-1 flex-col text-left focus:outline-none disabled:cursor-not-allowed"
+                className="flex min-w-[8rem] flex-1 flex-col text-left focus:outline-none disabled:cursor-not-allowed"
               >
                 <span className="flex items-center gap-1">
                   <span className="truncate font-medium text-sm">

--- a/frontend/src/components/admin/AdminDeleteUserDialog.tsx
+++ b/frontend/src/components/admin/AdminDeleteUserDialog.tsx
@@ -252,7 +252,7 @@ export function AdminDeleteUserDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>{t("adminDeleteUser.subtitle", { email: displayName })}</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/announcements/AnnouncementDialog.tsx
+++ b/frontend/src/components/announcements/AnnouncementDialog.tsx
@@ -102,7 +102,7 @@ export const AnnouncementDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] max-w-2xl flex-col gap-0">
+      <DialogContent className="flex max-h-[85vh] flex-col gap-0 sm:max-w-2xl">
         <DialogHeader className="shrink-0 space-y-2">
           <div className="flex items-center gap-2">
             <Badge variant="secondary" className="gap-1.5">

--- a/frontend/src/components/announcements/AnnouncementEditorDialog.tsx
+++ b/frontend/src/components/announcements/AnnouncementEditorDialog.tsx
@@ -240,7 +240,7 @@ export const AnnouncementEditorDialog = ({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="flex max-h-[90vh] max-w-3xl flex-col gap-0">
+        <DialogContent className="flex max-h-[90vh] flex-col gap-0 sm:max-w-3xl">
           <DialogHeader className="shrink-0">
             <DialogTitle>{announcement ? t("admin.editTitle") : t("admin.newTitle")}</DialogTitle>
             <DialogDescription>{t("admin.editorSubtitle")}</DialogDescription>

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -216,7 +216,7 @@ export const CreateDocumentDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+      <DialogContent className="max-h-screen w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("create.title")}</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/documents/CreateDocumentWizard.tsx
+++ b/frontend/src/components/documents/CreateDocumentWizard.tsx
@@ -220,7 +220,7 @@ export const CreateDocumentWizard = () => {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t("createWizard.title")}</DialogTitle>
           <DialogDescription>{stepTitle}</DialogDescription>

--- a/frontend/src/components/exports/ExportWizard.tsx
+++ b/frontend/src/components/exports/ExportWizard.tsx
@@ -161,7 +161,7 @@ export function ExportWizard({ scope, initiativeId, open, onOpenChange }: Export
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             {scope === "guild" ? t("wizard.titleGuild") : t("wizard.titleInitiative")}

--- a/frontend/src/components/guilds/TransferContentOwnershipDialog.tsx
+++ b/frontend/src/components/guilds/TransferContentOwnershipDialog.tsx
@@ -155,7 +155,7 @@ export const TransferContentOwnershipDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             {isClaim ? t("transferOwnership.claimTitle") : t("transferOwnership.title")}

--- a/frontend/src/components/import/TickTickImportDialog.tsx
+++ b/frontend/src/components/import/TickTickImportDialog.tsx
@@ -202,7 +202,7 @@ export const TickTickImportDialog = ({ open, onOpenChange }: TickTickImportDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("ticktick.title")}</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/import/TodoistImportDialog.tsx
+++ b/frontend/src/components/import/TodoistImportDialog.tsx
@@ -186,7 +186,7 @@ export const TodoistImportDialog = ({ open, onOpenChange }: TodoistImportDialogP
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("todoist.title")}</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/import/VikunjaImportDialog.tsx
+++ b/frontend/src/components/import/VikunjaImportDialog.tsx
@@ -210,7 +210,7 @@ export const VikunjaImportDialog = ({ open, onOpenChange }: VikunjaImportDialogP
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("vikunja.title")}</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/imports/DataJobsTable.tsx
+++ b/frontend/src/components/imports/DataJobsTable.tsx
@@ -227,7 +227,7 @@ export function DataJobsTable() {
         </TableBody>
       </Table>
       <Dialog open={reportJob != null} onOpenChange={(open) => !open && setReportJob(null)}>
-        <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>{t("imports:table.reportTitle")}</DialogTitle>
           </DialogHeader>

--- a/frontend/src/components/imports/ImportWizard.tsx
+++ b/frontend/src/components/imports/ImportWizard.tsx
@@ -187,7 +187,7 @@ export function ImportWizard({ open, onOpenChange }: ImportWizardProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("wizard.title")}</DialogTitle>
           {step === "pick" && <DialogDescription>{t("wizard.pick.hint")}</DialogDescription>}

--- a/frontend/src/components/initiativeTools/counters/CounterFormDialog.tsx
+++ b/frontend/src/components/initiativeTools/counters/CounterFormDialog.tsx
@@ -134,7 +134,7 @@ export const CounterFormDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+      <DialogContent className="max-h-screen w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{isEdit ? t("editCounter") : t("addCounter")}</DialogTitle>
           <DialogDescription>{t("counterFormDescription")}</DialogDescription>

--- a/frontend/src/components/initiativeTools/events/CreateCalendarDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateCalendarDialog.tsx
@@ -117,7 +117,7 @@ export const CreateCalendarDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+      <DialogContent className="max-h-[90vh] w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("createCalendar")}</DialogTitle>
         </DialogHeader>

--- a/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/CreateEventDialog.tsx
@@ -256,7 +256,7 @@ export const CreateEventDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+      <DialogContent className="max-h-[90vh] w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("createEvent")}</DialogTitle>
         </DialogHeader>

--- a/frontend/src/components/initiativeTools/events/ICalImportDialog.tsx
+++ b/frontend/src/components/initiativeTools/events/ICalImportDialog.tsx
@@ -140,7 +140,7 @@ export const ICalImportDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("calendars:import.title")}</DialogTitle>
           <DialogDescription>{t("calendars:import.uploadDescription")}</DialogDescription>

--- a/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/AddQueueItemDialog.tsx
@@ -99,7 +99,7 @@ export const AddQueueItemDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+      <DialogContent className="max-h-screen w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t("addItem")}</DialogTitle>
           <DialogDescription>{t("noItemsDescription")}</DialogDescription>

--- a/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
+++ b/frontend/src/components/initiativeTools/queues/EditQueueItemDialog.tsx
@@ -167,7 +167,7 @@ export const EditQueueItemDialog = ({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+        <DialogContent className="max-h-screen w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>{t("editItem")}</DialogTitle>
             <DialogDescription>{item.label}</DialogDescription>

--- a/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
+++ b/frontend/src/components/initiativeTools/shared/CreateToolDialog.tsx
@@ -153,7 +153,7 @@ export const CreateToolDialog = <TRead,>({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+      <DialogContent className="max-h-screen w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{t(titleKey)}</DialogTitle>
           <DialogDescription>{t(descriptionKey)}</DialogDescription>

--- a/frontend/src/components/messages/NewConversationDialog.tsx
+++ b/frontend/src/components/messages/NewConversationDialog.tsx
@@ -132,7 +132,7 @@ export const NewConversationDialog = () => {
           <TooltipContent side="top">{t("messages:newConversation.trigger")}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <DialogContent className="max-w-md">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t("messages:newConversation.title")}</DialogTitle>
           <DialogDescription>{t("messages:newConversation.description")}</DialogDescription>

--- a/frontend/src/components/projects/ProjectDocumentsSection.tsx
+++ b/frontend/src/components/projects/ProjectDocumentsSection.tsx
@@ -182,7 +182,7 @@ export const ProjectDocumentsSection = ({
                     {t("documents.attachExisting")}
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="max-h-screen w-full max-w-lg overflow-y-auto rounded-2xl border bg-card shadow-2xl">
+                <DialogContent className="max-h-screen w-full overflow-y-auto rounded-2xl border bg-card shadow-2xl sm:max-w-lg">
                   <DialogHeader>
                     <DialogTitle>{t("documents.attachDocument")}</DialogTitle>
                     <DialogDescription>{t("documents.attachDialogDescription")}</DialogDescription>

--- a/frontend/src/components/tasks/CreateTaskWizard.tsx
+++ b/frontend/src/components/tasks/CreateTaskWizard.tsx
@@ -319,7 +319,7 @@ export const CreateTaskWizard = () => {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t("createWizard.title")}</DialogTitle>
           <DialogDescription>{stepTitle}</DialogDescription>

--- a/frontend/src/components/ui/dialog.test.tsx
+++ b/frontend/src/components/ui/dialog.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * A dialog fits the phone it is opened on.
+ *
+ * Two rules, both of which were broken and both of which are invisible until
+ * somebody opens a dialog on a narrow screen:
+ *
+ * 1. The content box is a grid, so its children are grid items with
+ *    `min-width: auto` — a nowrap row or an editor toolbar sets a content
+ *    minimum wider than the dialog and spills out of it rather than shrinking.
+ * 2. A caller that sets an unprefixed `max-w-*` replaces the base viewport cap
+ *    at *every* width, so the dialog loses its margins on mobile. Widths belong
+ *    behind `sm:`, where the base `max-w-[calc(100%-2rem)]` still governs
+ *    below it.
+ *
+ * These are asserted against the classes rather than a layout, because jsdom
+ * does no layout — which is exactly why neither was caught by the suite.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
+
+const SRC = path.resolve(__dirname, "../..");
+
+describe("DialogContent", () => {
+  it("lets its grid children shrink instead of overflowing", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Anything</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    );
+
+    const content = screen.getByRole("dialog");
+    expect(content.className).toContain("[&>*]:min-w-0");
+  });
+
+  it("keeps the viewport cap when a caller sets its own width", () => {
+    render(
+      <Dialog open>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogTitle>Anything</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    );
+
+    const content = screen.getByRole("dialog");
+    // Both survive: the base governs below `sm`, the caller's above it.
+    expect(content.className).toContain("max-w-[calc(100%-2rem)]");
+    expect(content.className).toContain("sm:max-w-2xl");
+  });
+
+  // The class-merge rule the case above relies on, enforced across the app: an
+  // unprefixed width silently drops the base cap, and every dialog that did
+  // that was edge-to-edge on a phone.
+  it("no dialog sets an unprefixed max width", () => {
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.name.endsWith(".tsx")) {
+          const source = fs.readFileSync(full, "utf-8");
+          for (const match of source.matchAll(/<DialogContent\s+className="([^"]*)"/g)) {
+            if (/(?:^|\s)max-w-(?:xs|sm|md|lg|xl|\dxl)(?:\s|$)/.test(match[1])) {
+              offenders.push(`${path.relative(SRC, full)}: ${match[1]}`);
+            }
+          }
+        }
+      }
+    };
+    walk(SRC);
+
+    expect(offenders, `put these behind sm: — ${offenders.join(", ")}`).toEqual([]);
+  });
+});

--- a/frontend/src/components/ui/dialog.test.tsx
+++ b/frontend/src/components/ui/dialog.test.tsx
@@ -57,7 +57,17 @@ describe("DialogContent", () => {
   // The class-merge rule the case above relies on, enforced across the app: an
   // unprefixed width silently drops the base cap, and every dialog that did
   // that was edge-to-edge on a phone.
-  it("no dialog sets an unprefixed max width", () => {
+  //
+  // What counts as an offender is a *fixed* length — `max-w-lg`, `max-w-md`,
+  // `max-w-[32rem]`. A width relative to the viewport (`max-w-[90vw]`) or to
+  // the containing block (`max-w-full`, `max-w-[95%]`) still fits the screen it
+  // opens on, so it is not this bug even unprefixed.
+  //
+  // `max-w-none` drops the cap outright, which is only safe when the element
+  // bounds itself another way — `w-[min(72rem,95vw)]` is already viewport-
+  // bounded, so lifting the max is what makes that width apply. Flagged only
+  // when nothing else holds it in.
+  it("no dialog sets an unprefixed fixed max width", () => {
     const offenders: string[] = [];
     const walk = (dir: string) => {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -67,8 +77,21 @@ describe("DialogContent", () => {
         } else if (entry.name.endsWith(".tsx")) {
           const source = fs.readFileSync(full, "utf-8");
           for (const match of source.matchAll(/<DialogContent\s+className="([^"]*)"/g)) {
-            if (/(?:^|\s)max-w-(?:xs|sm|md|lg|xl|\dxl)(?:\s|$)/.test(match[1])) {
-              offenders.push(`${path.relative(SRC, full)}: ${match[1]}`);
+            const classes = match[1].split(/\s+/);
+            // Does the element bound its own width against the viewport?
+            const selfBounded = classes.some(
+              (cls) => !cls.includes(":") && /^w-(?:full|\[.*(?:vw|%).*\])$/.test(cls)
+            );
+            for (const cls of classes) {
+              // Anything behind a breakpoint or state is fine — the base cap
+              // still governs below it.
+              if (cls.includes(":") || !cls.startsWith("max-w-")) continue;
+              const value = cls.slice("max-w-".length);
+              const fitsAnyway =
+                value === "full" || /v[wh]|%/.test(value) || (value === "none" && selfBounded);
+              if (!fitsAnyway) {
+                offenders.push(`${path.relative(SRC, full)}: ${cls}`);
+              }
             }
           }
         }

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -48,7 +48,15 @@ const DialogContent = React.forwardRef<
       ref={ref}
       data-slot="dialog-content"
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg",
+        // `[&>*]:min-w-0` is load-bearing, not cosmetic. This is a grid, so every
+        // direct child is a grid item with `min-width: auto` — its automatic
+        // minimum is its *content's* minimum, which a nowrap row, a long
+        // unbroken word or an editor toolbar can push past the dialog's own
+        // width. The item then overflows the box rather than shrinking inside
+        // it, and on a phone the right-hand side of every field is simply cut
+        // off. Resetting the floor lets children shrink to the dialog and
+        // clip/wrap on their own terms.
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg [&>*]:min-w-0",
         className
       )}
       {...props}

--- a/frontend/src/components/user/DeleteAccountDialog.tsx
+++ b/frontend/src/components/user/DeleteAccountDialog.tsx
@@ -180,7 +180,7 @@ export function DeleteAccountDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>
             {/* When the dialog was opened with a specific action (the


### PR DESCRIPTION
## Problem

Create dialogs were clipped down the right-hand side on a phone. The sharing card — and with it the access-level select — sat off the edge of the screen, so you could not see or change who a new thing was shared with.


## Cause

Two independent bugs, both affecting **every** dialog in the app, not only the ones anybody noticed:

1. **`DialogContent` is a `grid`**, so its direct children are grid items with `min-width: auto`. Their automatic minimum is their *content's* minimum — a nowrap row, a long unbroken word, an editor toolbar — which can exceed the dialog's own width. The item then overflows the box rather than shrinking inside it.

2. **25 dialogs set an unprefixed `max-w-*`** (`max-w-lg`, `max-w-md`, `max-w-2xl`, …). Tailwind-merge keeps the last `max-w-*`, so that replaced the base `max-w-[calc(100%-2rem)]` at *every* width instead of only above `sm` — losing the viewport inset on mobile.

## Changes

- `DialogContent` gains `[&>*]:min-w-0`, so children shrink to the dialog and clip or wrap on their own terms.
- Every unprefixed dialog width moved behind `sm:`, where the base cap still governs below it.
- The share card wraps: its level select is a fixed 120px beside a translated label, so on a narrow dialog the two cannot always share a line. Wrapping puts the select underneath; not wrapping put it off the side of the screen. The mode trigger keeps an `8rem` floor so the label does not collapse before the select has wrapped away.

## Testing

```
pnpm typecheck          # clean
pnpm biome check src    # clean (1 pre-existing warning, untouched)
pnpm test:run           # 240 files, 2690 tests, all pass
```

New `src/components/ui/dialog.test.tsx` pins both rules, including one that **fails if any dialog reintroduces an unprefixed width**. Asserted against classes rather than layout on purpose: jsdom does no layout, which is exactly why neither cause was visible to the existing suite.

## Notes

No schema or env changes. Split out of the Posts branch because it is independent of that work and worth landing on its own.
