### PR TITLE
Revert "Decide tool sharing in the database"

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/comments.py
+++ b/backend/app/api/v1/tenant_endpoints/comments.py
@@ -19,6 +19,9 @@ from app.models.tenant.initiative import Initiative
 from app.models.tenant.project import Project
 from app.models.tenant.task import Task
 from app.models.platform.user import User
+from app.services.permissions import (
+    dac_scope_clause,
+)
 from app.schemas.tenant.comment import (
     CommentAuthor,
     CommentCreate,
@@ -129,7 +132,15 @@ async def recent_comments(
     legs = [
         and_(
             Comment.task_id.isnot(None),
-            Comment.task_id.in_(select(Task.id)),
+            Comment.task_id.in_(
+                select(Task.id)
+                .join(Project, Project.id == Task.project_id)
+                .where(
+                    dac_scope_clause(
+                        Tool.project, Project.id, user_id, guild_id=guild_id
+                    )
+                )
+            ),
         )
     ]
     for tool, target in comments_service.TOOL_COMMENT_TARGETS.items():
@@ -137,7 +148,10 @@ async def recent_comments(
         fk = getattr(Comment, target.column)
         # The entity's own comment switch gates its thread, so it gates the
         # feed too.
-        parent_ids = select(model.id).where(model.comments_enabled.is_(True))
+        parent_ids = select(model.id).where(
+            dac_scope_clause(tool, model.id, user_id, guild_id=guild_id),
+            model.comments_enabled.is_(True),
+        )
         if target.feature_disabled is not None:
             # The tool's master switch gates the thread, so it gates the feed
             # too. A parent that names no initiative (a guild calendar) has no

--- a/backend/app/api/v1/tenant_endpoints/property_definitions.py
+++ b/backend/app/api/v1/tenant_endpoints/property_definitions.py
@@ -18,6 +18,7 @@ from app.api.deps import (
     get_guild_membership,
 )
 from app.core.messages import PropertyMessages
+from app.core.tools import Tool
 from app.models.tenant.calendar import Calendar
 from app.models.tenant.calendar_event import CalendarEvent
 from app.models.tenant.document import Document
@@ -43,6 +44,7 @@ from app.schemas.tenant.tag import (
     TaggedEventSummary,
     TaggedTaskSummary,
 )
+from app.services import permissions as permissions_service
 from app.services.tenant import properties as properties_service
 
 router = APIRouter()
@@ -335,11 +337,25 @@ async def get_property_entities(
     """
     defn = await _get_definition_or_404(session, definition_id)
 
+    task_project_scope = permissions_service.dac_scope_clause(
+        Tool.project,
+        Task.project_id,
+        current_user.id,
+        guild_id=guild_context.guild_id,
+    )
+    doc_scope = permissions_service.dac_scope_clause(
+        Tool.document,
+        Document.id,
+        current_user.id,
+        guild_id=guild_context.guild_id,
+    )
+
     tasks_stmt = (
         select(Task)
         .join(TaskPropertyValue, TaskPropertyValue.task_id == Task.id)
         .where(
             TaskPropertyValue.property_id == defn.id,
+            task_project_scope,
         )
         .options(selectinload(Task.project))
     )
@@ -360,6 +376,7 @@ async def get_property_entities(
         .join(DocumentPropertyValue, DocumentPropertyValue.document_id == Document.id)
         .where(
             DocumentPropertyValue.property_id == defn.id,
+            doc_scope,
         )
         .options(selectinload(Document.initiative))
     )

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -1032,18 +1032,16 @@ async def _allowed_project_ids(
     those markers sit beside.
     """
     conditions = [
+        permissions_service.dac_scope_clause(
+            Tool.project, Project.id, user.id, guild_id=guild_id
+        )
+        if project_id is not None
+        else permissions_service.granted_scope_clause(
+            Tool.project, Project.id, user.id, guild_id=guild_id
+        ),
         Initiative.guild_id == guild_id,
         Project.is_archived == False,  # noqa: E712
     ]
-    if project_id is None:
-        # Spanning initiatives, the answer is what has been shared with the
-        # reader, which is a narrower question than "may I reach it" — so it
-        # stays here rather than resting on the table's own policy.
-        conditions.append(
-            permissions_service.granted_scope_clause(
-                Tool.project, Project.id, user.id, guild_id=guild_id
-            )
-        )
     if not include_templates:
         conditions.append(Project.is_template == False)  # noqa: E712
     stmt = select(Project.id).join(Project.initiative).where(*conditions)

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -33,7 +33,6 @@ from sqlalchemy.schema import CheckConstraint, CreateTable
 from app.db.initiative_rls import (
     INITIATIVE_PATHS,
     INITIATIVE_SCOPED_TABLES,
-    dac_asks_at_write,
     InitiativePath,
 )
 from app.db.soft_delete_filter import SOFT_DELETE_TABLES
@@ -175,18 +174,6 @@ def _table_block(table: str, path: InitiativePath) -> str:
     ]
     for suffix, command, clause, write in _COMMANDS:
         pred = path.predicate(table, write)
-        if path.dac is not None:
-            # What the command asks of sharing is per table: changing content
-            # takes write on the resource, where responding to it (a comment,
-            # a reaction) and keeping a reader's own record of it do not.
-            sharing = path.dac.predicate(table, dac_asks_at_write(table, command))
-            # A resource has no sharing before it exists, so the table that IS
-            # the resource carries no leg on INSERT — creating one answers to
-            # the initiative-role gate instead. A child table keeps it: adding a
-            # task means reaching the project it goes in.
-            exempt = command == "INSERT" and path.dac.self_governed
-            if sharing is not None and not exempt:
-                pred = f"{pred} AND {sharing}"
         if command == "INSERT" and table in _TRIGGER_WRITTEN_INSERT:
             pred = _TRIGGER_WRITTEN_INSERT[table]
         name = f"initiative_member_{suffix}"

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -42,91 +42,6 @@ PathBuilder = Callable[[str, bool], str]
 # expression yielding that row's initiative id (or NULL).
 RowLocator = Callable[[str], str]
 
-# A DAC builder has the same shape as a PathBuilder but may answer None, for a
-# table no tool's sharing governs — the guild's own vocabulary, an initiative's
-# configuration. None renders no leg at all rather than a `true` one.
-DacBuilder = Callable[[str, bool], "str | None"]
-
-#: Every tool's own table, keyed by table name. The sharing gate is DERIVED from
-#: this rather than declared per table: a row is governed by the tool it belongs
-#: to, and a table that belongs to none is governed by none. So a seventh tool
-#: gates its own rows and its children's the day its table exists.
-_TOOL_BY_TABLE: dict[str, Tool] = {tool.plural: tool for tool in Tool}
-
-
-@dataclass(frozen=True)
-class DacPath:
-    """How a row names the resource whose sharing governs it — gate 4, as SQL.
-
-    ``predicate`` renders the ``public.resource_access(...)`` leg that the
-    table's policies AND onto the initiative one, or None where nothing governs
-    the table. ``self_governed`` marks a table that IS the shared resource; its
-    INSERT carries no leg, because a resource has no sharing until it exists
-    (see ``app.db.guild_ddl``).
-    """
-
-    predicate: DacBuilder
-    self_governed: bool = False
-
-
-def _resource_call(tool: str, resource_id: str, initiative: str, write: bool) -> str:
-    """One ``public.resource_access`` call, in policy form."""
-    return (
-        f"public.resource_access({tool}, {resource_id}, {_UID}, "
-        f"{initiative}, {'true' if write else 'false'})"
-    )
-
-
-def _dac_self(tool: Tool | None = None) -> DacPath:
-    """The row IS the shared resource. Which tool that is comes from the table
-    name at render time, so a table that is no tool's renders nothing; a caller
-    reaching the table under an alias (reactions, below) names the tool itself.
-    """
-
-    def build(t: str, w: bool) -> str | None:
-        governing = tool if tool is not None else _TOOL_BY_TABLE.get(t)
-        if governing is None:
-            return None
-        return _resource_call(
-            f"'{governing.value}'", f"{t}.id", f"{t}.initiative_id", w
-        )
-
-    return DacPath(predicate=build, self_governed=True)
-
-
-def _dac_via(
-    parent: str, fk: str, *, parent_pk: str = "id", alias: str = "dac"
-) -> DacPath:
-    """The row is shared as part of its parent — a task by its project."""
-    tool = _TOOL_BY_TABLE.get(parent)
-    if tool is None:
-        return DacPath(predicate=lambda t, w: None)
-
-    return DacPath(
-        predicate=lambda t, w: (
-            f"EXISTS (SELECT 1 FROM {parent} {alias} "
-            f"WHERE {alias}.{parent_pk} = {t}.{fk} AND "
-            + _resource_call(
-                f"'{tool.value}'", f"{alias}.id", f"{alias}.initiative_id", w
-            )
-            + ")"
-        )
-    )
-
-
-def _dac_two_hop(mid: str, mid_fk: str, parent: str, fk: str) -> DacPath:
-    """Two hops to the governing resource: ``table.<fk> -> mid -> parent`` — a
-    subtask by its task's project, an attendee by its event's calendar."""
-    tool = _TOOL_BY_TABLE[parent]
-    return DacPath(
-        predicate=lambda t, w: (
-            f"EXISTS (SELECT 1 FROM {mid} dmid JOIN {parent} dpar "
-            f"ON dpar.id = dmid.{mid_fk} WHERE dmid.id = {t}.{fk} AND "
-            + _resource_call("'" + tool.value + "'", "dpar.id", "dpar.initiative_id", w)
-            + ")"
-        )
-    )
-
 
 @dataclass(frozen=True)
 class InitiativePath:
@@ -141,10 +56,6 @@ class InitiativePath:
 
     predicate: PathBuilder
     initiative_expr: RowLocator
-    #: The sharing leg (gate 4), ANDed onto ``predicate`` by the DDL renderer.
-    #: Derived by the factories below from the parent a table already declares,
-    #: so it is never a second list to keep in step.
-    dac: DacPath | None = None
 
 
 #: The routed guild-admin leg, for rows that span every initiative in a guild.
@@ -155,12 +66,23 @@ def _access(initiative_expr: str, write: bool) -> str:
     return f"public.initiative_access({initiative_expr}, {_UID}, {'true' if write else 'false'})"
 
 
+def _resource_access(table: str, write: bool) -> str:
+    """The sharing decision for a row that stores which resource governs it.
+
+    ``dac_tool``/``dac_id`` name that resource — often a parent — so the check
+    needs no join. A NULL ``dac_tool`` means the row answers to no sharing.
+    """
+    return (
+        f"public.resource_access({table}.dac_tool, {table}.dac_id, {_UID}, "
+        f"{table}.initiative_id, {'true' if write else 'false'})"
+    )
+
+
 def direct() -> InitiativePath:
     """The table has its own ``initiative_id`` column."""
     return InitiativePath(
         predicate=lambda t, w: _access(f"{t}.initiative_id", w),
         initiative_expr=lambda r: f"{r}.initiative_id",
-        dac=_dac_self(),
     )
 
 
@@ -176,7 +98,6 @@ def via(parent: str, fk: str, *, parent_pk: str = "id") -> InitiativePath:
             f"(SELECT {parent}.initiative_id FROM {parent} "  # noqa: S608
             f"WHERE {parent}.{parent_pk} = {r}.{fk})"
         ),
-        dac=_dac_via(parent, fk, parent_pk=parent_pk),
     )
 
 
@@ -192,7 +113,6 @@ def via_task_project(fk: str = "task_id") -> InitiativePath:
             f"(SELECT pr.initiative_id FROM tasks tk "  # noqa: S608
             f"JOIN projects pr ON pr.id = tk.project_id WHERE tk.id = {r}.{fk})"
         ),
