### PR TITLE
Fix four faults behind the 0.66 upgrade failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrading no longer stops when Initiative connects to its database as the database's own owner.** An install from before Initiative had its own least-privilege login names one PostgreSQL role for everything, and 0.66 asks for a fourth connection made as the database owner — which on those installs is that same role. Startup then tried to give it the shape a purpose-made provisioning login gets, PostgreSQL refused (`permission denied to alter role`), and the app never came up. Startup now leaves a role that is already a superuser with exactly the privileges it had, and goes on to everything else. The banner asking you to move that connection to `app_provisioner` is unchanged, and it is still worth doing.
+
+- **The direct-message privacy setting that was never added.** A deployment that ran 0.65 got the direct-message settings table without the column behind the read-receipts switch, and 0.66 had no way to notice: opening messaging settings failed with `column user_dm_settings.send_receipts does not exist`. The column is now added wherever it is missing.
+
+- **Purging a task somebody was assigned to.** Emptying one from the trash failed outright, and the hourly clean-up that removes trash past its retention came back to the same task every hour and failed there too. Assignments are now removed with the task, as every other part of it already was.
+
+- **Handing a community's content to another admin.** Both *Claim unowned content* and *Transfer ownership*, on the community's member screens, failed with a permission error instead of moving anything: the check that the recipient is an admin was reading the account list through a connection that a community's screens deliberately cannot read it through. It now reads the same member roster the rest of those screens do.
+
 - **The whole app no longer scrolls out of the window on a long comment thread.** On a task with enough comments, or a file document with them, focusing the comment box or scrolling over the sidebar moved the entire app — sidebar, header and all — up out of view, leaving a blank band underneath that nothing could scroll back from. The hidden "Delete" label on each comment was being measured against the window instead of the page, and enough of them below the fold made the window itself scrollable.
 
 ## [0.66.0] - 2026-09-07

--- a/backend/alembic/versions/20260907_0234_restore_dm_send_receipts.py
+++ b/backend/alembic/versions/20260907_0234_restore_dm_send_receipts.py
@@ -1,0 +1,37 @@
+"""add user_dm_settings.send_receipts where it is missing
+
+``user_dm_settings`` was created by revision ``20260904_0223``, which shipped in
+0.65.0. ``send_receipts`` was added to that same revision afterwards, in 0.66.0.
+A database that ran 0.65.0 therefore has the table without the column, and
+never sees the added line: the revision is already stamped. Reading DM settings
+on such a database fails with ``column user_dm_settings.send_receipts does not
+exist``.
+
+This adds the column where it is absent and does nothing where 0.66.0 created
+it, so both histories converge.
+
+There is no downgrade: dropping a column the previous revision may or may not
+have created cannot be expressed, and the column is what the app now expects.
+
+Revision ID: 20260907_0234
+Revises: 20260907_0233
+Create Date: 2026-09-07
+"""
+
+from alembic import op
+
+revision = "20260907_0234"
+down_revision = "20260907_0233"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE public.user_dm_settings "
+        "ADD COLUMN IF NOT EXISTS send_receipts boolean NOT NULL DEFAULT true"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/20260907_0235_task_assignees_cascade.py
+++ b/backend/alembic/versions/20260907_0235_task_assignees_cascade.py
@@ -1,0 +1,43 @@
+"""cascade task_assignees when a task is deleted
+
+Every other child of ``tasks`` is taken with it — comments, subtasks, tags,
+property values, assignment digest items all carry ``ON DELETE CASCADE``, and
+queue links are cleared by the ORM relationship. ``task_assignees`` had
+neither: ``Task.assignees`` is a read-only relationship, so nothing removed
+those rows, and the foreign key had no cascade to remove them either.
+
+Hard-deleting a task that anyone was assigned to therefore failed on
+``task_assignees_task_id_fkey`` — purging one from the trash by hand, and the
+hourly retention worker every time it reached one.
+
+Revision ID: 20260907_0235
+Revises: 20260907_0234
+Create Date: 2026-09-07
+"""
+
+from alembic import op
+
+from app.db.guild_migrations import apply_to_all_guild_schemas
+
+revision = "20260907_0235"
+down_revision = "20260907_0234"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT = "task_assignees_task_id_fkey"
+
+
+def _replace(rule: str) -> tuple[str, ...]:
+    return (
+        f"ALTER TABLE task_assignees DROP CONSTRAINT IF EXISTS {_CONSTRAINT}",
+        f"ALTER TABLE task_assignees ADD CONSTRAINT {_CONSTRAINT} "
+        f"FOREIGN KEY (task_id) REFERENCES tasks(id){rule}",
+    )
+
+
+def upgrade() -> None:
+    apply_to_all_guild_schemas(op.get_bind(), *_replace(" ON DELETE CASCADE"))
+
+
+def downgrade() -> None:
+    apply_to_all_guild_schemas(op.get_bind(), *_replace(""))

