### PR TITLE
Add a board widget to dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Anyone is its own group on My Contacts, under the communities.** Being open to anyone cannot be listed — it would be everybody here — so the group holds the part of it that means something: the people you are already messaging who no community you are in accounts for.
 
+- **A board widget for dashboards.** Tasks dealt into columns, and you choose what a column stands for: a status, the people on the work, priority, project, tag — or one of your initiative's own properties, so a board can be columned by a field we have never heard of. A value that exists and has nothing in it still gets its column, because a state nobody is in is usually the one worth seeing. Cards carry who is on the work, the due date and the checklist; anything past its date reads red and its column says how many. Read-only like every widget on a dashboard — a card is a card, not a handle, and moving work between states is still a project view's job.
+
 ### Changed
 
 - **My Projects and My Documents are one page: My Tools.** Two pages that were the same table for one tool each are now one. Pick a tool at the top and see everything of that kind that reaches you, across every community you're in, rather than one community at a time. A tool you have nothing of anywhere gets no tab, so the page never opens onto an empty table. A toggle switches the whole view between everything that reaches you and only what you made, and the tool, the search, the order, the page and the communities you're filtering to all ride in the address — so any view of it is a link you can send.

--- a/backend/app/services/tenant/dashboard_definition.py
+++ b/backend/app/services/tenant/dashboard_definition.py
@@ -214,6 +214,40 @@ WIDGET_SPECS: dict[str, WidgetSpec] = {
         sources=frozenset({"task_counts"}),
         options={"tone": _option("accent", "positive", "warning")},
     ),