-        dac=_dac_two_hop("tasks", "project_id", "projects", fk),
     )
 
 
@@ -208,7 +128,6 @@ def via_queue_item(fk: str = "queue_item_id") -> InitiativePath:
             f"(SELECT q.initiative_id FROM queue_items qi "  # noqa: S608
             f"JOIN queues q ON q.id = qi.queue_id WHERE qi.id = {r}.{fk})"
         ),
-        dac=_dac_two_hop("queue_items", "queue_id", "queues", fk),
     )
 
 
@@ -224,7 +143,6 @@ def via_post_poll(fk: str = "poll_id") -> InitiativePath:
             f"(SELECT po.initiative_id FROM post_polls pp "  # noqa: S608
             f"JOIN posts po ON po.id = pp.post_id WHERE pp.id = {r}.{fk})"
         ),
-        dac=_dac_two_hop("post_polls", "post_id", "posts", fk),
     )
 
 
@@ -241,12 +159,11 @@ def via_event_calendar(fk: str = "calendar_event_id") -> InitiativePath:
             f"(SELECT cal.initiative_id FROM calendar_events ce "  # noqa: S608
             f"JOIN calendars cal ON cal.id = ce.calendar_id WHERE ce.id = {r}.{fk})"
         ),
-        dac=_dac_two_hop("calendar_events", "calendar_id", "calendars", fk),
     )
 
 
 def via_property(
-    entity_from: str, entity_pred: str, entity_init: str, dac: DacPath | None = None
+    entity_from: str, entity_pred: str, entity_init: str
 ) -> InitiativePath:
     """Property-value rows: join the entity and ``property_definitions`` and
     require both resolve to the SAME initiative, then check access on it.
@@ -273,7 +190,6 @@ def via_property(
             f"(SELECT pd.initiative_id FROM property_definitions pd "  # noqa: S608
             f"WHERE pd.id = {r}.property_id)"
         ),
-        dac=dac,
     )
 
 
@@ -305,28 +221,6 @@ _COMMENT_PARENTS: tuple[tuple[str, str, str, str], ...] = (
 COMMENT_PARENT_COLUMNS: tuple[str, ...] = tuple(col for col, *_ in _COMMENT_PARENTS)
 
 
-def _comments_dac() -> DacPath:
-    """Which tool's sharing governs a comment — its one parent's.
-
-    Derived from ``_COMMENT_PARENTS``, so the sharing legs and the membership
-    legs are the same list read twice. A comment on a task is the one parent
-    whose resource is not its own column: a task is shared as part of its
-    project.
-    """
-
-    def build(t: str, w: bool) -> str:
-        legs = []
-        for col, *_ in _COMMENT_PARENTS:
-            if col == "task_id":
-                leg = _dac_two_hop("tasks", "project_id", "projects", col)
-            else:
-                leg = _dac_via(Tool(col.removesuffix("_id")).plural, col)
-            legs.append(f"({t}.{col} IS NOT NULL AND {leg.predicate(t, w)})")
-        return "(" + " OR ".join(legs) + ")"
-
-    return DacPath(predicate=build)
-
-
 def comments_path() -> InitiativePath:
     """Comments hang off exactly one parent — a task or any tool entity —
     declared once in ``_COMMENT_PARENTS`` and rendered here both ways."""
@@ -347,7 +241,7 @@ def comments_path() -> InitiativePath:
         )
         return f"COALESCE({lookups})"
 
-    return InitiativePath(predicate=build, initiative_expr=locate, dac=_comments_dac())
+    return InitiativePath(predicate=build, initiative_expr=locate)
 
 
 def reactions_path() -> InitiativePath:
@@ -363,25 +257,6 @@ def reactions_path() -> InitiativePath:
         ReactionTarget.comment: comments_path(),
         ReactionTarget.post: direct(),
     }
-    # The same targets, read for sharing. A post answers for itself and is
-    # named explicitly, because under an alias the table name no longer says
-    # which tool it is.
-    dac_legs: dict[ReactionTarget, DacPath] = {
-        ReactionTarget.comment: _comments_dac(),
-        ReactionTarget.post: _dac_self(Tool.post),
-    }
-
-    def build_dac(t: str, w: bool) -> str:
-        return (
-            "("
-            + " OR ".join(
-                f"({t}.target_type = '{target.value}' AND EXISTS ("
-                f"SELECT 1 FROM {target.table} rdac WHERE rdac.id = {t}.target_id "
-                f"AND {path.predicate('rdac', w)}))"
-                for target, path in dac_legs.items()
-            )
-            + ")"
-        )
 
     def build(t: str, w: bool) -> str:
         return (
@@ -404,9 +279,7 @@ def reactions_path() -> InitiativePath:
         )
         return f"(CASE {r}.target_type {arms} END)"
 
-    return InitiativePath(
-        predicate=build, initiative_expr=locate, dac=DacPath(predicate=build_dac)
-    )
+    return InitiativePath(predicate=build, initiative_expr=locate)
 
 
 # recent_views is polymorphic over (entity_type, entity_id). Every entity it can
@@ -458,15 +331,9 @@ def search_entries_path() -> InitiativePath:
             f"(CASE WHEN {t}.initiative_id IS NULL "
             f"THEN true "
             f"ELSE {_access(f'{t}.initiative_id', w)} END)"
+            f" AND {_resource_access(t, w)}"
         ),
         initiative_expr=lambda r: f"{r}.initiative_id",
-        # The index stores the governing pair, so the leg needs no join. Every
-        # other table derives the same call from its parent.
-        dac=DacPath(
-            predicate=lambda t, w: _resource_call(
-                f"{t}.dac_tool", f"{t}.dac_id", f"{t}.initiative_id", w
-            )
-        ),
     )
 
 
@@ -487,17 +354,7 @@ def recent_views_path() -> InitiativePath:
         )
         return f"(CASE {r}.entity_type {arms} END)"
 
-    def build_dac(t: str, w: bool) -> str:
-        legs = [
-            f"({t}.entity_type = '{etype}' AND "
-            f"{_dac_via(tbl, 'entity_id').predicate(t, w)})"
-            for etype, tbl in RECENT_ENTITY_TABLES.items()
-        ]
-        return "(" + " OR ".join(legs) + ")"
-
-    return InitiativePath(
-        predicate=build, initiative_expr=locate, dac=DacPath(predicate=build_dac)
-    )
+    return InitiativePath(predicate=build, initiative_expr=locate)
 
 
 def document_links_path() -> InitiativePath:
@@ -512,18 +369,9 @@ def document_links_path() -> InitiativePath:
             f"AND {_access('documents.initiative_id', w)})"
         )
 
-    def _dac_leg(fk: str, t: str, w: bool) -> str:
-        return str(_dac_via("documents", fk, alias=f"dac_{fk}").predicate(t, w))
-
     return InitiativePath(
         predicate=lambda t, w: (
             f"({_leg('source_document_id', t, w)} AND {_leg('target_document_id', t, w)})"
-        ),
-        dac=DacPath(
-            predicate=lambda t, w: (
-                f"({_dac_leg('source_document_id', t, w)} AND "
-                f"{_dac_leg('target_document_id', t, w)})"
-            )
         ),
         # Both endpoints clear the same gate to exist, so the source names the
         # initiative the link belongs to.
@@ -547,9 +395,6 @@ INITIATIVE_PATHS: dict[str, InitiativePath] = {
     "dashboards": direct(),
     "posts": direct(),
     "property_definitions": direct(),
-    # Sharing itself. It carries no sharing leg of its own: resource_access
-    # reads this table, so a policy here that called it would not resolve.
-    # ``direct()`` derives none, because the table is no tool's own.
     "resource_grants": direct(),
     # The change log itself. Scoped like the rows it describes, which is what
     # lets the poller read it AS the subscriber (see EVENT_SOURCES below).
@@ -602,22 +447,17 @@ INITIATIVE_PATHS: dict[str, InitiativePath] = {
     "calendar_event_tags": via_event_calendar("calendar_event_id"),
     # Property values (entity + property_definitions, same-initiative)
     "document_property_values": via_property(
-        "documents d",
-        "d.id = {t}.document_id",
-        "d.initiative_id",
-        _dac_via("documents", "document_id"),
+        "documents d", "d.id = {t}.document_id", "d.initiative_id"
     ),
     "task_property_values": via_property(
         "tasks tk JOIN projects pr ON pr.id = tk.project_id",
         "tk.id = {t}.task_id",
         "pr.initiative_id",
-        _dac_two_hop("tasks", "project_id", "projects", "task_id"),
     ),
     "calendar_event_property_values": via_property(
         "calendar_events ce JOIN calendars cal ON cal.id = ce.calendar_id",
         "ce.id = {t}.event_id",
         "cal.initiative_id",
-        _dac_two_hop("calendar_events", "calendar_id", "calendars", "event_id"),
     ),
     # Multi-parent
     "comments": comments_path(),
@@ -636,62 +476,6 @@ INITIATIVE_PATHS: dict[str, InitiativePath] = {
 
 # Derived — the classification follows the registry, never duplicates it.
 INITIATIVE_SCOPED_TABLES: frozenset[str] = frozenset(INITIATIVE_PATHS)
-
-
-#: Which commands ask the sharing gate at WRITE level, for the tables that
-#: deviate from the default — where every writing command does.
-#:
-#: An entry states what the table's own endpoints state, so the policy and the
-#: service ask the same question of the same row:
-#:
-#: - **Nothing** for a reader's own record OF a resource — a favourite, a view,
-#:   a read receipt, a poll answer, an RSVP. Reordering and favouriting a
-#:   project, recording a view, marking a notice read, answering a poll and
-#:   answering an invitation are all endpoints that take read access; the RSVP
-#:   one says so in as many words ("RSVPing is answering an invitation, not
-#:   editing the event").
-#: - **Nothing** for comments and reactions. Responding to something is not
-#:   editing it: you may answer a notice you cannot rewrite. What gates a
-#:   response is whether you can reach the thing at all, plus the thread's own
-#:   switch — so every command here asks at read, and the switch is the
-#:   endpoint's to apply.
-#:
-#: Membership is a statement about the table, not about the gate: initiative
-#: membership and the schema boundary still apply in full.
-#: Responding to something asks nothing of write — named, so the tables that
-#: are one gesture and its bookkeeping cannot drift apart.
-_RESPONDING: frozenset[str] = frozenset()
-
-DAC_WRITE_COMMANDS: dict[str, frozenset[str]] = {
-    "project_orders": frozenset(),
-    "project_favorites": frozenset(),
-    "recent_views": frozenset(),
-    "post_reads": frozenset(),
-    "post_poll_votes": frozenset(),
-    "calendar_event_attendees": frozenset(),
-    "comments": _RESPONDING,
-    "reactions": _RESPONDING,
-    # The queued line describing a reaction is written in the SAME request as
-    # the reaction, so it answers at the same level. It shares
-    # ``reactions_path``; this is the other half of that sharing.
-    "reaction_digest_items": _RESPONDING,
-}
-
-#: The default: a command that writes asks at write level.
-ALL_WRITE_COMMANDS: frozenset[str] = frozenset({"INSERT", "UPDATE", "DELETE"})
-
-assert DAC_WRITE_COMMANDS.keys() <= INITIATIVE_SCOPED_TABLES, (
-    "DAC_WRITE_COMMANDS names a table that is not initiative-scoped: "
-    f"{sorted(DAC_WRITE_COMMANDS.keys() - INITIATIVE_SCOPED_TABLES)}"
-)
-assert all(
-    commands <= ALL_WRITE_COMMANDS for commands in DAC_WRITE_COMMANDS.values()
-), "DAC_WRITE_COMMANDS names a command that does not write"
-
-
-def dac_asks_at_write(table: str, command: str) -> bool:
-    """Whether ``table``'s sharing leg asks at write level for ``command``."""
-    return command in DAC_WRITE_COMMANDS.get(table, ALL_WRITE_COMMANDS)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/tenant/calendars.py
+++ b/backend/app/services/tenant/calendars.py
@@ -168,9 +168,14 @@ async def list_calendar_ids_for_export(
     applies in both shapes — the narrowing composes with it rather than
     replacing it, so a disabled initiative exports nothing here just as it
     lists nothing everywhere else."""
+    from app.services import permissions as permissions_service
 
     conditions = [
         tool_enabled_clause(),
+        # The same sharing gate the list endpoint applies.
+        permissions_service.dac_scope_clause(
+            Tool.calendar, Calendar.id, current_user.id, guild_id=guild_id
+        ),
     ]
     if initiative_id is not None:
         conditions.append(Calendar.initiative_id == initiative_id)

--- a/backend/app/services/tenant/counters.py
+++ b/backend/app/services/tenant/counters.py
@@ -13,6 +13,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
+from app.services import permissions as permissions_service
 from app.core.tools import Tool
 from app.services.tenant import tags as tags_service
 from app.services.permissions import (
@@ -150,6 +151,9 @@ async def list_counter_group_ids_for_export(
     conditions = [
         CounterGroup.initiative_id.in_(initiative_ids),
         Initiative.counter_groups_enabled == True,  # noqa: E712
+        permissions_service.dac_scope_clause(
+            Tool.counter_group, CounterGroup.id, current_user.id, guild_id=guild_id
+        ),
     ]
     statement = (
         select(CounterGroup.id)

--- a/backend/app/services/tenant/documents.py
+++ b/backend/app/services/tenant/documents.py
@@ -222,10 +222,16 @@ async def list_document_ids_for_export(
     Deterministic order for stable backup output."""
     from sqlmodel import select
 
+    from app.core.tools import Tool
+    from app.services import permissions as permissions_service
+
     if not initiative_ids:
         return []
     conditions = [
         Document.initiative_id.in_(initiative_ids),
+        permissions_service.dac_scope_clause(
+            Tool.document, Document.id, current_user.id, guild_id=guild_id
+        ),
     ]
     statement = select(Document.id).where(*conditions).order_by(Document.id.asc())
     return list(await session.exec(statement))
@@ -621,12 +627,19 @@ async def get_backlinks(
     guild_id: int,
 ) -> list[Document]:
     """Documents that link to this one, through the same sharing gate the
-    document list applies — the table's own policy, which narrows this
-    statement as it narrows that one."""
+    document list applies."""
+    from app.core.tools import Tool
+    from app.services import permissions as permissions_service
+
     stmt = (
         select(Document)
         .join(DocumentLink, DocumentLink.source_document_id == Document.id)
-        .where(DocumentLink.target_document_id == document_id)
+        .where(
+            DocumentLink.target_document_id == document_id,
+            permissions_service.dac_scope_clause(
+                Tool.document, Document.id, user_id, guild_id=guild_id
+            ),
+        )
         .order_by(Document.updated_at.desc())
     )
 

--- a/backend/app/services/tenant/posts.py
+++ b/backend/app/services/tenant/posts.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from typing import Any, cast
 
 from sqlalchemy.orm import selectinload
+from sqlalchemy import false
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -313,18 +314,27 @@ async def mark_read(
     permanently unread. The ids may span initiatives, so the second is asked
     per row rather than once for the request.
     """
+    from sqlalchemy import or_
     from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.core.role_context import override_sharing_initiatives
 
     if not post_ids:
         return 0
     now = datetime.now(timezone.utc)
-    # Sharing (including the "Full access" override) is the table's own policy,
-    # so the statement asks only what this endpoint adds to it.
+    full_access = override_sharing_initiatives()
+    reachable = or_(
+        permissions_service.dac_scope_clause(
+            Tool.post, Post.id, user_id, guild_id=guild_id
+        ),
+        Post.initiative_id.in_(tuple(full_access)) if full_access else false(),
+    )
     readable = (
         await session.exec(
             select(Post.id).where(
                 Post.id.in_(tuple(post_ids)),
                 Post.created_by != user_id,
+                reachable,
                 visibility_clause(user_id, guild_id=guild_id),
             )
         )
@@ -460,6 +470,9 @@ async def list_post_ids_for_export(
         # it is in no export either. A backup therefore does not carry drafts,
         # which is the trade this one rule makes.
         is_published_clause(),
+        permissions_service.dac_scope_clause(
+            Tool.post, Post.id, current_user.id, guild_id=guild_id
+        ),
     ]
     statement = (
         select(Post.id)

--- a/backend/app/services/tenant/project_export.py
+++ b/backend/app/services/tenant/project_export.py
@@ -207,12 +207,17 @@ async def list_project_ids_for_export(
     still enforce their own access level per entity."""
     from sqlmodel import select
 
+    from app.core.tools import Tool
     from app.models.tenant.project import Project
+    from app.services import permissions as permissions_service
 
     if not initiative_ids:
         return []
     conditions = [
         Project.initiative_id.in_(initiative_ids),
+        permissions_service.dac_scope_clause(
+            Tool.project, Project.id, current_user.id, guild_id=guild_id
+        ),
     ]
     statement = select(Project.id).where(*conditions).order_by(Project.id.asc())
     return list(await session.exec(statement))

--- a/backend/app/services/tenant/queues.py
+++ b/backend/app/services/tenant/queues.py
@@ -19,6 +19,7 @@ from sqlmodel import select
 from app.core.messages import QueueMessages
 from app.core.tools import Tool
 from app.services.tenant import tags as tags_service
+from app.services import permissions as permissions_service
 from app.services.permissions import (
     DAC_RESOURCES,
     compute_permission,
@@ -165,6 +166,9 @@ async def list_queue_ids_for_export(
     conditions = [
         Queue.initiative_id.in_(initiative_ids),
         Initiative.queues_enabled == True,  # noqa: E712
+        permissions_service.dac_scope_clause(
+            Tool.queue, Queue.id, current_user.id, guild_id=guild_id
+        ),
     ]
     statement = (
         select(Queue.id)

--- a/backend/app/services/tenant/task_statuses.py
+++ b/backend/app/services/tenant/task_statuses.py
@@ -7,9 +7,11 @@ from sqlalchemy import func
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.tools import Tool
 from app.models.tenant.project import Project
 from app.models.tenant.task import TaskStatus, TaskStatusCategory
 from app.schemas.tenant.task_status import InitiativeTaskStatusRead
+from app.services import permissions as permissions_service
 
 CATEGORY_DEFAULTS: dict[TaskStatusCategory, tuple[str, str]] = {
     TaskStatusCategory.backlog: ("#94A3B8", "circle-dashed"),
@@ -170,6 +172,13 @@ async def list_initiative_statuses(
         Project.initiative_id == initiative_id,
         Project.is_archived.is_(False),
         Project.is_template.is_(False),
+        permissions_service.dac_scope_clause(
+            Tool.project,
+            Project.id,
+            user_id,
+            guild_id=guild_id,
+            initiative_id=initiative_id,
+        ),
     ]
 
     total_stmt = select(func.count()).select_from(Project).where(*project_conditions)


### PR DESCRIPTION
## Problem

#1423 ("Decide tool sharing in the database") was merged with its Backend CI job failing, and every dev run since that exercises the backend fails the same 45 tests: https://github.com/Morelitea/initiative/actions/runs/34143079002/job/101809149244. The failures reproduce locally against direct Postgres, so the pooler is not the cause.

The rendered sharing leg runs into three Postgres RLS behaviours the design did not account for:

- **Creating a tool fails for anyone who is not a guild admin.** The tool's own table is exempt from the leg on INSERT, but SQLAlchemy inserts with `RETURNING`, and Postgres applies the SELECT policy to returned rows. The owner grant does not exist yet, so the insert is rejected with "new row violates row-level security policy". This is every `GUILD_ACCESS_DENIED` on create (projects, documents, calendars, counters, imports).
- **Readers cannot vote on polls.** `lock_open_poll` takes the row with `SELECT ... FOR UPDATE`, and a row lock has to pass the UPDATE policy, which now demands write-level sharing on the post. A read-level member gets no row, reported as `POST_POLL_CLOSED`.
- **The event reminder job cannot record what it sent.** It routes as the attendee, who typically holds read-level sharing on the calendar, and the `event_reminder_dispatches` INSERT policy now requires write.

The remaining failures are the API contract moving under the tests: an initiative member without a grant no longer sees the row at all, so endpoints answer 404 (and the bulk grant endpoint `not_found`) where the tests, and the PR description, expect 403.

## Changes

Reverts the merge of #1423, with two things deliberately kept:

- **Migration `20260907_0236`** (the level-aware `public.resource_access` body). It has already run on dev databases, `20260907_0237` (#1426) revises it, and the function is not what broke anything. Removing it would orphan the chain.
- **The `sqlmodel.sql.sqltypes` import** in `script.py.mako` and the two migrations that had it. That is the `ty` fix the PR called out as unrelated.

#1426 landed on top of #1423 and adjusted the sharing leg for comments and reactions (`DAC_WRITE_COMMANDS`). Those hunks go with the leg; the rest of #1426 (the reactions switch, comments and reactions taking read access in the services, the frontend) is app-layer and stays. Its tests pass on this branch.

The redesign of the database-side sharing gate is a follow-up.

## Schema / env

No new migration. The registry edit changes the rendered RLS back to the pre-#1423 policies, which bumps the provisioning stamp, so `backfill_guild_schemas()` re-provisions every guild on the next boot.

## Testing

```
cd backend
ruff check app && ruff format --check app && ty check app
pytest -n 0 app/api/v1/tenant_endpoints/projects_test.py app/api/v1/tenant_endpoints/post_polls_test.py \
  app/api/v1/tenant_endpoints/comments_test.py app/services/initiative_rls_test.py \
  app/api/v1/tenant_endpoints/reactions_test.py   # 184 passed
pytest -n auto app                                # 5051 passed, 98 skipped
```
