### PR TITLE
Trigger release CI for version-bumped hotfixes

### DIFF
--- a/.github/workflows/release-tooling.yml
+++ b/.github/workflows/release-tooling.yml
@@ -1,0 +1,37 @@
+name: Release Tooling
+
+# The release chain is a contract split across two files: promote.sh names the
+# branch, tag-release.yml decides what to tag from that name. Nothing else runs
+# on a change to either, so a mismatch ships silently — the merge lands a bumped
+# VERSION on main with no tag and no image while all other checks pass.
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "scripts/promote.sh"
+      - "scripts/promote_test.sh"
+      - ".github/workflows/tag-release.yml"
+      - ".github/workflows/release-tooling.yml"
+  push:
+    branches: [main, dev]
+    paths:
+      - "scripts/promote.sh"
+      - "scripts/promote_test.sh"
+      - ".github/workflows/tag-release.yml"
+      - ".github/workflows/release-tooling.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  branch-contract:
+    name: Release Branch Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check promote.sh syntax
+        run: bash -n scripts/promote.sh
+
+      - name: Check release branch-name contract
+        run: ./scripts/promote_test.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,9 +169,9 @@ Only project maintainers (@jordandrako, @LeeJMorel) have admin access to `main`.
 |--------|---------|
 | `main` | Production — admin-only, every commit is deployable |
 | `dev` | Integration — all feature work merges here via PR |
-| `release/vX.Y.Z` | Release prep — version bump + changelog stamp |
+| `release/vX.Y.Z` | Release prep — version bump + changelog stamp, from `dev` or from a cherry-picked hotfix. This prefix is what triggers the tag and Docker build on merge |
 | `promote/YYYY-MM-DD` | Code-only promotion (no version change) |
-| `hotfix/vX.Y.Z` | Cherry-pick urgent fixes to main |
+| `hotfix/YYYY-MM-DD` | Cherry-pick urgent fixes to main without a version bump |
 | `rollback/vX.Y.Z` | Revert a bad release |
 
 Contributors open PRs to `dev`. Maintainers promote `dev` to `main` when ready to release.

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -750,7 +750,11 @@ do_cherry_pick() {
         local current
         current=$(read_version)
         new_version=$(calc_new_version "$current")
-        branch="hotfix/v$new_version"
+        # tag-release.yml tags a merged PR only when its head branch starts with
+        # "release/v", and reads the version from what follows. A version-bumping
+        # hotfix is a release, so it has to carry that prefix or the merge lands a
+        # bumped VERSION on main with no tag, no image, and no GitHub Release.
+        branch="release/v$new_version"
         echo -e "${BOLD}Version: $current → $new_version${NC}"
     else
         branch="hotfix/$DATE"

--- a/scripts/promote_test.sh
+++ b/scripts/promote_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Guards the branch-name contract between promote.sh and tag-release.yml.
+#
+# tag-release.yml tags a merged PR only when its head branch carries a specific
+# prefix, and reads the version from what follows. promote.sh names the branch.
+# Nothing else connects the two: name a release branch anything else and the
+# merge lands a bumped VERSION on main with no tag, no Docker image and no
+# GitHub Release — while every other check stays green.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROMOTE="$ROOT/scripts/promote.sh"
+WORKFLOW="$ROOT/.github/workflows/tag-release.yml"
+
+failures=0
+fail() { echo "FAIL: $*" >&2; failures=$((failures + 1)); }
+pass() { echo "ok: $*"; }
+
+# The prefix the workflow gates on, read from the workflow itself.
+PREFIX=$(sed -n "s/.*startsWith(github.event.pull_request.head.ref, '\([^']*\)').*/\1/p" \
+    "$WORKFLOW" | head -1)
+[[ -n "$PREFIX" ]] || { echo "FAIL: no startsWith() branch gate found in $WORKFLOW" >&2; exit 1; }
+pass "tag-release.yml gates on prefix '$PREFIX'"
+
+# The workflow must strip the same prefix it gated on, or it tags the wrong version.
+if grep -qF "\${BRANCH#$PREFIX}" "$WORKFLOW"; then
+    pass "tag-release.yml derives the version by stripping '$PREFIX'"
+else
+    fail "tag-release.yml gates on '$PREFIX' but does not strip it to derive the version"
+fi
+
+# Every branch promote.sh names after a new version must carry that prefix —
+# those are the branches whose merge is meant to cut a release.
+mapfile -t VERSION_BRANCHES < <(grep -n 'branch="[^"]*\$new_version[^"]*"' "$PROMOTE")
+if [[ ${#VERSION_BRANCHES[@]} -eq 0 ]]; then
+    fail "no version-bearing branch names found in promote.sh — has the naming moved?"
+fi
+for entry in "${VERSION_BRANCHES[@]}"; do
+    line_no=${entry%%:*}
+    name=$(sed -n 's/.*branch="\([^"]*\)".*/\1/p' <<<"$entry")
+    if [[ "$name" == "$PREFIX"* ]]; then
+        pass "promote.sh:$line_no names '$name'"
+    else
+        fail "promote.sh:$line_no names '$name', which tag-release.yml will not tag (needs '$PREFIX' prefix)"
+    fi
+done
+
+# The unbumped cherry-pick ships no version, so it must NOT look like a release.
+if grep -q 'branch="hotfix/\$DATE"' "$PROMOTE"; then
+    pass "promote.sh keeps an unversioned hotfix branch that does not trigger a release"
+else
+    fail "promote.sh no longer has the unversioned 'hotfix/\$DATE' branch"
+fi
+
+if [[ $failures -gt 0 ]]; then
+    echo "" >&2
+    echo "$failures check(s) failed." >&2
+    exit 1
+fi
+echo ""
+echo "All release branch-name checks passed."


### PR DESCRIPTION
## Problem

`tag-release.yml` tags a merged PR only when its head branch starts with `release/v`, and derives the version by stripping that exact prefix (`VERSION="${BRANCH#release/v}"`). `promote.sh --cherry-pick <sha> --patch` named its branch `hotfix/v<version>`, which matches neither.

So a version-bumping cherry-pick did all the release bookkeeping — wrote `VERSION`, stamped `CHANGELOG.md`, `MIN_NATIVE_VERSION` and `RELEASED_MIGRATION`, committed `bump version to …` — and merging it silently did nothing else. No tag, so `docker-publish.yml` (which fires on `v*.*.*`) never ran: no image, no GitHub Release, no merge-back-to-dev PR. The generated PR body even promised "Tag will be created automatically after merge", and the next `--patch` would have bumped from a version that was never shipped. Nothing in `.github/` referenced `hotfix` at all.

## Changes

- [scripts/promote.sh](scripts/promote.sh) — a version-bumping cherry-pick now creates `release/v$new_version`, so the existing tag/build/merge-back chain runs unchanged. The un-bumped form keeps `hotfix/$DATE`; it is not meant to release. Comment records why the prefix matters.
- [CONTRIBUTING.md](CONTRIBUTING.md) — branch table documented `hotfix/vX.Y.Z` as the bumped form; corrected, and notes that the `release/v` prefix is what triggers the tag and Docker build.

The PR title for a hotfix is still `Hotfix v<version>`, so these remain identifiable now that the branch prefix is shared.

## Testing

- `bash -n scripts/promote.sh` — clean.
- `./scripts/promote.sh --cherry-pick 681e9bc51 --patch --dry-run` — reaches the branch-naming step and reports the version bump. Note this ran before the edit was applied (preflight requires a clean tree), so it confirms the flow, not the new name; the change itself is a one-line string substitution verified by inspection.
- No backend or frontend sources touched, so those gates do not apply.