### PR TITLE
Stop the app shell from scrolling sideways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The app's scrollbar is back at the edge of the app.** It had moved into the middle of the window, floating beside the centred column rather than running down the side — and any page with something a little too wide dragged the whole app sideways. The shell scrolls; it no longer also decides how wide a page is.
+
 - **A profile's communities say how many people are in them.** Each card counted nobody, because the profile's own read never asked for the number — a community somebody belongs to has at least one member, so "0 members" was never true.
 
 - **Everyone in a community hears that it was listed.** The notice that a community joined the directory — which is what asks its members their age — only reached people whose tab happened to be held by the same server process that made the change. On a deployment running more than one, everybody else waited until they next navigated.

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -313,7 +313,23 @@ function AppLayout() {
                   data-scroll-restoration-id="app-main"
                   className="min-w-0 flex-1 overflow-y-auto overflow-x-clip"
                 >
-                  <div className="container mx-auto p-4 pb-24 md:p-8 md:pb-24">
+                  {/* A grid, and `min-h-full` rather than `h-full`, because
+                      this sits between the scrollport and the page and must
+                      pass a height through without capping one.
+
+                      `h-full` would fix it at the scrollport's height, and a
+                      page taller than that would spill past its own bottom
+                      padding. `min-h-full` alone grows correctly but leaves
+                      `height: auto`, and a percentage height resolves against
+                      the parent's *height* — so `h-full` on a page would
+                      silently become `auto`. Three pages depend on that chain
+                      (My Messages, a document, an app surface): each pins
+                      something to an edge and needs a real height to do it.
+
+                      A grid row is definite either way. It is at least the
+                      scrollport, grows with a long page, and gives a child's
+                      `h-full` an area to resolve against. */}
+                  <div className="container mx-auto grid min-h-full grid-rows-[1fr] p-4 pb-24 md:p-8 md:pb-24">
                     <Suspense fallback={<PageLoader />}>
                       <Outlet />
                     </Suspense>

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -289,17 +289,35 @@ function AppLayout() {
                     backgroundSize: "37px 64px",
                   }}
                 />*/}
+                {/* The app's scroller. Named twice over: the router restores
+                    this element's position across navigations rather than the
+                    window's, and pull-to-refresh asks it how far down it is.
+
+                    It spans the row and holds the page's width inside it,
+                    rather than being that width itself. A scrollbar renders at
+                    the edge of its own scrollport, so a scroller that was also
+                    `container mx-auto` put the bar in the middle of the window
+                    — floating beside the centred column instead of down the
+                    side of the app.
+
+                    `overflow-x-clip` because `overflow-y: auto` alone does not
+                    stay on one axis: with the other left `visible`, CSS
+                    computes that one to `auto` too, quietly making the shell a
+                    horizontal scroller. Anything anywhere that overran then
+                    dragged the whole app sideways. Wide content owns its own
+                    scroller here — the tool rail and every table already do —
+                    so the shell says no to the axis rather than offering a bar
+                    nothing should need. */}
                 <main
-                  // The app's scroller. Named twice over: the router restores
-                  // this element's position across navigations rather than the
-                  // window's, and pull-to-refresh asks it how far down it is.
                   data-app-scroll=""
                   data-scroll-restoration-id="app-main"
-                  className="container mx-auto min-w-0 overflow-y-auto p-4 pb-24 md:p-8 md:pb-24"
+                  className="min-w-0 flex-1 overflow-y-auto overflow-x-clip"
                 >
-                  <Suspense fallback={<PageLoader />}>
-                    <Outlet />
-                  </Suspense>
+                  <div className="container mx-auto p-4 pb-24 md:p-8 md:pb-24">
+                    <Suspense fallback={<PageLoader />}>
+                      <Outlet />
+                    </Suspense>
+                  </div>
                 </main>
               </div>
             </div>

--- a/frontend/src/routes/appScroller.test.ts
+++ b/frontend/src/routes/appScroller.test.ts
@@ -19,11 +19,20 @@ import { describe, expect, it } from "vitest";
 
 const SHELL = path.resolve(__dirname, "./_serverRequired/_authenticated.tsx");
 
+const shellSource = (): string => fs.readFileSync(SHELL, "utf-8");
+
 /** The `<main>` carrying `data-app-scroll`, as written. */
 const scrollerTag = (): string => {
-  const source = fs.readFileSync(SHELL, "utf-8");
-  const match = source.match(/<main\b[^>]*data-app-scroll[^>]*>/s);
+  const match = shellSource().match(/<main\b[^>]*data-app-scroll[^>]*>/s);
   if (!match) throw new Error("no [data-app-scroll] <main> in the app shell");
+  return match[0];
+};
+
+/** The first element inside that `<main>` — the one holding the page width. */
+const contentTag = (): string => {
+  const after = shellSource().split(scrollerTag())[1] ?? "";
+  const match = after.match(/<div\b[^>]*>/s);
+  if (!match) throw new Error("the app scroller has no content wrapper");
   return match[0];
 };
 