+    # Tasks in columns. Display only, like every widget: a card cannot be
+    # dragged from one column to the next, because a dashboard reads and never
+    # writes — moving work is a project view's job.
+    "board": WidgetSpec(
+        min_w=4,
+        min_h=4,
+        default_w=12,
+        default_h=6,
+        sources=frozenset({"tasks"}),
+        options={
+            # What a column stands for. "property" columns by the custom
+            # property the binding names, which is how a board groups by
+            # something this build has never heard of — a team's own field.
+            "group": _option(
+                "status",
+                "status_category",
+                "assignee",
+                "priority",
+                "project",
+                "tag",
+                "property",
+            ),
+            # The order cards sit in within a column. Not the author's manual
+            # order: that is a position inside one project's board, and a
+            # binding spanning several has no single one to honour.
+            "sort": _option("due", "priority", "created", "updated", "title"),
+            # How much of a task a card carries.
+            "cards": _option("standard", "compact", "detailed"),
+            # Mark cards that need attention, in the negative tone.
+            "highlight": _option("overdue", "off"),
+            # Which column comes first.
+            "columns": _option("natural", "largest", "label"),
+        },
+    ),
     # A plain read-only table. Display only, like every widget: no row actions,
     # no inline editing — that is a project view's job, not a dashboard's.
     "table": WidgetSpec(

--- a/docs/en/guides/dashboards.md
+++ b/docs/en/guides/dashboards.md
@@ -6,7 +6,7 @@ icon: lucide/chart-line
 
 A **dashboard** is one screen that answers "how are we doing?" — without anybody having to open five things and do sums in their head first.
 
-It's a canvas of tiles — charts, single big numbers, timelines — each reading from your own data. Open tasks by status. Progress against a deadline. What's on this week. A counter's current value.
+It's a canvas of tiles — charts, single big numbers, timelines, boards — each reading from your own data. Open tasks by status. Progress against a deadline. What's on this week. A counter's current value.
 
 Whatever the person who keeps asking the question actually needs to see, so that they stop asking.
 
@@ -38,6 +38,14 @@ Usually faster than starting from a blank canvas, and often better, because some
 
 !!! tip "Steal a layout, then change it"
     A marketplace dashboard becomes an ordinary dashboard of yours the second you add it. Rename it, rearrange it, delete the tiles you don't like. Nothing phones home and nobody's feelings are hurt.
+
+### Boards
+
+One of the tiles is a **board**: your tasks dealt into columns, and you say what a column stands for. A status. The people on the work, so everyone gets a column and you can see who is carrying what. Priority, project, tag — or one of your initiative's own properties, which is how you end up with a board columned by "Squad" or "Sprint" or whatever your group actually argues about.
+
+A value that exists and has nothing in it still gets its column. An empty **Blocked** is information.
+
+Like everything else here it only displays. There's nothing to drag a card onto — moving work between states is still a project's job.
 
 ### Widgets from the marketplace
 

--- a/frontend/public/locales/de/dashboards.json
+++ b/frontend/public/locales/de/dashboards.json
@@ -152,7 +152,8 @@
     "appNotInstalled": "Diese App ist in dieser Community nicht installiert.",
     "appParamPlaceholder": "Wählen…",
     "appParamNeedsSibling": "Wähle zuerst den Wert darüber.",
-    "appParamListHint": "Werte durch Kommas trennen."
+    "appParamListHint": "Werte durch Kommas trennen.",
+    "all_property": "Keine Eigenschaft"
   },
   "picker": {
     "title": "Widget hinzufügen",
@@ -288,7 +289,9 @@
     "progress": "Fortschritt",
     "stage": "Stufe",
     "label": "Bezeichnung",
-    "column": "Spalte"
+    "column": "Spalte",
+    "card": "Karte",
+    "due": "Fällig"
   },
   "bindingParam": {
     "project": "Projekt",
@@ -302,7 +305,8 @@
     "source_id": "App-Datenquelle",
     "bucket": "Zählungen gruppieren nach",
     "day_field": "Jede Aufgabe zählen am",
-    "window_days": "Zeitfenster (Tage)"
+    "window_days": "Zeitfenster (Tage)",
+    "property": "Eigenschaft"
   },
   "paramValue": {
     "status_category": "Statuskategorie",

--- a/frontend/public/locales/en/dashboards.json
+++ b/frontend/public/locales/en/dashboards.json
@@ -152,7 +152,8 @@
     "appNotInstalled": "This app is not installed in this community.",
     "appParamPlaceholder": "Choose…",
     "appParamNeedsSibling": "Choose the value above first.",
-    "appParamListHint": "Separate values with commas."
+    "appParamListHint": "Separate values with commas.",
+    "all_property": "No property"
   },
   "picker": {
     "title": "Add a widget",
@@ -278,7 +279,9 @@
     "progress": "Progress",
     "stage": "Stage",
     "label": "Label",
-    "column": "Column"
+    "column": "Column",
+    "card": "Card",
+    "due": "Due"
   },
   "filterOp": {
     "eq": "is",
@@ -302,7 +305,8 @@
     "source_id": "App data source",
     "bucket": "Group counts by",
     "day_field": "Count each task on its",
-    "window_days": "Time window (days)"
+    "window_days": "Time window (days)",
+    "property": "Property"
   },
   "paramValue": {
     "status_category": "Status category",

--- a/frontend/public/locales/es/dashboards.json
+++ b/frontend/public/locales/es/dashboards.json
@@ -152,7 +152,8 @@
     "appNotInstalled": "Esta aplicación no está instalada en esta comunidad.",
     "appParamPlaceholder": "Elige…",
     "appParamNeedsSibling": "Elige primero el valor de arriba.",
-    "appParamListHint": "Separa los valores con comas."
+    "appParamListHint": "Separa los valores con comas.",
+    "all_property": "Sin propiedad"
   },
   "picker": {
     "title": "Añadir un widget",
@@ -288,7 +289,9 @@
     "progress": "Progreso",
     "stage": "Etapa",
     "label": "Etiqueta",
-    "column": "Columna"
+    "column": "Columna",
+    "card": "Tarjeta",
+    "due": "Vence"
   },
   "bindingParam": {
     "project": "Proyecto",
@@ -302,7 +305,8 @@
     "source_id": "Fuente de datos de la app",
     "bucket": "Agrupar los recuentos por",
     "day_field": "Contar cada tarea en su",
-    "window_days": "Ventana temporal (días)"
+    "window_days": "Ventana temporal (días)",
+    "property": "Propiedad"
   },
   "paramValue": {
     "status_category": "Categoría de estado",

--- a/frontend/public/locales/fr/dashboards.json
+++ b/frontend/public/locales/fr/dashboards.json
@@ -152,7 +152,8 @@
     "appNotInstalled": "Cette application n'est pas installée dans cette communauté.",
     "appParamPlaceholder": "Choisir…",
     "appParamNeedsSibling": "Choisissez d'abord la valeur ci-dessus.",
-    "appParamListHint": "Séparez les valeurs par des virgules."
+    "appParamListHint": "Séparez les valeurs par des virgules.",
+    "all_property": "Aucune propriété"
   },
   "picker": {
     "title": "Ajouter un widget",
@@ -288,7 +289,9 @@
     "progress": "Avancement",
     "stage": "Étape",
     "label": "Libellé",
-    "column": "Colonne"
+    "column": "Colonne",
+    "card": "Carte",
+    "due": "Échéance"
   },
   "bindingParam": {
     "project": "Projet",
@@ -302,7 +305,8 @@
     "source_id": "Source de données de l'application",
     "bucket": "Grouper les comptages par",
     "day_field": "Compter chaque tâche à sa",
-    "window_days": "Fenêtre temporelle (jours)"
+    "window_days": "Fenêtre temporelle (jours)",
+    "property": "Propriété"
   },
   "paramValue": {
     "status_category": "Catégorie de statut",

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -6129,6 +6129,7 @@ export interface WebhookSubscriptionUpdate {
 export type WidgetType = (typeof WidgetType)[keyof typeof WidgetType];
 
 export const WidgetType = {
+  board: "board",
   chart: "chart",
   funnel: "funnel",
   gantt: "gantt",

--- a/frontend/src/components/initiativeTools/dashboards/WidgetConfigDialog.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/WidgetConfigDialog.tsx
@@ -50,6 +50,7 @@ import { useCalendarsList } from "@/hooks/useCalendars";
 import { useCounterGroup, useCounterGroupsList } from "@/hooks/useCounters";
 import { useDocumentsList } from "@/hooks/useDocuments";
 import { useProjects } from "@/hooks/useProjects";
+import { useProperties } from "@/hooks/useProperties";
 import { useWidgetData, type WidgetBinding } from "@/hooks/useWidgetData";
 import { useWidgetMeta } from "@/hooks/useWidgetMeta";
 import { asControlValue, asDeclaredList, asDeclaredType } from "@/lib/widgets/appParams";
@@ -59,6 +60,7 @@ import { catalogEntry, type DefinitionWidget, isAppWidgetType } from "@/lib/widg
 import {
   type EntityKind,
   type EntityParam,
+  paramsFor,
   type SourceParam,
   sourceDescriptor,
 } from "@/lib/widgets/sources";
@@ -158,8 +160,12 @@ export function WidgetConfigDialog({
   // Which lists this source's controls need. Each is enabled only while its own
   // control is on screen, so opening the dialog for a counter widget does not
   // fetch this initiative's documents.
+  // Read from the parameters this *widget* offers, not the source's whole list:
+  // a table bound to tasks is never shown the property picker, so it must not
+  // fetch the definitions behind it either.
+  const params = widget ? paramsFor(source, widget.type) : [];
   const needs = (kind: EntityKind) =>
-    open && (descriptor?.params ?? []).some((p) => p.kind === "entity" && p.entity === kind);
+    open && params.some((p) => p.kind === "entity" && p.entity === kind);
 
   const counterGroups = useCounterGroupsList(
     { initiative_id: initiativeId },
@@ -174,6 +180,7 @@ export function WidgetConfigDialog({
     { initiative_id: initiativeId },
     { enabled: needs("calendar") }
   );
+  const properties = useProperties({ initiativeId, enabled: needs("property") });
   // The list endpoint returns group summaries; the counters themselves come
   // from the group's own read, which is also the query the widget will use.
   const selectedGroup = useCounterGroup(binding.counter_group_id ?? null, {
@@ -201,6 +208,9 @@ export function WidgetConfigDialog({
         value: String(document.id),
         label: document.name,
       })),
+      property: (properties.data ?? [])
+        .filter((property) => property.initiative_id === initiativeId)
+        .map((property) => ({ value: String(property.id), label: property.name })),
     }),
     [
       projects.data,
@@ -208,6 +218,7 @@ export function WidgetConfigDialog({
       counterGroups.data,
       selectedGroup.data,
       documents.data,
+      properties.data,
       initiativeId,
     ]
   );
@@ -363,7 +374,7 @@ export function WidgetConfigDialog({
                 slots for it are `app_uid` and `endpoint_id`, and neither is a
                 thing to type: one comes from the widget's type, the other is a
                 choice among the reads the app declares. */}
-            {(isApp ? [] : (descriptor?.params ?? [])).map((param) => (
+            {(isApp ? [] : params).map((param) => (
               <ParamControl
                 key={param.key as string}
                 param={param}

--- a/frontend/src/components/initiativeTools/dashboards/scene/BoardNode.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/BoardNode.tsx
@@ -1,0 +1,105 @@
+import { formatAxisValue } from "@/lib/widgets/format";
+import type { BoardCard, SceneNode } from "@/lib/widgets/sceneSpec";
+import { toneColor } from "@/lib/widgets/tone";
+
+type Node = Extract<SceneNode, { kind: "board" }>;
+
+/**
+ * Rows dealt into columns.
+ *
+ * What a column stands for was decided by the widget and arrives already made,
+ * so nothing here knows about statuses or assignees — it draws columns of cards
+ * and a count per column, and that is the whole contract.
+ *
+ * Read-only, and visibly so: a card is a `<div>`, not a drag handle. A
+ * dashboard reads and never writes, so there is nothing to drop a card onto and
+ * no affordance suggesting otherwise.
+ */
+export function BoardNode({ node }: { node: Node }) {
+  return (
+    <div className="flex h-full w-full gap-2 overflow-x-auto overflow-y-hidden pb-1">
+      {node.columns.map((column, index) => (
+        <Column
+          // biome-ignore lint/suspicious/noArrayIndexKey: two columns can carry the same label (a board grouped by a property with duplicate option labels), so position is the only identity a column has
+          key={index}
+          column={column}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Column({ column }: { column: Node["columns"][number] }) {
+  const count = column.total ?? column.cards.length;
+  return (
+    <section
+      className="flex h-full w-56 min-w-56 flex-col rounded-md bg-muted/40"
+      aria-label={column.label}
+    >
+      <header className="flex shrink-0 items-baseline gap-2 px-2 py-1.5">
+        <h4 className="min-w-0 flex-1 truncate font-medium text-xs">{column.label}</h4>
+        {column.caption && (
+          <span className="shrink-0 text-[11px] text-muted-foreground">{column.caption}</span>
+        )}
+        <span className="shrink-0 text-muted-foreground text-xs tabular-nums">{count}</span>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto px-1.5 pb-1.5">
+        {column.cards.map((card, index) => (
+          <Card
+            // biome-ignore lint/suspicious/noArrayIndexKey: scene cards carry no id — the widget already fixed the order, so position is the card's identity
+            key={index}
+            card={card}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Card({ card }: { card: BoardCard }) {
+  // The edge is the only place a card's tone is painted: a whole tinted card
+  // fights the theme's own surfaces, and a stripe reads at a glance.
+  const edge = card.tone ? toneColor(card.tone) : undefined;
+  return (
+    <article
+      className="overflow-hidden rounded border border-border/60 bg-card"
+      style={edge ? { borderLeftColor: edge, borderLeftWidth: 3 } : undefined}
+    >
+      <div className="px-2 py-1.5">
+        <p className="line-clamp-2 text-xs leading-snug">{card.title}</p>
+        {card.chips && card.chips.length > 0 && (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {card.chips.map((chip, index) => (
+              <span
+                // biome-ignore lint/suspicious/noArrayIndexKey: chips are plain strings a card may legitimately repeat, so position is their identity
+                key={index}
+                className="max-w-full truncate rounded-sm bg-muted px-1 py-px text-[10px] text-muted-foreground"
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+        )}
+        {(card.date !== undefined || card.caption) && (
+          <div className="mt-1 flex items-baseline justify-between gap-2 text-[10px] text-muted-foreground">
+            <span className="truncate">
+              {card.date === undefined ? "" : formatAxisValue(card.date, "date")}
+            </span>
+            {card.caption && <span className="shrink-0 tabular-nums">{card.caption}</span>}
+          </div>
+        )}
+      </div>
+      {card.progress !== undefined && (
+        <div className="h-0.5 w-full bg-muted">
+          <div
+            className="h-full"
+            style={{
+              width: `${Math.max(0, Math.min(1, card.progress)) * 100}%`,
+              backgroundColor: toneColor("accent"),
+            }}
+          />
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/components/initiativeTools/dashboards/scene/SceneRenderer.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/SceneRenderer.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/utils";
 import type { SceneNode } from "@/lib/widgets/sceneSpec";
 import { toneTextClass } from "@/lib/widgets/tone";
 
+import { BoardNode } from "./BoardNode";
 import { FunnelNode } from "./FunnelNode";
 import { MatrixNode } from "./MatrixNode";
 import { MetricNode } from "./MetricNode";
@@ -93,6 +94,8 @@ export const SceneRenderer = memo(function SceneRenderer({ node }: SceneNodeProp
       return <MatrixNode node={node} />;
     case "table":
       return <TableNode node={node} />;
+    case "board":
+      return <BoardNode node={node} />;
     case "text":
       return <TextNode node={node} />;
     case "empty":

--- a/frontend/src/hooks/useBindingLabels.ts
+++ b/frontend/src/hooks/useBindingLabels.ts
@@ -20,6 +20,7 @@ import { useCounterGroup } from "@/hooks/useCounters";
 import { useDocument } from "@/hooks/useDocuments";
 import { useInitiative } from "@/hooks/useInitiatives";
 import { useProjects } from "@/hooks/useProjects";
+import { useProperties } from "@/hooks/useProperties";
 import { useTags } from "@/hooks/useTags";
 import type { WidgetBinding } from "@/hooks/useWidgetData";
 import { getUserDisplayName } from "@/lib/userDisplay";
@@ -54,6 +55,7 @@ export function useBindingLabels(
   const needsDocument = scoped && binding.document_id != null;
   const needsMembers = scoped && fields.has("assignee_ids");
   const needsTags = scoped && fields.has("tag_ids");
+  const needsProperties = scoped && binding.property_id != null;
 
   const projects = useProjects(undefined, { enabled: needsProjects });
   const calendars = useCalendarsList({ initiative_id: initiativeId }, { enabled: needsCalendars });
@@ -61,6 +63,7 @@ export function useBindingLabels(
   const document = useDocument(needsDocument ? (binding.document_id ?? null) : null);
   const initiative = useInitiative(needsMembers ? (initiativeId ?? null) : null);
   const tags = useTags({ enabled: needsTags });
+  const properties = useProperties({ initiativeId, enabled: needsProperties });
 
   return useMemo<EntityLabels>(() => {
     if (!scoped) return EMPTY_LABELS;
@@ -73,6 +76,7 @@ export function useBindingLabels(
       document: new Map(),
       member: new Map(),
       tag: new Map(),
+      property: new Map(),
       // Nothing may be called unresolvable while a lookup that could still
       // resolve it is in flight.
       ready: ![
@@ -82,6 +86,7 @@ export function useBindingLabels(
         needsDocument && document.isLoading,
         needsMembers && initiative.isLoading,
         needsTags && tags.isLoading,
+        needsProperties && properties.isLoading,
       ].some(Boolean),
     };
 
@@ -104,6 +109,9 @@ export function useBindingLabels(
       labels.member.set(member.user.id, getUserDisplayName(member.user));
     }
     for (const tag of tags.data ?? []) labels.tag.set(tag.id, tag.name);
+    for (const property of properties.data ?? []) {
+      if (property.initiative_id === initiativeId) labels.property.set(property.id, property.name);
+    }
 
     return labels;
   }, [
@@ -115,6 +123,7 @@ export function useBindingLabels(
     needsDocument,
     needsMembers,
     needsTags,
+    needsProperties,
     projects.data,
     projects.isLoading,
     calendars.data,
@@ -127,5 +136,7 @@ export function useBindingLabels(
     initiative.isLoading,
     tags.data,
     tags.isLoading,
+    properties.data,
+    properties.isLoading,
   ]);
 }

--- a/frontend/src/hooks/useProperties.ts
+++ b/frontend/src/hooks/useProperties.ts
@@ -53,7 +53,7 @@ import type { MutationOpts } from "@/types/mutation";
  *   caller is a member of — used by global views (My Tasks, Documents list,
  *   events list) so property columns and filters aggregate across initiatives.
  */
-export const useProperties = (options?: { initiativeId?: number }) => {
+export const useProperties = (options?: { initiativeId?: number; enabled?: boolean }) => {
   const guildId = useActiveGuildId();
   const initiativeId = options?.initiativeId;
   const params: { initiative_id?: number } = {};
@@ -69,6 +69,7 @@ export const useProperties = (options?: { initiativeId?: number }) => {
         guildId,
         hasParams ? params : undefined
       ),
+    enabled: options?.enabled ?? true,
     staleTime: 60 * 1000,
   });
 };

--- a/frontend/src/hooks/useWidgetData.test.tsx
+++ b/frontend/src/hooks/useWidgetData.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/hooks/useCalendarEntries", () => ({ useCalendarEntries: () => idle })
 vi.mock("@/hooks/useCalendars", () => ({ useCalendarsList: () => idle }));
 vi.mock("@/hooks/useCounters", () => ({ useCounterGroup: () => idle }));
 vi.mock("@/hooks/useDocuments", () => ({ useDocument: () => idle }));
+vi.mock("@/hooks/useProperties", () => ({ useProperties: () => idle }));
 // Mocked like every other sibling: this file is about how a task binding
 // becomes a request, and the app hooks reach for guild context a bare
 // renderHook has no provider for.

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -28,6 +28,7 @@ import { useCalendarsList } from "@/hooks/useCalendars";
 import { useCounterGroup } from "@/hooks/useCounters";
 import { useDocument } from "@/hooks/useDocuments";
 import { useProjects } from "@/hooks/useProjects";
+import { useProperties } from "@/hooks/useProperties";
 import { useTasks } from "@/hooks/useTasks";
 import { expandConditions, readConditions } from "@/lib/widgets/conditions";
 import type { DataMeta, WidgetData, WidgetSource } from "@/lib/widgets/dataShapes";
@@ -44,6 +45,7 @@ import {
   normalizeProjects,
   normalizeSheetRange,
   normalizeTasks,
+  propertyDomain,
 } from "@/lib/widgets/normalize";
 
 /** A normalized definition binding. Everything past `source` is the fetcher's
@@ -60,6 +62,10 @@ export interface WidgetBinding {
   counter_id?: number | null;
   calendar_id?: number | null;
   document_id?: number | null;
+  /** Which of the initiative's custom properties a board deals its columns
+   *  from. Read by the `board` widget alone; every other widget bound to the
+   *  same rows ignores it. */
+  property_id?: number | null;
   sheet?: string | null;
   range?: string | null;
   bucket?: CountBucket | null;
@@ -210,6 +216,13 @@ export function useWidgetData(
   const documentQuery = useDocument(
     scoped && source === "sheet_range" ? (binding.document_id ?? null) : null
   );
+  // Only the *definitions*, and only when a binding names one: a property's
+  // values ride on the task rows already fetched, so this is here for the name
+  // and for what the property could say that nobody has said yet.
+  const propertiesQuery = useProperties({
+    initiativeId,
+    enabled: scoped && source === "tasks" && binding.property_id != null,
+  });
 
   // The app palette is one request per guild, shared by every app widget on the
   // canvas. It is what turns a binding's `app_uid` into an install id and tells
@@ -235,6 +248,7 @@ export function useWidgetData(
     }
     if (source === "counter" || source === "counter_group") void counterGroupQuery.refetch();
     if (source === "sheet_range") void documentQuery.refetch();
+    if (source === "tasks" && binding.property_id != null) void propertiesQuery.refetch();
     if (isApp) void appQuery.refetch();
   }, [
     source,
@@ -245,6 +259,8 @@ export function useWidgetData(
     calendarsQuery.refetch,
     counterGroupQuery.refetch,
     documentQuery.refetch,
+    propertiesQuery.refetch,
+    binding.property_id,
     appQuery.refetch,
   ]);
 
@@ -289,8 +305,19 @@ export function useWidgetData(
     switch (source) {
       case "tasks": {
         const rows = normalizeTasks(tasksQuery.data?.items ?? []);
+        // A property this viewer cannot resolve is simply absent, exactly like
+        // every other id a binding names: the rows still draw, and the widget
+        // says it has nothing to column by.
+        const definition = binding.property_id
+          ? (propertiesQuery.data ?? []).find((candidate) => candidate.id === binding.property_id)
+          : undefined;
         return {
-          data: { source, rows, meta: taskMeta },
+          data: {
+            source,
+            rows,
+            ...(definition ? { property: propertyDomain(definition) } : {}),
+            meta: taskMeta,
+          },
           isLoading: tasksQuery.isLoading,
           isUnbound: false,
           isRestricted: false,
@@ -505,8 +532,10 @@ export function useWidgetData(
     binding.counter_group_id,
     binding.counter_id,
     binding.document_id,
+    binding.property_id,
     binding.range,
     binding.sheet,
+    propertiesQuery.data,
     tasksQuery.data,
     tasksQuery.isLoading,
     projectsQuery.data,

--- a/frontend/src/lib/widgets/builtins/board.widget.js
+++ b/frontend/src/lib/widgets/builtins/board.widget.js
@@ -1,0 +1,453 @@
+/**
+ * What this widget calls itself, in every language it supports.
+ *
+ * Names and option labels live in the module rather than in the app's locale
+ * files: a marketplace widget has to be able to name itself without an app
+ * release, and the built-ins get no special treatment. Binding *source* labels
+ * stay app-owned — they name our endpoints and are shared by every widget.
+ */
+const meta = {
+  name: {
+    en: "Board",
+    de: "Board",
+    es: "Tablero",
+    fr: "Tableau",
+  },
+  description: {
+    en: "Tasks dealt into columns — by status, by who is on them, or by one of your own fields.",
+    de: "Aufgaben in Spalten — nach Status, nach zuständiger Person oder nach einem eigenen Feld.",
+    es: "Tareas repartidas en columnas: por estado, por quién las lleva o por un campo propio.",
+    fr: "Les tâches réparties en colonnes : par statut, par personne en charge ou selon l'un de vos champs.",
+  },
+  options: {
+    group: {
+      label: {
+        en: "Columns are",
+        de: "Spalten sind",
+        es: "Las columnas son",
+        fr: "Les colonnes sont",
+      },
+      values: {
+        status: { en: "Statuses", de: "Status", es: "Estados", fr: "Statuts" },
+        status_category: {
+          en: "Status categories",
+          de: "Statuskategorien",
+          es: "Categorías de estado",
+          fr: "Catégories de statut",
+        },
+        assignee: { en: "People", de: "Personen", es: "Personas", fr: "Personnes" },
+        priority: { en: "Priorities", de: "Prioritäten", es: "Prioridades", fr: "Priorités" },
+        project: { en: "Projects", de: "Projekte", es: "Proyectos", fr: "Projets" },
+        tag: { en: "Tags", de: "Tags", es: "Etiquetas", fr: "Étiquettes" },
+        property: {
+          en: "The property below",
+          de: "Die Eigenschaft unten",
+          es: "La propiedad de abajo",
+          fr: "La propriété ci-dessous",
+        },
+      },
+    },
+    sort: {
+      label: {
+        en: "Cards in order of",
+        de: "Karten sortiert nach",
+        es: "Tarjetas ordenadas por",
+        fr: "Cartes classées par",
+      },
+      values: {
+        due: { en: "Due date", de: "Fälligkeit", es: "Fecha límite", fr: "Échéance" },
+        priority: { en: "Priority", de: "Priorität", es: "Prioridad", fr: "Priorité" },
+        created: {
+          en: "Newest first",
+          de: "Neueste zuerst",
+          es: "Más recientes primero",
+          fr: "Les plus récentes d'abord",
+        },
+        updated: {
+          en: "Recently touched",
+          de: "Zuletzt bearbeitet",
+          es: "Modificadas hace poco",
+          fr: "Modifiées récemment",
+        },
+        title: { en: "Name", de: "Name", es: "Nombre", fr: "Nom" },
+      },
+    },
+    cards: {
+      label: {
+        en: "Cards show",
+        de: "Karten zeigen",
+        es: "Las tarjetas muestran",
+        fr: "Les cartes montrent",
+      },
+      values: {
+        standard: {
+          en: "The essentials",
+          de: "Das Wesentliche",
+          es: "Lo esencial",
+          fr: "L'essentiel",
+        },
+        compact: { en: "Titles only", de: "Nur Titel", es: "Solo títulos", fr: "Les titres seuls" },
+        detailed: {
+          en: "Everything the card carries",
+          de: "Alles, was die Karte enthält",
+          es: "Todo lo que trae la tarjeta",
+          fr: "Tout ce que la carte contient",
+        },
+      },
+    },
+    highlight: {
+      label: { en: "Highlight", de: "Hervorheben", es: "Destacar", fr: "Mettre en avant" },
+      values: {
+        overdue: {
+          en: "Anything overdue",
+          de: "Alles Überfällige",
+          es: "Todo lo vencido",
+          fr: "Tout ce qui est en retard",
+        },
+        off: { en: "Nothing", de: "Nichts", es: "Nada", fr: "Rien" },
+      },
+    },
+    columns: {
+      label: {
+        en: "Column order",
+        de: "Spaltenreihenfolge",
+        es: "Orden de las columnas",
+        fr: "Ordre des colonnes",
+      },
+      values: {
+        natural: {
+          en: "The field's own",
+          de: "Die des Feldes",
+          es: "El del propio campo",
+          fr: "Celui du champ",
+        },
+        largest: {
+          en: "Fullest first",
+          de: "Vollste zuerst",
+          es: "Las más llenas primero",
+          fr: "Les plus remplies d'abord",
+        },
+        label: { en: "By name", de: "Nach Name", es: "Por nombre", fr: "Par nom" },
+      },
+    },
+  },
+};
+
+/**
+ * This widget's own output, in every language it speaks.
+ *
+ * Beside `meta` and for the same reason: a column heading and an empty-state
+ * line are the widget's words, and there is no app locale file a marketplace
+ * widget could add itself to. The host hands `render` the viewer's language
+ * tag; `say` picks from here. Formatting numbers and dates is still the host's
+ * job — the sandbox has no locale data and no timezone.
+ */
+const strings = {
+  noTasks: {
+    en: "No tasks match",
+    de: "Keine Aufgaben passen",
+    es: "Ninguna tarea coincide",
+    fr: "Aucune tâche ne correspond",
+  },
+  needProperty: {
+    en: "Choose which property the columns come from",
+    de: "Wähle die Eigenschaft, aus der die Spalten kommen",
+    es: "Elige de qué propiedad salen las columnas",
+    fr: "Choisissez la propriété d'où viennent les colonnes",
+  },
+  cannotDraw: {
+    en: "This widget cannot draw ",
+    de: "Dieses Widget kann das nicht zeichnen: ",
+    es: "Este widget no puede dibujar ",
+    fr: "Ce widget ne peut pas dessiner ",
+  },
+  late: { en: "late", de: "überfällig", es: "vencidas", fr: "en retard" },
+  noneAssignee: {
+    en: "Unassigned",
+    de: "Nicht zugewiesen",
+    es: "Sin asignar",
+    fr: "Non attribué",
+  },
+  noneProject: { en: "No project", de: "Kein Projekt", es: "Sin proyecto", fr: "Sans projet" },
+  noneTag: { en: "Untagged", de: "Ohne Tag", es: "Sin etiqueta", fr: "Sans étiquette" },
+  nonePriority: {
+    en: "No priority",
+    de: "Keine Priorität",
+    es: "Sin prioridad",
+    fr: "Sans priorité",
+  },
+  noneStatus: { en: "No status", de: "Kein Status", es: "Sin estado", fr: "Sans statut" },
+  noneValue: { en: "Not set", de: "Nicht gesetzt", es: "Sin valor", fr: "Non renseigné" },
+  categories: {
+    backlog: { en: "Backlog", de: "Backlog", es: "Pendientes", fr: "Réserve" },
+    todo: { en: "To do", de: "Zu erledigen", es: "Por hacer", fr: "À faire" },
+    in_progress: { en: "In progress", de: "In Arbeit", es: "En curso", fr: "En cours" },
+    done: { en: "Done", de: "Erledigt", es: "Hecho", fr: "Terminé" },
+  },
+  priorities: {
+    urgent: { en: "Urgent", de: "Dringend", es: "Urgente", fr: "Urgent" },
+    high: { en: "High", de: "Hoch", es: "Alta", fr: "Haute" },
+    medium: { en: "Medium", de: "Mittel", es: "Media", fr: "Moyenne" },
+    low: { en: "Low", de: "Niedrig", es: "Baja", fr: "Basse" },
+  },
+  booleans: {
+    true: { en: "Yes", de: "Ja", es: "Sí", fr: "Oui" },
+    false: { en: "No", de: "Nein", es: "No", fr: "Non" },
+  },
+};
+
+/**
+ * Built-in: board — tasks dealt into columns.
+ *
+ * Display only, like every widget on a dashboard: a card is a card, not a
+ * handle. There is nothing to drag it onto and no affordance suggesting there
+ * is, because moving work between states is a project view's job and a
+ * dashboard only ever reads.
+ *
+ * What a column stands for is this widget's whole decision — a status, the
+ * person on the work, a tag, or one of the initiative's own custom properties.
+ * That last one is why the property arrives on the *binding* rather than as a
+ * display option: options are a closed set of literals fixed at build time, and
+ * a team's own field is by definition one this build never heard of. The host
+ * resolves the binding to the property's name and the values it can take, so an
+ * option nobody has used yet still gets its column instead of quietly ceasing
+ * to exist.
+ *
+ * @param {import("../dataShapes").WidgetData} data
+ * @param {import("../dataShapes").WidgetConfig} config
+ */
+function render(data, config, context) {
+  // The viewer's language, and this module's own words in it. An older host
+  // that passes no context leaves this at English rather than failing.
+  const lang = context?.locale || "en";
+  const resolve = (entry) => {
+    const table = entry || {};
+    return table[lang] || table[lang.split("-")[0]] || table.en;
+  };
+  const say = (key) => resolve(strings[key]) || key;
+  const pick = (table, key) => resolve(table[key]) || key;
+
+  const empty = (message) => ({ v: 1, scene: { kind: "empty", message } });
+
+  if (data.source !== "tasks") return empty(say("cannotDraw") + data.source);
+
+  const rows = data.rows || [];
+  const group = config.group || "status";
+  const sort = config.sort || "due";
+  const detail = config.cards || "standard";
+  const markOverdue = config.highlight !== "off";
+  const columnOrder = config.columns || "natural";
+  const property = data.property;
+
+  // Grouping by a property nobody has pointed at is a binding that is not
+  // finished, not an empty board — so say which half is missing.
+  if (group === "property" && !property) return empty(say("needProperty"));
+  if (!rows.length) return empty(say("noTasks"));
+
+  // The clock the host handed us. A widget must never invent one.
+  const today = Date.now();
+  const CATEGORIES = ["backlog", "todo", "in_progress", "done"];
+  const PRIORITIES = ["urgent", "high", "medium", "low"];
+
+  /** The bucket for a task with nothing in the grouped field. Named for the
+   *  field, because "Unassigned" and "Untagged" are not the same absence. */
+  const noneLabel =
+    group === "assignee"
+      ? say("noneAssignee")
+      : group === "project"
+        ? say("noneProject")
+        : group === "tag"
+          ? say("noneTag")
+          : group === "priority"
+            ? say("nonePriority")
+            : group === "status" || group === "status_category"
+              ? say("noneStatus")
+              : say("noneValue");
+
+  /** How a raw field value reads. Statuses, project names and tags are already
+   *  words somebody chose; the closed vocabularies are this module's to name. */
+  const labelFor = (value) => {
+    if (value === null) return noneLabel;
+    if (group === "status_category") return pick(strings.categories, value);
+    if (group === "priority") return pick(strings.priorities, value);
+    if (group === "property" && (value === "true" || value === "false")) {
+      return pick(strings.booleans, value);
+    }
+    return value;
+  };
+
+  /** The columns a task belongs in — several where the field holds several, so
+   *  work shared by two people appears under both of them. */
+  const keysFor = (task) => {
+    switch (group) {
+      case "assignee":
+        return task.assignees.length ? task.assignees : [null];
+      case "priority":
+        return [task.priority || null];
+      case "project":
+        return [task.projectName || null];
+      case "tag":
+        return task.tags.length ? task.tags : [null];
+      case "status_category":
+        return [task.statusCategory || null];
+      case "property": {
+        const values = task.properties?.[property.name] || [];
+        return values.length ? values : [null];
+      }
+      default:
+        return [task.status || null];
+    }
+  };
+
+  const isOverdue = (task) =>
+    task.statusCategory !== "done" && task.dueDate !== null && task.dueDate < today;
+
+  // --- the columns --------------------------------------------------------
+  //
+  // Keyed on the raw value, so two options that happen to read alike stay two
+  // columns. Seeded from the declared values first: an option nobody has used
+  // is still part of the workflow, and a column missing from a board is the one
+  // thing a board must not hide.
+
+  const columns = new Map();
+  const columnFor = (key) => {
+    const id = key === null ? " none" : key;
+    let column = columns.get(id);
+    if (!column) {
+      column = { key: key, tasks: [], rank: columns.size };
+      columns.set(id, column);
+    }
+    return column;
+  };
+
+  if (group === "property") {
+    for (const value of property.values || []) columnFor(value);
+  }
+  // A category and a priority are fixed ladders, so every rung is drawn whether
+  // or not any work is sitting on it.
+  if (group === "status_category") for (const value of CATEGORIES) columnFor(value);
+  if (group === "priority") for (const value of PRIORITIES) columnFor(value);
+
+  for (const task of rows) {
+    for (const key of keysFor(task)) columnFor(key).tasks.push(task);
+  }
+
+  // --- cards within a column ----------------------------------------------
+
+  const priorityRank = (task) => {
+    const index = PRIORITIES.indexOf(task.priority);
+    return index === -1 ? PRIORITIES.length : index;
+  };
+
+  const compare = (a, b) => {
+    switch (sort) {
+      case "priority": {
+        const byPriority = priorityRank(a) - priorityRank(b);
+        if (byPriority !== 0) return byPriority;
+        break;
+      }
+      case "created":
+        if (a.createdAt !== b.createdAt) return b.createdAt - a.createdAt;
+        break;
+      case "updated":
+        if (a.updatedAt !== b.updatedAt) return b.updatedAt - a.updatedAt;
+        break;
+      case "title": {
+        const byTitle = a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+        if (byTitle !== 0) return byTitle;
+        break;
+      }
+      default: {
+        // Undated work has no place on a due-date ladder, so it sits at the
+        // foot rather than being given a date it does not have.
+        const left = a.dueDate === null ? Infinity : a.dueDate;
+        const right = b.dueDate === null ? Infinity : b.dueDate;
+        if (left !== right) return left - right;
+        break;
+      }
+    }
+    // A stable tiebreak, so the same rows always draw in the same order.
+    return a.id - b.id;
+  };
+
+  const cardFor = (task) => {
+    const card = { title: task.title };
+    if (markOverdue && isOverdue(task)) card.tone = "negative";
+    if (detail === "compact") return card;
+
+    const chips = [];
+    // Never repeat the column's own field on the cards inside it: a column of
+    // "Ada" whose every card says "Ada" is a column of wasted room.
+    if (group !== "assignee") for (const name of task.assignees) chips.push(name);
+    if (group !== "priority" && task.priority) chips.push(pick(strings.priorities, task.priority));
+    if (detail === "detailed") {
+      if (group !== "project" && task.projectName) chips.push(task.projectName);
+      if (group !== "tag") for (const tag of task.tags) chips.push(tag);
+    }
+    if (chips.length) card.chips = chips;
+
+    if (task.dueDate !== null) card.date = task.dueDate;
+    if (task.subtaskTotal > 0) {
+      card.caption = task.subtaskDone + "/" + task.subtaskTotal;
+      card.progress = task.subtaskDone / task.subtaskTotal;
+    }
+    return card;
+  };
+
+  // --- column order -------------------------------------------------------
+
+  const naturalRank = (column) => {
+    // The empty bucket is nobody's first column, whatever the field.
+    if (column.key === null) return Number.MAX_SAFE_INTEGER;
+    if (group === "status_category") return CATEGORIES.indexOf(column.key);
+    if (group === "priority") return PRIORITIES.indexOf(column.key);
+    if (group === "property") return column.rank;
+    if (group === "status") {
+      // Statuses carry no order the rows can tell us, so they fall back to the
+      // category ladder their work sits on — which is the order somebody
+      // reading a board expects, even when the names are the initiative's own.
+      const first = column.tasks[0];
+      const category = first ? CATEGORIES.indexOf(first.statusCategory) : CATEGORIES.length;
+      return (category === -1 ? CATEGORIES.length : category) * 1000 + column.rank;
+    }
+    return column.rank;
+  };
+
+  const labelled = [...columns.values()].map((column) => ({
+    column: column,
+    label: labelFor(column.key),
+  }));
+
+  const byLabel = (a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0);
+
+  if (columnOrder === "largest") {
+    labelled.sort((a, b) => b.column.tasks.length - a.column.tasks.length);
+  } else if (columnOrder === "label") {
+    labelled.sort(byLabel);
+  } else if (group === "assignee" || group === "project" || group === "tag") {
+    // Free-form values have no ladder of their own, so alphabetical is the
+    // order somebody can predict — with the empty bucket still last.
+    labelled.sort((a, b) => {
+      if ((a.column.key === null) !== (b.column.key === null)) {
+        return a.column.key === null ? 1 : -1;
+      }
+      return byLabel(a, b);
+    });
+  } else {
+    labelled.sort((a, b) => naturalRank(a.column) - naturalRank(b.column));
+  }
+
+  const scene = { kind: "board", columns: [] };
+  for (const entry of labelled) {
+    const tasks = entry.column.tasks.slice().sort(compare);
+    const column = { label: entry.label, cards: tasks.map(cardFor) };
+    if (markOverdue) {
+      let late = 0;
+      for (const task of tasks) if (isOverdue(task)) late++;
+      if (late) column.caption = late + " " + say("late");
+    }
+    scene.columns.push(column);
+  }
+
+  return { v: 1, scene: scene };
+}

--- a/frontend/src/lib/widgets/builtins/board.widget.test.ts
+++ b/frontend/src/lib/widgets/builtins/board.widget.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The board through the whole path it takes in production: sandboxed module,
+ * validator, scene. Asserted on the scene rather than on the DOM, because what
+ * is worth pinning here is the widget's own reasoning — which column a task
+ * lands in, which columns exist at all, and what order they come in — and none
+ * of that is visible in a rendering.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { WidgetData } from "../dataShapes";
+import { builtinWidgetSource } from "../registry";
+import { renderInSandbox } from "../runtime/sandbox";
+import { SAMPLE_NOW, sampleFor } from "../sampleData";
+import type { BoardNode, SceneNode } from "../sceneSpec";
+import { validateScene } from "../validateScene";
+
+const run = async (config: Record<string, string>, data?: WidgetData): Promise<SceneNode> => {
+  const result = await renderInSandbox({
+    source: builtinWidgetSource("board") as string,
+    data: data ?? sampleFor("tasks", "board"),
+    config,
+    now: SAMPLE_NOW,
+  });
+  expect(result.ok, JSON.stringify(result)).toBe(true);
+  if (!result.ok) throw new Error("render failed");
+
+  // Through the same boundary a live tile crosses, so a field the validator
+  // would drop cannot be asserted on here either.
+  const validation = validateScene(result.value);
+  expect(validation.ok, JSON.stringify(validation)).toBe(true);
+  if (!validation.ok) throw new Error("invalid scene");
+  return validation.spec.scene;
+};
+
+const draw = async (config: Record<string, string> = {}, data?: WidgetData): Promise<BoardNode> => {
+  const scene = await run(config, data);
+  expect(scene.kind).toBe("board");
+  return scene as BoardNode;
+};
+
+const columnNamed = (board: BoardNode, label: string) => {
+  const found = board.columns.find((column) => column.label === label);
+  if (!found) {
+    throw new Error(`no column ${label} in ${board.columns.map((c) => c.label).join(", ")}`);
+  }
+  return found;
+};
+
+const titles = (board: BoardNode, label: string) =>
+  columnNamed(board, label).cards.map((card) => card.title);
+
+describe("what a column stands for", () => {
+  it("columns by status, ordered by the category its work sits in", async () => {
+    const board = await draw();
+    // "Blocked" is a to-do status, so it sits with the other to-dos rather than
+    // wherever the rows happened to mention it first.
+    expect(board.columns.map((column) => column.label)).toEqual([
+      "To do",
+      "Blocked",
+      "In progress",
+      "Done",
+    ]);
+    expect(titles(board, "In progress")).toContain("Migrate the search index");
+  });
+
+  it("puts work with two people on it under both of them", async () => {
+    const board = await draw({ group: "assignee" });
+    expect(titles(board, "Grace")).toContain("Ship the migration");
+    expect(titles(board, "Ada")).toContain("Ship the migration");
+  });
+
+  it("gives work with nobody on it its own column, last", async () => {
+    const board = await draw({ group: "assignee" });
+    const last = board.columns[board.columns.length - 1];
+    expect(last.label).toBe("Unassigned");
+    expect(last.cards.map((card) => card.title)).toEqual(["Chase the vendor"]);
+  });
+
+  it("draws every rung of a fixed ladder, including the empty ones", async () => {
+    const board = await draw({ group: "priority" });
+    expect(board.columns.map((column) => column.label)).toEqual([
+      "Urgent",
+      "High",
+      "Medium",
+      "Low",
+      "No priority",
+    ]);
+    // Nothing in the samples is urgent, and the column still exists.
+    expect(columnNamed(board, "Urgent").cards).toEqual([]);
+  });
+});
+
+describe("columns from a custom property", () => {
+  it("reads the property the binding named", async () => {
+    const board = await draw({ group: "property" });
+    expect(titles(board, "Platform")).toContain("Draft the spec");
+    expect(titles(board, "Growth")).toContain("Localize the emails");
+  });
+
+  it("keeps a declared value that nobody has used yet", async () => {
+    const board = await draw({ group: "property" });
+    // "Research" is an option on the property and on no task; a board that
+    // dropped it would be hiding part of the workflow.
+    expect(columnNamed(board, "Research").cards).toEqual([]);
+  });
+
+  it("collects tasks with no value into their own column", async () => {
+    const board = await draw({ group: "property" });
+    expect(titles(board, "Not set")).toEqual(["Chase the vendor"]);
+  });
+
+  it("asks for the property instead of drawing an empty board", async () => {
+    const sample = sampleFor("tasks", "board") as Extract<WidgetData, { source: "tasks" }>;
+    const scene = await run({ group: "property" }, { ...sample, property: undefined });
+    expect(scene.kind).toBe("empty");
+  });
+});
+
+describe("cards", () => {
+  it("marks work that is past its date and still open", async () => {
+    const board = await draw();
+    const late = columnNamed(board, "Blocked").cards[0];
+    expect(late).toMatchObject({ title: "Chase the vendor", tone: "negative" });
+    expect(columnNamed(board, "Blocked").caption).toBe("1 late");
+  });
+
+  it("leaves finished work alone, however old its due date", async () => {
+    const board = await draw();
+    for (const card of columnNamed(board, "Done").cards) expect(card.tone).toBeUndefined();
+  });
+
+  it("does not repeat the column's own field on the cards inside it", async () => {
+    const byPerson = await draw({ group: "assignee" });
+    expect(columnNamed(byPerson, "Ada").cards[0].chips ?? []).not.toContain("Ada");
+
+    const byStatus = await draw({ group: "status" });
+    expect(columnNamed(byStatus, "In progress").cards[0].chips).toContain("Grace");
+  });
+
+  it("carries checklist progress as both a caption and a bar", async () => {
+    const board = await draw();
+    const card = columnNamed(board, "In progress").cards.find(
+      (entry) => entry.title === "Migrate the search index"
+    );
+    expect(card).toMatchObject({ caption: "1/4", progress: 0.25 });
+  });
+
+  it("reduces to titles when asked for", async () => {
+    const board = await draw({ cards: "compact" });
+    for (const column of board.columns) {
+      for (const card of column.cards) {
+        expect(card.chips).toBeUndefined();
+        expect(card.date).toBeUndefined();
+        expect(card.caption).toBeUndefined();
+      }
+    }
+  });
+});
+
+describe("order", () => {
+  it("sorts by due date with undated work at the foot", async () => {
+    const board = await draw({ group: "status_category", sort: "due" });
+    const todo = columnNamed(board, "To do");
+    const dated = todo.cards.filter((card) => card.date !== undefined);
+    expect(dated.map((card) => card.date)).toEqual(
+      [...dated.map((card) => card.date as number)].sort((a, b) => a - b)
+    );
+    const undated = todo.cards.findIndex((card) => card.date === undefined);
+    if (undated !== -1) expect(undated).toBe(todo.cards.length - 1);
+  });
+
+  it("puts the fullest column first when asked", async () => {
+    const board = await draw({ group: "assignee", columns: "largest" });
+    const sizes = board.columns.map((column) => column.cards.length);
+    expect(sizes).toEqual([...sizes].sort((a, b) => b - a));
+  });
+});

--- a/frontend/src/lib/widgets/dataShapes.ts
+++ b/frontend/src/lib/widgets/dataShapes.ts
@@ -40,6 +40,16 @@ export interface TaskRow {
   subtaskDone: number;
   subtaskTotal: number;
   commentCount: number;
+  /** The initiative's own custom properties, by the property's name, each value
+   *  already resolved to what a person reads — an option's label rather than
+   *  its slug, a person's name rather than their id. Multi-valued properties
+   *  carry several; one nobody has set on this task is simply absent.
+   *
+   *  Labels rather than ids because a widget can only *show* them, and matching
+   *  them across rows is what grouping needs. A property whose value is a date
+   *  or a number arrives as its plain string form: the sandbox has no locale to
+   *  format one with, so anything more would be a lie about the viewer. */
+  properties: Record<string, string[]>;
 }
 
 export interface ProjectRow {
@@ -68,6 +78,32 @@ export interface ProjectsData {
   source: "projects";
   rows: ProjectRow[];
   tasks: TaskRow[];
+}
+
+/** A custom property a binding singled out: its name, and the values it can
+ *  take, in the order the initiative defined them.
+ *
+ *  The domain is here because rows cannot supply it. Grouping read off the rows
+ *  alone can only ever show the values somebody has already used — so an option
+ *  that exists and is empty silently stops existing, which for a workflow state
+ *  is the column you most needed to see. */
+export interface PropertyDomain {
+  name: string;
+  values: string[];
+}
+
+/**
+ * The `tasks` envelope.
+ *
+ * `property` is present only when the binding named one, and says which of the
+ * initiative's custom properties it named. A widget that groups by a property
+ * needs both halves: the name to read it off a row, and the domain so an
+ * unused option still gets a column.
+ */
+export interface TasksData {
+  source: "tasks";
+  rows: TaskRow[];
+  property?: PropertyDomain;
 }
 
 export interface CalendarEntryRow {
@@ -145,7 +181,7 @@ export interface DataMeta {
 }
 
 export type WidgetData = (
-  | { source: "tasks"; rows: TaskRow[] }
+  | TasksData
   | ProjectsData
   | { source: "calendar_entries"; rows: CalendarEntryRow[] }
   | { source: "task_counts"; rows: CountRow[] }

--- a/frontend/src/lib/widgets/normalize.ts
+++ b/frontend/src/lib/widgets/normalize.ts
@@ -18,16 +18,19 @@ import type {
   CounterRead,
   DocumentRead,
   ProjectRead,
+  PropertyDefinitionRead,
+  PropertySummary,
   TaskListRead,
 } from "@/api/generated/initiativeAPI.schemas";
 import { keyOf, parseA1Range } from "@/lib/spreadsheet/coords";
-import { getUserDisplayName } from "@/lib/userDisplay";
+import { type DisplayableUser, getUserDisplayName } from "@/lib/userDisplay";
 
 import type {
   CalendarEntryRow,
   CounterValue,
   CountRow,
   ProjectRow,
+  PropertyDomain,
   SheetRange,
   TaskRow,
   WidgetData,
@@ -52,6 +55,74 @@ const UTC_DAY = 86_400_000;
 /** Midnight UTC for a timestamp — the bucket key for day-grouped counts. */
 export const startOfUtcDay = (epoch: number): number => Math.floor(epoch / UTC_DAY) * UTC_DAY;
 
+// --- custom properties ------------------------------------------------------
+
+/** One property value as the labels a person reads.
+ *
+ * Select options resolve through the definition's own option list, so a widget
+ * groups by "Design" rather than by `design-2`; a person resolves to their
+ * display name. Everything else is its plain string form — the sandbox has no
+ * locale, so formatting a number or a date for a viewer is not something this
+ * side can honestly do. An unset value produces nothing at all, which is what
+ * keeps it out of the row entirely. */
+const propertyLabels = (summary: PropertySummary): string[] => {
+  const { type, value } = summary;
+  if (value === null || value === undefined || value === "") return [];
+
+  const optionLabel = (slug: unknown): string => {
+    const match = (summary.options ?? []).find((option) => option.value === slug);
+    return match?.label ?? String(slug);
+  };
+
+  switch (type) {
+    case "select":
+      return [optionLabel(value)];
+    case "multi_select":
+      return Array.isArray(value) ? value.map(optionLabel) : [];
+    case "user_reference": {
+      const person = typeof value === "object" ? (value as DisplayableUser) : null;
+      const name = person ? getUserDisplayName(person, "") : "";
+      return name ? [name] : [];
+    }
+    case "checkbox":
+      // The two words are the widget's to say — it carries its own strings in
+      // every language it speaks, and this side has none to lend it.
+      return [value === true ? "true" : "false"];
+    case "date":
+    case "datetime":
+      return typeof value === "string" ? [value.slice(0, type === "date" ? 10 : 16)] : [];
+    default:
+      return [String(value)];
+  }
+};
+
+/** A task's properties, by name. Empty values are absent rather than present
+ *  and blank, so a widget grouping by a property can tell "not set" from a
+ *  value that happens to read as nothing. */
+export const normalizeProperties = (
+  summaries: PropertySummary[] | null | undefined
+): Record<string, string[]> => {
+  const out: Record<string, string[]> = {};
+  for (const summary of summaries ?? []) {
+    const labels = propertyLabels(summary);
+    if (labels.length) out[summary.name] = labels;
+  }
+  return out;
+};
+
+/** What a property *could* say, from its definition rather than from what
+ *  anybody has filled in. Only the closed types have a domain to state; for the
+ *  rest the values are whatever the rows turn out to hold. */
+export const propertyDomain = (definition: PropertyDefinitionRead): PropertyDomain => ({
+  name: definition.name,
+  values:
+    definition.type === "select" || definition.type === "multi_select"
+      ? (definition.options ?? []).map((option) => option.label)
+      : definition.type === "checkbox"
+        ? ["true", "false"]
+        : [],
+});
+
 // --- per-source normalizers -------------------------------------------------
 
 export const normalizeTasks = (tasks: TaskListRead[]): TaskRow[] =>
@@ -75,6 +146,7 @@ export const normalizeTasks = (tasks: TaskListRead[]): TaskRow[] =>
     subtaskDone: task.subtask_progress?.completed ?? 0,
     subtaskTotal: task.subtask_progress?.total ?? 0,
     commentCount: task.comment_count ?? 0,
+    properties: normalizeProperties(task.properties),
   }));
 
 export const normalizeProjects = (

--- a/frontend/src/lib/widgets/provenance.ts
+++ b/frontend/src/lib/widgets/provenance.ts
@@ -59,6 +59,7 @@ export interface EntityLabels {
   document: Map<number, string>;
   member: Map<number, string>;
   tag: Map<number, string>;
+  property: Map<number, string>;
   /** False while any lookup is still in flight. Nothing may be called
    *  unresolvable until this is true. */
   ready: boolean;
@@ -72,6 +73,7 @@ export const EMPTY_LABELS: EntityLabels = {
   document: new Map(),
   member: new Map(),
   tag: new Map(),
+  property: new Map(),
   ready: false,
 };
 
@@ -90,6 +92,7 @@ const LABEL_MAPS: Record<EntityKind, keyof EntityLabels> = {
   counter_group: "counterGroup",
   counter: "counter",
   document: "document",
+  property: "property",
 };
 
 const lookup = (labels: EntityLabels, kind: EntityKind, id: number): string | undefined =>

--- a/frontend/src/lib/widgets/registry.ts
+++ b/frontend/src/lib/widgets/registry.ts
@@ -13,6 +13,7 @@
  * two and fails on drift.
  */
 
+import boardSource from "./builtins/board.widget.js?raw";
 import chartSource from "./builtins/chart.widget.js?raw";
 import funnelSource from "./builtins/funnel.widget.js?raw";
 import ganttSource from "./builtins/gantt.widget.js?raw";
@@ -35,6 +36,7 @@ export const BUILTIN_WIDGETS: Record<string, string> = {
   progress: progressSource,
   heatmap: heatmapSource,
   table: tableSource,
+  board: boardSource,
 };
 
 export const BUILTIN_WIDGET_TYPES = Object.keys(BUILTIN_WIDGETS);

--- a/frontend/src/lib/widgets/sampleData.ts
+++ b/frontend/src/lib/widgets/sampleData.ts
@@ -66,6 +66,7 @@ const tasks: WidgetSample = {
         subtaskDone: 3,
         subtaskTotal: 3,
         commentCount: 4,
+        properties: { Squad: ["Platform"], Effort: ["3"] },
       },
       {
         id: 2,
@@ -87,6 +88,7 @@ const tasks: WidgetSample = {
         subtaskDone: 5,
         subtaskTotal: 5,
         commentCount: 2,
+        properties: { Squad: ["Platform"], Effort: ["5"] },
       },
       {
         id: 3,
@@ -106,6 +108,7 @@ const tasks: WidgetSample = {
         subtaskDone: 1,
         subtaskTotal: 4,
         commentCount: 0,
+        properties: { Squad: ["Platform"] },
       },
       {
         id: 4,
@@ -126,6 +129,7 @@ const tasks: WidgetSample = {
         subtaskDone: 0,
         subtaskTotal: 0,
         commentCount: 1,
+        properties: { Squad: ["Growth"] },
       },
       {
         id: 5,
@@ -145,6 +149,7 @@ const tasks: WidgetSample = {
         subtaskDone: 2,
         subtaskTotal: 6,
         commentCount: 7,
+        properties: { Squad: ["Growth"], Effort: ["2"] },
       },
       {
         id: 6,
@@ -164,6 +169,7 @@ const tasks: WidgetSample = {
         subtaskDone: 0,
         subtaskTotal: 3,
         commentCount: 0,
+        properties: { Squad: ["Growth"] },
       },
       {
         id: 7,
@@ -183,6 +189,7 @@ const tasks: WidgetSample = {
         subtaskDone: 4,
         subtaskTotal: 4,
         commentCount: 3,
+        properties: { Squad: ["Platform", "Growth"] },
       },
       {
         id: 8,
@@ -203,6 +210,7 @@ const tasks: WidgetSample = {
         subtaskDone: 0,
         subtaskTotal: 0,
         commentCount: 0,
+        properties: {},
       },
       {
         id: 9,
@@ -222,8 +230,12 @@ const tasks: WidgetSample = {
         subtaskDone: 1,
         subtaskTotal: 2,
         commentCount: 2,
+        properties: { Squad: ["Growth"] },
       },
     ],
+    // What a binding that singled out a property hands over: its name and the
+    // values it can take. Every other widget ignores it.
+    property: { name: "Squad", values: ["Platform", "Growth", "Research"] },
   },
   empty: { source: "tasks", rows: [] },
 };
@@ -433,4 +445,5 @@ export const SOURCES_BY_WIDGET: Record<string, WidgetSource[]> = {
   progress: ["counter", "task_counts", "projects"],
   heatmap: ["task_counts"],
   table: ["tasks", "projects", "sheet_range", "calendar_entries"],
+  board: ["tasks"],
 };

--- a/frontend/src/lib/widgets/sceneSpec.ts
+++ b/frontend/src/lib/widgets/sceneSpec.ts
@@ -73,6 +73,10 @@ export const SCENE_LIMITS = {
   /** `table` shape. */
   maxColumns: 32,
   maxRows: 10_000,
+  /** `board` shape — columns across, and cards counted across the whole board
+   *  rather than per column, since a card costs the same wherever it sits. */
+  maxBoardColumns: 32,
+  maxCards: 10_000,
   /** `funnel` stages. */
   maxStages: 32,
 } as const;
@@ -337,6 +341,47 @@ export interface TableNode {
   rows: Record<string, TableCell>[];
 }
 
+/** One card on a board — a work item reduced to what a column can show.
+ *
+ *  `date` is epoch milliseconds and the renderer formats it, like every other
+ *  timestamp here; `tone` colours the card's edge, which is how an overdue card
+ *  reads as late without the widget naming a colour. */
+export interface BoardCard {
+  title: string;
+  /** Short labels under the title — an assignee, a tag, a priority. */
+  chips?: string[];
+  /** A date to show on the card. */
+  date?: number;
+  /** 0..1, drawn as a hairline across the card's foot — the share of this
+   *  card's own checklist that is finished. */
+  progress?: number;
+  /** A short read-out at the card's right ("3/8"). Text, so a widget says what
+   *  its own denominator means rather than every renderer guessing. */
+  caption?: string;
+  tone?: Tone;
+}
+
+/** A column, and the cards in it.
+ *
+ *  `total` is the column's real size when `cards` is a leading slice of it, so
+ *  a column that draws twenty of two hundred can still say two hundred. */
+export interface BoardColumn {
+  label: string;
+  cards: BoardCard[];
+  total?: number;
+  /** A read-out beside the count — what the column adds up to. */
+  caption?: string;
+  tone?: Tone;
+}
+
+/** Rows dealt into columns — the board shape. What a column *stands for* is the
+ *  widget's decision and arrives already made: this draws columns of cards and
+ *  knows nothing about statuses or assignees. */
+export interface BoardNode {
+  kind: "board";
+  columns: BoardColumn[];
+}
+
 export interface TextNode {
   kind: "text";
   text: string;
@@ -371,6 +416,7 @@ export type SceneNode =
   | ProgressNode
   | MatrixNode
   | TableNode
+  | BoardNode
   | TextNode
   | EmptyNode
   | StackNode;
@@ -383,6 +429,7 @@ export const SCENE_NODE_KINDS = [
   "progress",
   "matrix",
   "table",
+  "board",
   "text",
   "empty",
   "stack",

--- a/frontend/src/lib/widgets/sceneTable.ts
+++ b/frontend/src/lib/widgets/sceneTable.ts
@@ -183,6 +183,29 @@ export function sceneToTables(node: SceneNode, t: SceneTableT): TableScene[] {
         ),
       ];
 
+    case "board":
+      // One row per card, with its column beside it — the reading a board makes
+      // you do with your eyes, done in the table instead. Column order is kept,
+      // so the two carry the same story in the same sequence.
+      return [
+        table(
+          [
+            { key: "column", label: t("dashboards:tableView.column") },
+            { key: "card", label: t("dashboards:tableView.card") },
+            { key: "chips", label: t("dashboards:tableView.label") },
+            { key: "date", label: t("dashboards:tableView.due"), align: "end", format: "date" },
+          ],
+          node.columns.flatMap((column) =>
+            column.cards.map((card) => ({
+              column: column.label,
+              card: card.title,
+              chips: card.chips?.length ? card.chips.join(", ") : null,
+              date: card.date ?? null,
+            }))
+          )
+        ),
+      ];
+
     case "text":
       return [
         table([{ key: "text", label: t("dashboards:tableView.label") }], [{ text: node.text }]),

--- a/frontend/src/lib/widgets/sources.ts
+++ b/frontend/src/lib/widgets/sources.ts
@@ -29,7 +29,13 @@ import type { WidgetSource } from "@/lib/widgets/dataShapes";
 /** An entity a binding can point at. The kind decides which of the canvas's
  *  already-cached list queries resolves it to a name — never a fetch of its
  *  own, so a dense canvas costs no extra requests. */
-export type EntityKind = "project" | "counter_group" | "counter" | "calendar" | "document";
+export type EntityKind =
+  | "project"
+  | "counter_group"
+  | "counter"
+  | "calendar"
+  | "document"
+  | "property";
 
 interface BaseParam {
   /** The binding key this parameter reads and writes. */
@@ -37,6 +43,14 @@ interface BaseParam {
   /** Whether a binding is unusable until this is filled. Drives
    *  {@link unboundSlots}; a listing may ship a widget with the slot empty. */
   required?: boolean;
+  /** The widgets that read this parameter, when only some of them do.
+   *
+   *  A source's parameters are usually the source's alone — every widget bound
+   *  to `tasks` is narrowed by the same project and the same filters. A few are
+   *  not: which custom property to column a board by means nothing to a table
+   *  drawing the same rows, and offering it there would be offering a control
+   *  that does nothing. Omitted means every widget. */
+  usedBy?: readonly string[];
 }
 
 /** An id pointing at another resource in this initiative. */
@@ -105,6 +119,12 @@ export const SOURCES: Record<WidgetSource, SourceDescriptor> = {
     rowNoun: "task",
     params: [
       { kind: "entity", key: "project_id", entity: "project" },
+      // Which of the initiative's own fields a board deals its columns from.
+      // It rides on the binding rather than on the widget's display options
+      // because those are a closed set of literals decided at build time, and
+      // the whole point of a custom property is that this build never heard of
+      // it.
+      { kind: "entity", key: "property_id", entity: "property", usedBy: ["board"] },
       { kind: "filters", key: "conditions" },
     ],
   },
@@ -186,6 +206,16 @@ export const unboundSlots = (binding: WidgetBinding): string[] => {
 export const entityParams = (source: WidgetSource | string): EntityParam[] =>
   (sourceDescriptor(source)?.params ?? []).filter(
     (param): param is EntityParam => param.kind === "entity"
+  );
+
+/** The parameters to offer for one source *on one widget* — everything the
+ *  source declares, minus the few a different widget reads. */
+export const paramsFor = (
+  source: WidgetSource | string,
+  widgetType: string
+): readonly SourceParam[] =>
+  (sourceDescriptor(source)?.params ?? []).filter(
+    (param) => !param.usedBy || param.usedBy.includes(widgetType)
   );
 
 /** Whether this source takes filter conditions at all. */

--- a/frontend/src/lib/widgets/validateScene.ts
+++ b/frontend/src/lib/widgets/validateScene.ts
@@ -15,6 +15,8 @@
  */
 
 import {
+  type BoardCard,
+  type BoardColumn,
   type MatrixCell,
   NUMBER_FORMATS,
   type NumberFormat,
@@ -255,6 +257,37 @@ const parseRow = (raw: unknown, columns: TableColumn[]): Record<string, TableCel
   return row;
 };
 
+const parseCard = (raw: unknown, budget: CardBudget): BoardCard => {
+  if (++budget.cards > SCENE_LIMITS.maxCards) fail(SceneErrorCode.TOO_LARGE);
+  if (!isPlainObject(raw)) fail(SceneErrorCode.NODE_INVALID);
+  return compact({
+    title: text(raw.title),
+    chips:
+      raw.chips === undefined || raw.chips === null
+        ? undefined
+        : arrayOf(raw.chips, SCENE_LIMITS.maxColumns).map(text),
+    date: optNum(raw.date),
+    progress: optNum(raw.progress),
+    caption: optText(raw.caption),
+    tone: optTone(raw.tone),
+  });
+};
+
+/** A column and its cards. Cards draw from one budget shared by the whole
+ *  board rather than a cap per column, for the same reason lanes do: a card
+ *  costs the same drawing wherever it sits, so only the total is worth
+ *  bounding. */
+const parseBoardColumn = (raw: unknown, budget: CardBudget): BoardColumn => {
+  if (!isPlainObject(raw)) fail(SceneErrorCode.NODE_INVALID);
+  return compact({
+    label: text(raw.label),
+    cards: asList(raw.cards).map((card) => parseCard(card, budget)),
+    total: optNum(raw.total),
+    caption: optText(raw.caption),
+    tone: optTone(raw.tone),
+  });
+};
+
 // --- nodes -----------------------------------------------------------------
 
 interface Budget {
@@ -263,6 +296,10 @@ interface Budget {
 
 interface LaneBudget {
   lanes: number;
+}
+
+interface CardBudget {
+  cards: number;
 }
 
 const parseNode = (raw: unknown, depth: number, budget: Budget): SceneNode => {
@@ -362,6 +399,16 @@ const parseNode = (raw: unknown, depth: number, budget: Budget): SceneNode => {
         kind: "table" as const,
         columns,
         rows: arrayOf(node.rows, SCENE_LIMITS.maxRows).map((row) => parseRow(row, columns)),
+      });
+    }
+
+    case "board": {
+      const cards: CardBudget = { cards: 0 };
+      return compact({
+        kind: "board" as const,
+        columns: arrayOf(node.columns, SCENE_LIMITS.maxBoardColumns).map((column) =>
+          parseBoardColumn(column, cards)
+        ),
       });
     }
 


### PR DESCRIPTION
## Problem

A dashboard could draw a timeline, a chart, a table and a heatmap, but it could not draw the shape most people picture when they think about work in flight: columns. There was no way to see "who is carrying what" or "how much is sitting in Blocked" without reading a table and doing the grouping in your head.

## What this adds

A **board** widget: tasks dealt into columns, read-only, on the dashboard canvas.

What a column stands for is the author's choice — `status`, `status_category`, `assignee`, `priority`, `project`, `tag`, or **one of the initiative's own custom properties**.

That last one drove the one design decision worth reviewing. A widget's display options are a closed set of literals, fixed at build time and validated against `WIDGET_SPECS[...].options` on save. A team's own property is by definition a value this build has never heard of, so it cannot be an option. It rides on the **binding** instead — which is the existing home for "the ids a definition names" — and the host resolves it to the property's name and the values it may take before the widget runs. That resolution is why an option nobody has used yet still gets a column: grouping read off the rows alone can only show values somebody has already picked, so an empty **Blocked** would silently stop existing.

Other display options: `sort` (due / priority / newest / recently touched / name), `cards` (compact / standard / detailed), `highlight` (overdue), `columns` (natural / fullest first / by name).

## Notable changes

**Scene vocabulary** — a new `board` node (`columns` → `cards`, each with chips, a date, checklist progress and a tone), its validator arm, its renderer, and its entry in `sceneToTables` so the board has the same tabular twin every other scene gets. Cards are budgeted across the whole board rather than per column, the way lanes already are.

**Widget envelope** — `TaskRow.properties`: every custom property on the task, by name, with values already resolved to what a person reads (an option's label, not its slug; a person's name, not their id), because a slug is not something you can group a column by. `TasksData.property` carries the bound property's name and domain.

**Source registry** — `usedBy` on a source parameter. `tasks` gains a `property_id` entity parameter, offered on the board and *not* on a table or gantt drawing the same rows, where the control would do nothing. The config dialog also stops fetching property definitions for widgets that never read them.

**Backend** — one `WidgetSpec` entry. No migration, no schema change: a definition naming `board` validates against the same closed vocabulary everything else does, and no new binding source was added.

## Access

Nothing new is reachable. The board binds `tasks`, which resolves through the same RLS-gated hook every other task widget uses, so the rows are the viewer's own. The property definitions are read through `useProperties` under the viewer's session and a property they cannot resolve is simply absent — the board draws and says it has nothing to column by, exactly as a bound counter they cannot see renders today. Provenance names the property only when the viewer's own lookup resolved it.

## Testing

```
cd frontend && pnpm typecheck
cd frontend && pnpm lint
cd frontend && pnpm vitest run src/lib/widgets src/components/initiativeTools/dashboards src/hooks/useWidgetData.test.tsx
cd frontend && ./scripts/test-changed.sh
cd backend && ruff check app && ruff format app && ty check
cd backend && pytest app/services/tenant/dashboard_definition_test.py
```

`board.widget.test.ts` runs the module through the real sandbox and validator and asserts on the scene: which column a task lands in, that shared work appears under both people, that fixed ladders draw their empty rungs, that a declared property value nobody has used keeps its column, that the column's own field is not repeated on the cards inside it, and that overdue marking leaves finished work alone.

Generated API types were regenerated (`WidgetType` gains `board`).

## Screenshots

To follow — the widget is reachable from **Dashboards → Add a widget → Board**.