--- a/backend/app/api/v1/platform_endpoints/ownership_endpoints_test.py
+++ b/backend/app/api/v1/platform_endpoints/ownership_endpoints_test.py
@@ -1,0 +1,98 @@
+"""The guild-admin ownership screens, over HTTP.
+
+Handing content to somebody is the one place ownership moves by hand, so the
+request runs inside the guild's own schema, as that guild's admin. Everything
+it reads has to be readable from there — a guild session reads people through
+``guild_member_profiles``, not ``users`` — and the service-level tests for
+``app.services.tenant.ownership`` run on the setup session, which sees more
+than a request does.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.tools import Tool
+from app.models.platform.guild import GuildRole
+from app.services.tenant import ownership as ownership_service
+from app.testing import (
+    TOOL_FACTORIES,
+    route_session_to_guild,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def _released_project(session: AsyncSession, actor):
+    """A project in ``actor``'s initiative that nobody owns."""
+    project = await TOOL_FACTORIES[Tool.project](session, actor.initiative, actor.user)
+    await route_session_to_guild(session, actor.guild.id)
+    await ownership_service.set_resource_owner(
+        session, tool=Tool.project, row=project, new_owner_id=None
+    )
+    await session.commit()
+    return project
+
+
+async def test_a_guild_admin_can_claim_unowned_content(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    project = await _released_project(session, admin)
+
+    response = await client.post(
+        f"/api/v1/g/{admin.guild.id}/users/unowned-content/claim",
+        headers=admin.headers,
+        json={"new_owner_id": admin.user.id},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["total"] >= 1, response.text
+
+    await route_session_to_guild(session, admin.guild.id)
+    owners = await ownership_service.summarize_unowned_content(
+        session, guild_id=admin.guild.id
+    )
+    assert (Tool.project, project.id) not in {(i.tool, i.id) for i in owners}
+
+
+async def test_content_cannot_be_handed_to_an_ordinary_member(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The recipient check is the same query, from the other side."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    member = await acting_user(
+        guild_role=GuildRole.member,
+        guild=admin.guild,
+        initiative=admin.initiative,
+        initiative_role="member",
+    )
+    await _released_project(session, admin)
+
+    response = await client.post(
+        f"/api/v1/g/{admin.guild.id}/users/unowned-content/claim",
+        headers=admin.headers,
+        json={"new_owner_id": member.user.id},
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "OWNER_MUST_BE_GUILD_ADMIN"
+
+
+async def test_ownership_transfers_between_guild_admins(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    owner = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    receiver = await acting_user(
+        guild_role=GuildRole.admin,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="project_manager",
+    )
+    await TOOL_FACTORIES[Tool.project](session, owner.initiative, owner.user)
+
+    response = await client.post(
+        f"/api/v1/g/{owner.guild.id}/users/{owner.user.id}/transfer-ownership",
+        headers=owner.headers,
+        json={"new_owner_id": receiver.user.id},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["total"] >= 1, response.text

--- a/backend/app/api/v1/platform_endpoints/ownership_endpoints_test.py
+++ b/backend/app/api/v1/platform_endpoints/ownership_endpoints_test.py
@@ -14,6 +14,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.tools import Tool
 from app.models.platform.guild import GuildRole
+from app.models.platform.user import UserStatus
 from app.services.tenant import ownership as ownership_service
 from app.testing import (
     TOOL_FACTORIES,
@@ -96,3 +97,47 @@ async def test_ownership_transfers_between_guild_admins(
     )
     assert response.status_code == 200, response.text
     assert response.json()["total"] >= 1, response.text
+
+
+async def test_content_cannot_be_handed_outside_the_guild(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """The roster view is a column boundary, not a row one: it publishes those
+    nine columns for every account. What confines the recipient to this guild
+    is the membership row the check joins to — scoped to the current guild by
+    that table's own policy, and named again by the query. An admin of some
+    other guild is refused exactly like a stranger.
+    """
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    elsewhere = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    assert elsewhere.guild.id != admin.guild.id
+    await _released_project(session, admin)
+
+    response = await client.post(
+        f"/api/v1/g/{admin.guild.id}/users/unowned-content/claim",
+        headers=admin.headers,
+        json={"new_owner_id": elsewhere.user.id},
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "OWNER_MUST_BE_GUILD_ADMIN"
+
+
+async def test_content_cannot_be_handed_to_a_suspended_admin(
+    client: AsyncClient, session: AsyncSession, acting_user
+):
+    """``status`` is the one thing the roster view supplies that the
+    membership row cannot, and it is why the check reads the view at all."""
+    admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    frozen = await acting_user(guild_role=GuildRole.admin, guild=admin.guild)
+    frozen.user.status = UserStatus.suspended
+    session.add(frozen.user)
+    await session.commit()
+    await _released_project(session, admin)
+
+    response = await client.post(
+        f"/api/v1/g/{admin.guild.id}/users/unowned-content/claim",
+        headers=admin.headers,
+        json={"new_owner_id": frozen.user.id},
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "OWNER_MUST_BE_GUILD_ADMIN"

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -1350,14 +1350,17 @@ async def _require_receiving_admin(
     never widen anyone's reach. An ordinary member could end up nominal owner of
     content in an initiative they are not in, which RLS would then hide from
     them.
+
+    The caller has routed into the guild's schema, so the roster comes from
+    ``MemberProfile`` — the view a guild session reads people through.
     """
     recipient = (
         await session.exec(
-            select(User)
-            .join(GuildMembership, GuildMembership.user_id == User.id)
+            select(MemberProfile.id)
+            .join(GuildMembership, GuildMembership.user_id == MemberProfile.id)
             .where(
-                User.id == new_owner_id,
-                User.status == UserStatus.active,
+                MemberProfile.id == new_owner_id,
+                MemberProfile.status == UserStatus.active,
                 GuildMembership.guild_id == guild_id,
                 GuildMembership.role == GuildRole.admin,
             )

--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -77,6 +77,15 @@ _ADMINISTERED_ROLE_PATTERN = (
 )
 
 
+#: Clauses that take a privilege away from a role that already holds it. The
+#: bootstrap creates the logins the app needs; a role the deployment already
+#: runs as a superuser keeps the attributes it has. Postgres refuses to remove
+#: SUPERUSER from the cluster's own bootstrap role at all, and that is the role
+#: an install predating ``app_provisioner`` names in both ``DATABASE_URL`` and
+#: ``DATABASE_URL_BOOTSTRAP``.
+_DEMOTING_CLAUSES = frozenset({"NOSUPERUSER", "NOBYPASSRLS"})
+
+
 @dataclass(frozen=True)
 class LoginRole:
     """One login the bootstrap maintains, as named by its connection URL."""
@@ -84,6 +93,13 @@ class LoginRole:
     name: str
     password: str | None
     attributes: str
+
+    @property
+    def attributes_if_superuser(self) -> str:
+        """The same shape, minus the clauses that would demote the role."""
+        return " ".join(
+            word for word in self.attributes.split() if word not in _DEMOTING_CLAUSES
+        )
 
 
 @dataclass(frozen=True)
@@ -141,10 +157,15 @@ DECLARE
     role_name text := current_setting('app._bootstrap_role');
     role_attrs text := current_setting('app._bootstrap_attrs');
     role_pw text := nullif(current_setting('app._bootstrap_pw'), '');
+    already_superuser boolean;
     verb text;
 BEGIN
-    SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name)
-                THEN 'ALTER' ELSE 'CREATE' END INTO verb;
+    -- NULL when the role does not exist yet, which is what selects CREATE.
+    SELECT rolsuper INTO already_superuser FROM pg_roles WHERE rolname = role_name;
+    verb := CASE WHEN already_superuser IS NULL THEN 'CREATE' ELSE 'ALTER' END;
+    IF already_superuser THEN
+        role_attrs := current_setting('app._bootstrap_attrs_superuser');
+    END IF;
     IF role_pw IS NULL THEN
         EXECUTE format('%s ROLE %I WITH %s', verb, role_name, role_attrs);
     ELSE
@@ -251,7 +272,10 @@ _TRANSFER_STATEMENTS = """
 WITH app_tables AS (
     SELECT unnest(string_to_array(current_setting('app._bootstrap_tables'), ',')) AS name
 ), target AS (
+    -- Empty when the bootstrap connects as the provisioning role itself, which
+    -- makes every branch below return no rows: it already owns what it owns.
     SELECT current_setting('app._bootstrap_role') AS role
+     WHERE current_setting('app._bootstrap_role') <> current_user
 )
 SELECT format('table %I.%I', n.nspname, c.relname) AS label,
        format('ALTER TABLE %I.%I OWNER TO %I', n.nspname, c.relname, target.role) AS stmt
@@ -480,13 +504,21 @@ async def _set_local(conn, key: str, value: str) -> None:
     await conn.execute(text("SELECT set_config(:k, :v, true)"), {"k": key, "v": value})
 
 
+async def _ensure_role(conn, role: LoginRole) -> None:
+    """Create the login, or bring an existing one to this shape."""
+    await _set_local(conn, "app._bootstrap_role", role.name)
+    await _set_local(conn, "app._bootstrap_attrs", role.attributes)
+    await _set_local(
+        conn, "app._bootstrap_attrs_superuser", role.attributes_if_superuser
+    )
+    await _set_local(conn, "app._bootstrap_pw", role.password or "")
+    await conn.execute(text(_ENSURE_ROLE))
+
+
 async def _apply_roles(conn, roles: tuple[LoginRole, ...]) -> None:
     provisioner = roles[0]
     for role in roles:
-        await _set_local(conn, "app._bootstrap_role", role.name)
-        await _set_local(conn, "app._bootstrap_attrs", role.attributes)
-        await _set_local(conn, "app._bootstrap_pw", role.password or "")
-        await conn.execute(text(_ENSURE_ROLE))
+        await _ensure_role(conn, role)
     await _set_local(conn, "app._bootstrap_pw", "")
 
     # Everything below acts for the provisioning role.
@@ -599,6 +631,7 @@ def bootstrap_sql() -> str:
             f"-- {role.name}",
             setting("app._bootstrap_role", role.name),
             setting("app._bootstrap_attrs", role.attributes),
+            setting("app._bootstrap_attrs_superuser", role.attributes_if_superuser),
             setting("app._bootstrap_pw", role.password or ""),
             _ENSURE_ROLE.strip(),
         ]

--- a/backend/app/db/bootstrap_test.py
+++ b/backend/app/db/bootstrap_test.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from app.db.bootstrap import (
+    LoginRole,
     bootstrap_sql,
     login_roles,
     search_operator_sql,
@@ -90,3 +91,72 @@ def test_the_stock_operator_is_not_touched():
     joined = "\n".join(search_operator_sql())
     assert "public.@@@" in joined
     assert "CREATE OPERATOR pg_catalog" not in joined
+
+
+def test_a_role_that_is_already_a_superuser_keeps_what_it_has():
+    """The provisioner's shape is applied to an existing superuser without the
+    clauses that would take privileges off it.
+
+    An install predating ``app_provisioner`` names the same role in
+    ``DATABASE_URL`` and ``DATABASE_URL_BOOTSTRAP`` — the cluster's own
+    bootstrap role, which Postgres will not let anyone demote.
+    """
+    provisioner, _app_login, _system = login_roles()
+    kept = provisioner.attributes_if_superuser.split()
+    assert kept == ["LOGIN", "CREATEROLE"]
+
+
+def test_the_printed_sql_carries_both_shapes():
+    """``--print-sql`` runs the same statements, so it needs the same settings."""
+    body = bootstrap_sql()
+    assert body.count("set_config('app._bootstrap_attrs'") == 3
+    assert body.count("set_config('app._bootstrap_attrs_superuser'") == 3
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("created_with", "attribute", "expected"),
+    [
+        # An install predating app_provisioner names one role in both
+        # DATABASE_URL and DATABASE_URL_BOOTSTRAP — the cluster's own bootstrap
+        # role, which Postgres will not let anyone demote.
+        ("SUPERUSER", "rolsuper", True),
+        # The counterpart: an ordinary role still converges on the shape, so a
+        # provisioner created with more than it needs gives it up.
+        ("BYPASSRLS", "rolbypassrls", False),
+    ],
+)
+async def test_the_provisioner_shape_on_an_existing_role(
+    created_with, attribute, expected
+):
+    """What applying the provisioner's attributes does to a role that is
+    already there, by what that role already holds."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlalchemy.pool import NullPool
+
+    from app.db.bootstrap import _ensure_role
+    from conftest import RUN_ID, TEST_DATABASE_URL
+
+    # Roles are cluster-global; key the probe to this run so concurrent
+    # checkouts and xdist workers never drop each other's.
+    name = f"test_{RUN_ID}_probe_{created_with.lower()}"
+    provisioner, _app_login, _system = login_roles()
+    engine = create_async_engine(TEST_DATABASE_URL, poolclass=NullPool)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP ROLE IF EXISTS "{name}"'))
+            await conn.execute(text(f'CREATE ROLE "{name}" {created_with}'))
+        try:
+            async with engine.begin() as conn:
+                await _ensure_role(conn, LoginRole(name, None, provisioner.attributes))
+                held = await conn.scalar(
+                    text(f"SELECT {attribute} FROM pg_roles WHERE rolname = :n"),
+                    {"n": name},
+                )
+            assert held is expected
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'DROP ROLE IF EXISTS "{name}"'))
+    finally:
+        await engine.dispose()

--- a/backend/app/models/tenant/task.py
+++ b/backend/app/models/tenant/task.py
@@ -2,7 +2,17 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Optional, TYPE_CHECKING
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, JSON, Numeric, String, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    JSON,
+    Numeric,
+    String,
+    Text,
+)
 from sqlmodel import Enum as SQLEnum, Field, Relationship, SQLModel
 
 from app.models.tenant._mixins import CreatedByMixin, SoftDeleteMixin
@@ -71,7 +81,16 @@ class TaskStatus(CreatedByMixin, table=True):
 class TaskAssignee(SQLModel, table=True):
     __tablename__ = "task_assignees"
 
-    task_id: int = Field(foreign_key="tasks.id", primary_key=True)
+    # ``Task.assignees`` is a read-only view over this table, so nothing in the
+    # ORM clears these rows when a task is hard-deleted. The database does.
+    task_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("tasks.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        )
+    )
     user_id: int = Field(foreign_key="users.id", primary_key=True, index=True)
     guild_id: Optional[int] = Field(
         default=None, foreign_key="guilds.id", nullable=True

--- a/backend/app/services/tenant/trash_purge_test.py
+++ b/backend/app/services/tenant/trash_purge_test.py
@@ -13,12 +13,14 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.db.soft_delete_filter import select_including_deleted
 from app.models.tenant.initiative import Initiative
 from app.models.tenant.project import Project
+from app.models.tenant.task import Task
 from app.services.tenant.soft_delete import soft_delete_entity
 from app.services.tenant.trash_purge import _run_purge_pass
 from app.testing.factories import (
     create_guild,
     create_initiative,
     create_project,
+    create_task,
     create_user,
 )
 
@@ -250,3 +252,43 @@ async def test_auto_purge_skips_non_active_guilds(session: AsyncSession, role_se
         )
     ).scalar_one()
     assert count == 0, "reactivated guild's due trash must purge again"
+
+
+async def test_a_task_with_assignees_can_be_purged(session: AsyncSession):
+    """``task_assignees`` rows go with the task.
+
+    ``Task.assignees`` is read-only, so the ORM clears nothing there; the
+    foreign key is what takes them. Without the cascade a purge — by hand from
+    the trash, or by this worker on retention — dies on
+    ``task_assignees_task_id_fkey`` and comes back to the same task every hour.
+    """
+    user = await create_user(session)
+    guild = await create_guild(session, creator=user)
+    initiative = await create_initiative(session, guild, user)
+    project = await create_project(session, initiative, user)
+    task = await create_task(session, project, assignees=[user])
+
+    await soft_delete_entity(
+        session, task, deleted_by_user_id=user.id, retention_days=1
+    )
+    await session.commit()
+
+    refreshed = (
+        await session.exec(select_including_deleted(Task).where(Task.id == task.id))
+    ).one()
+    refreshed.purge_at = datetime.now(timezone.utc) - timedelta(days=2)
+    session.add(refreshed)
+    await session.commit()
+
+    await _run_purge_pass(session, now=datetime.now(timezone.utc))
+    await session.commit()
+
+    assert (
+        await session.exec(select_including_deleted(Task).where(Task.id == task.id))
+    ).one_or_none() is None
+    left = await session.exec(
+        text("SELECT count(*) FROM task_assignees WHERE task_id = :t").bindparams(
+            t=task.id
+        )
+    )
+    assert left.one()[0] == 0


### PR DESCRIPTION
Closes #1420.

Four separate faults, all reported in that one issue. Each was reproduced first and each of the new tests fails on the commit before its fix.

## 1. Startup fails when the bootstrap connection is also `DATABASE_URL`'s role

An install from before `app_provisioner` names one Postgres role in `DATABASE_URL`, and that role is the database owner — so the fourth connection 0.66 asks for points at itself. Startup applied the provisioning shape to it, `NOSUPERUSER` included, and Postgres refuses that outright for the cluster's own bootstrap role:

```
permission denied to alter role
DETAIL: The bootstrap superuser must have the SUPERUSER attribute.
CONTEXT: SQL statement "ALTER ROLE initiative WITH LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS PASSWORD '…'"
```

The app never came up. Note that this is exactly what both the deprecation banner and the `0-66-search-needs-bootstrap-connection` announcement tell those deployments to do — step 1 of the banner is "set `DATABASE_URL_BOOTSTRAP` to this same connection URL".

On any *other* superuser the `ALTER` would have succeeded instead and taken the attribute off a role the deployment set up itself, mid-boot, which then costs it the search operator on the same start.

A role that is already a superuser now keeps the attributes it has. Every other role is brought to the full shape as before, so a provisioner created with more than it needs still gives it up. The ownership handover also returns nothing when the bootstrap connects as the provisioning role — it already owns what it owns.

Reproduced end to end against a scratch database with both URLs naming the cluster's bootstrap superuser: fails with the error above on `dev`, applies all three roles and the search operator with the fix.

## 2. `user_dm_settings.send_receipts` is missing on anything that ran 0.65

Revision `20260904_0223` shipped in **v0.65.0 without `send_receipts`**; c9936a22f added the column to that same revision in v0.66.0, and no other revision adds it anywhere:

```
$ git show v0.65.0:backend/alembic/versions/20260904_0223_direct_messages.py | grep -c send_receipts
0
$ git show v0.66.0:backend/alembic/versions/20260904_0223_direct_messages.py | grep -c send_receipts
1
```

A database that ran 0.65 has the table stamped at 0223 without the column, and upgrading cannot fix it — 0223 does not run twice. `GET /api/v1/me/dm-settings` 500s there forever. New revision `20260907_0234` adds the column where it is absent and does nothing where 0.66 created it.

## 3. Purging a task with assignees

`task_assignees_task_id_fkey` had no `ON DELETE CASCADE`, and `Task.assignees` is `viewonly`, so nothing removed those rows. Every other child of `tasks` was already covered one way or the other. Hard-deleting a task anyone was assigned to failed:

```
update or delete on table "tasks" violates foreign key constraint
"task_assignees_task_id_fkey" on table "task_assignees"
```

That is a 500 on `DELETE /trash/task/{id}/purge`, and the hourly retention worker hitting the same task every hour from then on. Guild migration `20260907_0235` adds the cascade to `guild_template` and every `guild_<id>`; the model carries it too.

## 4. Claim-unowned-content and transfer-ownership return 403

Both route into the guild's schema and act as that guild's admin, but `_require_receiving_admin` selected `public.users`, which a guild session does not read people through:

```
insufficient_privilege mapped to 403: POST /api/v1/g/3/users/unowned-content/claim
orig=…InsufficientPrivilegeError: permission denied for table users
```

It now reads `MemberProfile`, the roster view the rest of those screens use, which carries the `id` and `status` it needs. The service-level tests run on the setup session, which sees more than a request does, so both endpoints get their own tests here.

## Not fixed

`GET /api/v1/notifications/stream` 404s in the reporter's log because that route is a WebSocket. A plain `GET` reaching it means the `Upgrade` header was dropped in front of the app — reverse-proxy configuration on their side, not a change here.

## Schema changes

Two new revisions, head moves `20260907_0233` → `20260907_0235`:

- `20260907_0234` — `ALTER TABLE public.user_dm_settings ADD COLUMN IF NOT EXISTS send_receipts boolean NOT NULL DEFAULT true`. No downgrade: dropping a column the previous revision may or may not have created cannot be expressed.
- `20260907_0235` — replaces `task_assignees_task_id_fkey` with an `ON DELETE CASCADE` one in every guild schema. Downgrade puts it back without the rule.

No env changes.

## Testing

```
cd backend && pytest -n 4 app/db alembic app/models app/services/tenant/ownership_test.py   # 830 passed
cd backend && pytest -n 0 app/db/bootstrap_test.py \
    app/api/v1/platform_endpoints/ownership_endpoints_test.py \
    app/services/tenant/trash_purge_test.py app/db/model_drift_test.py                       # 21 passed
ruff check app conftest.py alembic && ruff format app conftest.py alembic && ty check app
```

Each fix was also checked against its own failure by reverting it:

- bootstrap — `ensure_database_bootstrap` against a scratch DB with both URLs on the cluster superuser: `permission denied to alter role` before, applied after.
- cascade — flipping `guild_template`'s constraint back reproduces the FK violation in `test_a_task_with_assignees_can_be_purged`.
- roster — all three ownership endpoint tests fail with `permission denied for table users` on the parent commit.
