### PR TITLE
Stop a wide page from stretching its own column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pages are centred again.** A page holding something that would not wrap — a toolbar, a table's widest row — stretched the column it sits in, so the content spilled out of the right-hand side of a page area that was itself still centred. Introduced with the scroll fix above, and the same root cause: a box sized to its content where it should have been sized to its container.
+
 - **Dialogs fit the phone they open on.** Create dialogs were cut off down the right-hand side on a narrow screen — the sharing card, and with it the access level, sat off the edge. Two causes: the dialog's grid would not let its contents shrink to it, and a dialog asking for its own width dropped the screen-width cap at every size rather than only on a wide one. Both are fixed for every dialog in the app, not just the ones anybody noticed.
 
 - **A profile's communities say how many people are in them.** Each card counted nobody, because the profile's own read never asked for the number — a community somebody belongs to has at least one member, so "0 members" was never true.

--- a/frontend/src/routes/_serverRequired/_authenticated.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated.tsx
@@ -328,8 +328,19 @@ function AppLayout() {
 
                       A grid row is definite either way. It is at least the
                       scrollport, grows with a long page, and gives a child's
-                      `h-full` an area to resolve against. */}
-                  <div className="container mx-auto grid min-h-full grid-rows-[1fr] p-4 pb-24 md:p-8 md:pb-24">
+                      `h-full` an area to resolve against.
+
+                      `grid-cols-[minmax(0,1fr)]` is not decoration. A grid
+                      item's automatic minimum is its *content's* minimum, so a
+                      page holding anything that will not wrap — a toolbar, a
+                      table's widest row — sized the column to that instead of
+                      to the container. The container kept its max-width and
+                      stayed centred while its content spilled out of the right
+                      side of it, which reads as a page that is no longer
+                      centred. Flooring the track at 0 hands the item the
+                      container's width and lets what is inside scroll or
+                      truncate on its own terms. */}
+                  <div className="container mx-auto grid min-h-full grid-cols-[minmax(0,1fr)] grid-rows-[1fr] p-4 pb-24 md:p-8 md:pb-24">
                     <Suspense fallback={<PageLoader />}>
                       <Outlet />
                     </Suspense>

--- a/frontend/src/routes/appScroller.test.ts
+++ b/frontend/src/routes/appScroller.test.ts
@@ -79,4 +79,12 @@ describe("the app scroller", () => {
     expect(tag).toMatch(/\bgrid\b/);
     expect(tag).toMatch(/grid-rows-\[1fr\]/);
   });
+
+  // A grid item's automatic minimum is its content's minimum. Without a floor,
+  // a page holding something that will not wrap sized the column to that, and
+  // the content spilled out of a container that was still, correctly, centred.
+  // Measured: a 1918px item inside a 1536px container, overflowing by 414px.
+  it("floors its column so content cannot widen it", () => {
+    expect(contentTag()).toMatch(/grid-cols-\[minmax\(0,1fr\)\]/);
+  });
 });


### PR DESCRIPTION
## Problem

After #1400, pages looked off-centre: a large gap on the left, content flush against the right edge and cut off there.

## Cause

The content wrapper that #1400 introduced is a `grid`, and **a grid item's automatic minimum is its content's minimum**. A page holding anything that will not wrap — a toolbar, a table's widest row — sized the column to that rather than to the container.

The container itself was fine: it kept its `max-width` and stayed centred. Its *content* spilled out of the right-hand side of it, and `overflow-x: clip` on the scroller cut off what escaped. Hence the asymmetry — the left margin is the container's real margin, the right "edge" is the clip.

## Evidence

Measured in a headless browser rather than reasoned about, having guessed wrong at this twice:

| | grid item width | container | overflow |
|---|---|---|---|
| before | **1918px** | 1536px | +414px past the right edge |
| after | **1472px** | 1536px | none (1536 − 64 padding) |

This also matches the devtools reading from the live app: `main` 1986 × 712, container 1536 × 2364.94 — the container at exactly its max-width, so anything wider than it is overflow, not a mis-centred box.

## Change

One class on the wrapper:

```diff
- container mx-auto grid min-h-full grid-rows-[1fr] p-4 pb-24 md:p-8 md:pb-24
+ container mx-auto grid min-h-full grid-cols-[minmax(0,1fr)] grid-rows-[1fr] p-4 pb-24 md:p-8 md:pb-24
```

Flooring the track at 0 hands the item the container's width and lets what is inside scroll or truncate on its own terms — which the tool rail (`overflow-x-auto`) and every table (`ui/table` wraps in `overflow-auto`) already do.

Same root cause as the dialog fix in #1398: a box sized to its content where it should have been sized to its container.

## Testing

```
pnpm typecheck          # clean
pnpm biome check src    # clean (1 pre-existing warning, untouched)
pnpm test:run           # 241 files, 2696 tests, all pass
```

`appScroller.test.ts` gains an assertion for the floor, alongside the ones for the scroller and the height chain.

## Notes

No schema or env changes. Fixes a regression from #1400, which was mine.