@@ -47,5 +56,27 @@ describe("the app scroller", () => {
 
   it("still spans the row it sits in", () => {
     expect(scrollerTag()).toMatch(/\bflex-1\b/);
+  });
+
+  // Taking the width off the scroller is only half of it: the width has to
+  // land somewhere, or every page goes edge to edge.
+  it("hands the page width to the wrapper inside it", () => {
+    const tag = contentTag();
+    expect(tag).toMatch(/\bcontainer\b/);
+    expect(tag).toMatch(/\bmx-auto\b/);
+  });
+
+  // That wrapper sits between the scrollport and the page, so it has to pass a
+  // height through without capping one. `h-full` would fix it at the
+  // scrollport and a long page would spill past its own bottom padding;
+  // `min-h-full` alone leaves `height: auto`, and a page's own `h-full` would
+  // resolve against that and become auto. A grid row is definite either way.
+  it("passes a height through to full-height pages", () => {
+    const tag = contentTag();
+    expect(tag).toMatch(/\bmin-h-full\b/);
+    // `(?<![-\w])` so `min-h-full` is not read as `h-full`.
+    expect(tag).not.toMatch(/(?<![-\w])h-full\b/);
+    expect(tag).toMatch(/\bgrid\b/);
+    expect(tag).toMatch(/grid-rows-\[1fr\]/);
   });
 });

--- a/frontend/src/routes/appScroller.test.ts
+++ b/frontend/src/routes/appScroller.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The app shell scrolls; it does not also decide how wide a page is.
+ *
+ * Those two jobs were one element once, and both symptoms followed from it.
+ * A scrollbar renders at the edge of its own scrollport, so a scroller that
+ * was also `container mx-auto` put the bar beside the centred column instead
+ * of down the side of the app. And `overflow-y: auto` does not stay on one
+ * axis — with the other left `visible`, CSS computes that one to `auto` too,
+ * which quietly made the shell a horizontal scroller that anything overrunning
+ * anywhere could drag sideways.
+ *
+ * Asserted against the source because jsdom does no layout, which is why
+ * neither was visible to the suite.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SHELL = path.resolve(__dirname, "./_serverRequired/_authenticated.tsx");
+
+/** The `<main>` carrying `data-app-scroll`, as written. */
+const scrollerTag = (): string => {
+  const source = fs.readFileSync(SHELL, "utf-8");
+  const match = source.match(/<main\b[^>]*data-app-scroll[^>]*>/s);
+  if (!match) throw new Error("no [data-app-scroll] <main> in the app shell");
+  return match[0];
+};
+
+describe("the app scroller", () => {
+  it("scrolls vertically and refuses the other axis", () => {
+    const tag = scrollerTag();
+    expect(tag).toContain("overflow-y-auto");
+    // Not `overflow-x-auto`: wide content owns its own scroller (the tool
+    // rail, every table), so the shell never offers a horizontal bar.
+    expect(tag).toContain("overflow-x-clip");
+  });
+
+  it("is not also the thing that sets the page width", () => {
+    const tag = scrollerTag();
+    expect(
+      /\bcontainer\b/.test(tag),
+      "the scroller carries `container`, which puts its scrollbar beside the centred column"
+    ).toBe(false);
+    expect(/\bmx-auto\b/.test(tag)).toBe(false);
+  });
+
+  it("still spans the row it sits in", () => {
+    expect(scrollerTag()).toMatch(/\bflex-1\b/);
+  });
+});


### PR DESCRIPTION
## Problem

Two symptoms, one cause:

- The app's vertical scrollbar sat in the **middle of the window**, beside the centred column, instead of running down the side of the app.
- The community home page (and any page with something a little too wide) had a **horizontal scrollbar across the whole app**.

## Cause

[`c9936a22f`](https://github.com/Morelitea/initiative/commit/c9936a22f) (#1394) moved the app's scroll out of the document and into `<main>`, so a page could pin a header or a composer to an edge instead of measuring where that edge fell. That is the right shape — but it left `<main>` doing two jobs at once:

```diff
- <main className="container mx-auto min-w-0 p-4 pb-24 md:p-8 md:pb-24">
+ <main ... className="container mx-auto min-w-0 overflow-y-auto p-4 pb-24 md:p-8 md:pb-24">
```

1. **A scrollbar renders at the edge of its own scrollport.** The scroller was also `container mx-auto` — a max-width, horizontally centred — so the bar appeared at the edge of that centred column, floating in the middle of the window.

2. **`overflow-y: auto` does not stay on one axis.** With the other left `visible`, CSS computes that one to `auto` too. The shell silently became a *horizontal* scroller, so anything overrunning anywhere dragged the whole app sideways.

## Changes

`<main>` spans the row and holds the page's width inside it:

```tsx
<main data-app-scroll="" data-scroll-restoration-id="app-main"
      className="min-w-0 flex-1 overflow-y-auto overflow-x-clip">
  <div className="container mx-auto p-4 pb-24 md:p-8 md:pb-24">
```

`overflow-x-clip` rather than `auto` is deliberate: wide content owns its own scroller in this app — `ToolRail` (`overflow-x-auto` with `flex w-max min-w-full`) and every table (`ui/table` wraps in `overflow-auto`) already do — so the shell says no to the axis instead of offering a bar nothing should need.

Nothing about #1394's win is given up: `main` is still the scroller, so scroll restoration and `usePullToRefresh`'s `[data-app-scroll]` lookup are unaffected.

## Testing

```
pnpm typecheck          # clean
pnpm biome check src    # clean (1 pre-existing warning, untouched)
pnpm test:run           # 240 files, 2690 tests, all pass
```

New `src/routes/appScroller.test.ts` pins the separation: the scroller scrolls one axis, and is not also the element carrying `container`/`mx-auto`. Verified it fails against the pre-fix shell. Source-level on purpose — jsdom does no layout, which is why neither symptom was visible to the existing suite.

## Notes

No schema or env changes. Independent of the Posts branch; this is a `dev` bug that Posts merely happened to surface.