### PR TITLE
Derive marketplace kind params from the enum

### DIFF
--- a/frontend/src/components/sidebar/AppsSection.tsx
+++ b/frontend/src/components/sidebar/AppsSection.tsx
@@ -42,7 +42,7 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { GuildAppRead } from "@/api/generated/initiativeAPI.schemas";
+import { type GuildAppRead, ListingKind } from "@/api/generated/initiativeAPI.schemas";
 import { AppSettingsDialog } from "@/components/apps/AppSettingsDialog";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -166,7 +166,7 @@ export function AppsSection({ isGuildAdmin, open, onOpenChange }: AppsSectionPro
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton asChild size="sm">
-                  <Link to={gp("/marketplace")} search={{ kind: "app" }}>
+                  <Link to={gp("/marketplace")} search={{ kind: ListingKind.app }}>
                     {isGuildAdmin ? <Plus className="h-4 w-4" /> : <Store className="h-4 w-4" />}
                     <span>{isGuildAdmin ? t("apps:add") : t("apps:browse")}</span>
                   </Link>

--- a/frontend/src/lib/marketplace.test.ts
+++ b/frontend/src/lib/marketplace.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
 
-import { COMMUNITY_SHELVES, isUserShelf, USER_SHELVES } from "./marketplace";
+import {
+  COMMUNITY_SHELVES,
+  DEFAULT_COMMUNITY_SHELF,
+  isUserShelf,
+  parseCommunityShelf,
+  parseListingKind,
+  USER_SHELVES,
+} from "./marketplace";
 
 describe("who a listing is offered to", () => {
   it("places every kind the server knows on exactly one shelf", () => {
@@ -16,5 +23,37 @@ describe("who a listing is offered to", () => {
   it("sells a profile pack to a person", () => {
     expect(isUserShelf(ListingKind.profile_pack)).toBe(true);
     expect(isUserShelf(ListingKind.dashboard)).toBe(false);
+  });
+});
+
+describe("reading a kind out of the URL", () => {
+  it("accepts every kind the server publishes", () => {
+    for (const kind of Object.values(ListingKind)) {
+      expect(parseListingKind(kind)).toBe(kind);
+    }
+  });
+
+  it("reports nothing for a kind that is not one", () => {
+    expect(parseListingKind("dashboards")).toBeUndefined();
+    expect(parseListingKind(undefined)).toBeUndefined();
+    expect(parseListingKind(7)).toBeUndefined();
+  });
+
+  it("opens each community shelf the URL names", () => {
+    for (const shelf of COMMUNITY_SHELVES) {
+      expect(parseCommunityShelf(shelf)).toBe(shelf);
+    }
+  });
+
+  it("falls back to the default shelf for anything a community does not sell", () => {
+    // A person's shelf reached through a community URL is not that community's,
+    // and neither is a typo or an absent param.
+    expect(parseCommunityShelf(ListingKind.profile_pack)).toBe(DEFAULT_COMMUNITY_SHELF);
+    expect(parseCommunityShelf("nonsense")).toBe(DEFAULT_COMMUNITY_SHELF);
+    expect(parseCommunityShelf(undefined)).toBe(DEFAULT_COMMUNITY_SHELF);
+  });
+
+  it("defaults to a shelf the community actually has", () => {
+    expect(COMMUNITY_SHELVES).toContain(DEFAULT_COMMUNITY_SHELF);
   });
 });

--- a/frontend/src/lib/marketplace.ts
+++ b/frontend/src/lib/marketplace.ts
@@ -17,13 +17,49 @@ import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
  * definitions.py``, which is the source of truth; a kind missing from both
  * lists here is offered by neither, which the test below refuses.
  */
-export const USER_SHELVES: readonly ListingKind[] = [ListingKind.profile_pack];
+export const USER_SHELVES = [ListingKind.profile_pack] as const;
 
-export const COMMUNITY_SHELVES: readonly ListingKind[] = [
+export const COMMUNITY_SHELVES = [
   ListingKind.dashboard,
   ListingKind.app,
   ListingKind.auto,
-];
+] as const;
+
+/** A shelf a community installs from — the values `?kind=` may name under
+ *  `/c/{id}/marketplace`. Derived from the list above so a shelf added there is
+ *  a shelf the URL accepts, with nothing else to update. */
+export type CommunityShelf = (typeof COMMUNITY_SHELVES)[number];
+
+/** Where the community marketplace opens when the URL names no shelf, and what
+ *  a `kind` it does not sell normalizes to. */
+export const DEFAULT_COMMUNITY_SHELF: CommunityShelf = ListingKind.dashboard;
+
+const LISTING_KINDS: ReadonlySet<string> = new Set(Object.values(ListingKind));
+const COMMUNITY_SHELF_KINDS: ReadonlySet<string> = new Set(COMMUNITY_SHELVES);
+const USER_SHELF_KINDS: ReadonlySet<string> = new Set(USER_SHELVES);
+
+const isListingKind = (value: unknown): value is ListingKind =>
+  typeof value === "string" && LISTING_KINDS.has(value);
+
+const isCommunityShelf = (value: unknown): value is CommunityShelf =>
+  typeof value === "string" && COMMUNITY_SHELF_KINDS.has(value);
+
+/**
+ * A `kind` URL param as the kind the server named, or undefined when it names
+ * none.
+ *
+ * Both marketplace routes read `kind` through this rather than each spelling
+ * out the values it accepts: the enum the API generates is the list, so a kind
+ * added server-side is one the URL understands as soon as the types are
+ * regenerated.
+ */
+export const parseListingKind = (value: unknown): ListingKind | undefined =>
+  isListingKind(value) ? value : undefined;
+
+/** The same, narrowed to what a community's marketplace sells. Anything else —
+ *  a person's shelf, a typo, nothing at all — opens the default shelf. */
+export const parseCommunityShelf = (value: unknown): CommunityShelf =>
+  isCommunityShelf(value) ? value : DEFAULT_COMMUNITY_SHELF;
 
 /** Whether this kind is bought by a person rather than by a community. */
-export const isUserShelf = (kind: ListingKind): boolean => USER_SHELVES.includes(kind);
+export const isUserShelf = (kind: ListingKind): boolean => USER_SHELF_KINDS.has(kind);

--- a/frontend/src/pages/SettingsGuildAppsPage.tsx
+++ b/frontend/src/pages/SettingsGuildAppsPage.tsx
@@ -30,6 +30,7 @@ import { Blocks, ChevronDown, Loader2, ShieldCheck, Store, TriangleAlert } from 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
 import { AppConnectionsPanel } from "@/components/apps/AppConnectionsPanel";
 import { AppMembersPanel } from "@/components/apps/AppMembersPanel";
 import { AppUpdatesPanel } from "@/components/apps/AppUpdatesPanel";
@@ -73,7 +74,7 @@ export function SettingsGuildAppsPage() {
             <p className="text-muted-foreground text-sm">{t("apps:manage.empty")}</p>
             {isGuildAdmin && (
               <Button variant="outline" asChild>
-                <Link to={gp("/marketplace")} search={{ kind: "app" }}>
+                <Link to={gp("/marketplace")} search={{ kind: ListingKind.app }}>
                   <Store className="mr-1.5 h-4 w-4" />
                   {t("apps:manage.browse")}
                 </Link>

--- a/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceBrowsePage.tsx
@@ -24,17 +24,17 @@ import { useInstalledListings } from "@/hooks/useDashboards";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useGuildApps } from "@/hooks/useGuildApps";
 import { useMarketplaceListings } from "@/hooks/useMarketplace";
+import { type CommunityShelf, parseCommunityShelf } from "@/lib/marketplace";
 
 const PAGE_SIZE = 24;
 /** One line per shelf, so a new kind shows its own rather than the dashboards'.
- *  Partial because not every listing kind is a shelf a guild installs from —
- *  the route keeps those off this page, and anything without a line of its own
- *  falls back to the dashboards'. */
+ *  Keyed on the shelves themselves, so adding one to `COMMUNITY_SHELVES`
+ *  without a line of its own does not compile. */
 const SUBTITLE_KEYS = {
   [ListingKind.dashboard]: "subtitle",
   [ListingKind.app]: "subtitleApps",
   [ListingKind.auto]: "subtitleAuto",
-} as const;
+} as const satisfies Record<CommunityShelf, string>;
 /** Stable keys for the loading placeholders — they never reorder, and an index
  *  key on a list that can change is the lint rule this avoids. */
 const SKELETON_KEYS = ["a", "b", "c", "d", "e", "f"];
@@ -43,13 +43,13 @@ export function MarketplaceBrowsePage() {
   const { t } = useTranslation("marketplace");
   // Which shelf: dashboards, or the apps a guild admin adds.
   //
-  // Defaulted here, not left to the route. `useSearch({ strict: false })` reads
-  // the params as they are — it does not run the route's `validateSearch` — so
-  // relying on that default would mean the filter silently disappears anywhere
-  // the page is mounted another way, and the grid would mix apps into the
-  // dashboards.
-  const search_ = useSearch({ strict: false }) as { kind?: ListingKind };
-  const kind = search_.kind ?? ListingKind.dashboard;
+  // Normalized here through the same parser the route validates with, not left
+  // to the route. `useSearch({ strict: false })` reads the params as they are —
+  // it does not run the route's `validateSearch` — so relying on that would
+  // mean the filter silently disappears anywhere the page is mounted another
+  // way, and the grid would mix apps into the dashboards.
+  const search_ = useSearch({ strict: false });
+  const kind = parseCommunityShelf(search_.kind);
   const [query, setQuery] = useState("");
   // The catalog is a network call per keystroke otherwise, and the grid keeps
   // the previous page while the next one loads.
@@ -90,9 +90,7 @@ export function MarketplaceBrowsePage() {
     <div className="space-y-6">
       <div className="space-y-1">
         <h1 className="font-semibold text-3xl tracking-tight">{t("title")}</h1>
-        <p className="text-muted-foreground text-sm">
-          {t(SUBTITLE_KEYS[kind as keyof typeof SUBTITLE_KEYS] ?? "subtitle")}
-        </p>
+        <p className="text-muted-foreground text-sm">{t(SUBTITLE_KEYS[kind])}</p>
       </div>
 
       <Input

--- a/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
+++ b/frontend/src/pages/marketplace/MarketplaceListingPage.tsx
@@ -18,7 +18,7 @@ import { Download, SearchX } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { ListingKind } from "@/api/generated/initiativeAPI.schemas";
+import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
 import { DashboardCanvas } from "@/components/initiativeTools/dashboards/DashboardCanvas";
 import { InstallAppDialog } from "@/components/marketplace/InstallAppDialog";
 import { InstallListingDialog } from "@/components/marketplace/InstallListingDialog";
@@ -40,6 +40,7 @@ import { useGuildApps } from "@/hooks/useGuildApps";
 import { useGuilds } from "@/hooks/useGuilds";
 import { useMarketplaceListing } from "@/hooks/useMarketplace";
 import { useGuildPath } from "@/lib/guildUrl";
+import { parseCommunityShelf } from "@/lib/marketplace";
 import { resolveArtworkUrl } from "@/lib/uploadUrl";
 import { readConfig, readDefinition } from "@/lib/widgets/definition";
 
@@ -55,12 +56,13 @@ export function MarketplaceListingPage() {
   const { activeGuild } = useGuilds();
 
   const listing = listingQuery.data;
-  const isApp = listing?.kind === "app";
+  const isApp = listing?.kind === ListingKind.app;
   // Back to the shelf this listing was found on, falling back to the listing's
   // own kind when someone arrived by direct link. Both can be unknown when the
-  // listing failed to load — there is nothing to infer a shelf from then, and
-  // the browse route normalizes an absent kind to dashboards.
-  const backToShelf = { kind: shelf ?? listing?.kind };
+  // listing failed to load, and neither is guaranteed to be a shelf this
+  // marketplace has — so the link is built the same way the browse route reads
+  // it, and lands on the default shelf rather than on nothing.
+  const backToShelf = { kind: parseCommunityShelf(shelf ?? listing?.kind) };
   // Installing an app is a guild-admin action; the server enforces it, and the
   // button says so rather than failing after the click.
   const isGuildAdmin = activeGuild?.role === "admin";

--- a/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/marketplace.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/marketplace.tsx
@@ -1,18 +1,13 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
-import { COMMUNITY_SHELVES } from "@/lib/marketplace";
-
-/** Which shelf of this community's marketplace to show. The shelves a person
- *  buys from — profile packs — have their own marketplace and are not here;
- *  see `@/lib/marketplace`. Anything unrecognized normalizes to dashboards. */
-const KINDS = COMMUNITY_SHELVES;
+import { type CommunityShelf, parseCommunityShelf } from "@/lib/marketplace";
 
 export const Route = createFileRoute("/_serverRequired/_authenticated/c/$guildId/marketplace")({
-  validateSearch: (search: Record<string, unknown>): { kind: ListingKind } => ({
-    kind: KINDS.includes(search.kind as ListingKind)
-      ? (search.kind as ListingKind)
-      : ListingKind.dashboard,
+  /** Which shelf of this community's marketplace to show. The shelves a person
+   *  buys from — profile packs — have their own marketplace and are not here;
+   *  see `@/lib/marketplace`, which is where the accepted values come from. */
+  validateSearch: (search: Record<string, unknown>): { kind: CommunityShelf } => ({
+    kind: parseCommunityShelf(search.kind),
   }),
   component: lazyRouteComponent(() =>
     import("@/pages/marketplace/MarketplaceBrowsePage").then((m) => ({

--- a/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/marketplace_.$publicId.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/c/$guildId/marketplace_.$publicId.tsx
@@ -1,15 +1,16 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-import { ListingKind } from "@/api/generated/initiativeAPI.schemas";
-
-const KINDS = Object.values(ListingKind);
+import type { ListingKind } from "@/api/generated/initiativeAPI.schemas";
+import { parseListingKind } from "@/lib/marketplace";
 
 export const Route = createFileRoute(
   "/_serverRequired/_authenticated/c/$guildId/marketplace_/$publicId"
 )({
   // Carried so the back link can return to the shelf the listing was found on.
-  validateSearch: (search: Record<string, unknown>): { kind?: ListingKind } =>
-    KINDS.includes(search.kind as ListingKind) ? { kind: search.kind as ListingKind } : {},
+  validateSearch: (search: Record<string, unknown>): { kind?: ListingKind } => {
+    const kind = parseListingKind(search.kind);
+    return kind ? { kind } : {};
+  },
   component: lazyRouteComponent(() =>
     import("@/pages/marketplace/MarketplaceListingPage").then((m) => ({
       default: m.MarketplaceListingPage,


### PR DESCRIPTION
## Problem

Issue #1405 reports that the marketplace's `?kind=` param is handled by hand in several places. Both marketplace routes wrote out the values they accept and cast their way to them, and two links named the apps shelf as a bare `"app"` string:

```tsx
<Link to={gp("/marketplace")} search={{ kind: "app" }}>
```

The browse page then applied its own separate default (`search_.kind ?? ListingKind.dashboard`), so "which shelf does this URL mean" had three answers in three files.

The tabs the issue suggests are deliberately **not** in this PR — this is the param plumbing they would sit on.

## Changes

`frontend/src/lib/marketplace.ts` becomes the single place a `kind` param is read:

- `parseListingKind(value)` — a `kind` as the enum the API generates, or `undefined`. The accepted values are `Object.values(ListingKind)`, so a kind added server-side is one the URL understands as soon as the types are regenerated.
- `parseCommunityShelf(value)` — the same, narrowed to `COMMUNITY_SHELVES`, falling back to `DEFAULT_COMMUNITY_SHELF`.
- `CommunityShelf` derives from `COMMUNITY_SHELVES` (now a const tuple), which makes the browse page's per-shelf subtitle table exhaustive at compile time — adding a shelf without a subtitle no longer compiles, instead of silently showing the dashboards' line.

Callers:

- Both routes' `validateSearch` call the parsers instead of spelling the values out.
- `MarketplaceBrowsePage` normalizes through the same parser rather than keeping its own default.
- `MarketplaceListingPage`'s back link runs `shelf ?? listing?.kind` through `parseCommunityShelf`, so it always names a shelf this marketplace has; `listing?.kind === "app"` becomes `=== ListingKind.app`.
- The two "add an app" links pass `ListingKind.app`.

## Notes

No behaviour change a user would see, so no changelog entry — the shelves each link opens are the same ones they opened before.

## Testing

- `frontend/src/lib/marketplace.test.ts` — new cases covering every kind the enum publishes, a kind that is not one, each community shelf, and the fallback for a profile pack / typo / absent param.
- `npx tsc --noEmit` — clean.
- `pnpm lint` — 3 warnings, all pre-existing and in untouched files.
- `npx vitest run src/lib/marketplace.test.ts src/pages/marketplace src/components/marketplace src/routes src/components/sidebar/AppsSection.test.tsx` — 54 passed.

Refs #1405