### PR TITLE
Let the ratchet worker compile WebAssembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Viewing something now lets you join the conversation about it.** Anyone a project, document, notice, queue, counter group or calendar has been shared with as a viewer can comment on it and react, where both used to take edit access. Answering something is not editing it — you can reply to a notice you have no business rewriting, the way you always could on a thread you were merely reading. Whether a thread is open at all is still the tool's own comment setting, and a viewer still cannot change the thing itself.
 
+### Fixed
+
+- **Direct messages could not set up a device on a deployed server.** Opening *My Messages* failed with *this device could not be set up*, on every install, while working perfectly in development. The encryption the messages run on is WebAssembly, and a browser only compiles WebAssembly a page's security policy makes room for — the worker that ratchets messages was served without that room, so the browser refused to compile it before it had done anything. It is now served the same narrow policy the dashboard widget sandbox already had: its own script, WebAssembly, and nothing else. The app-wide policy is unchanged, and still forbids WebAssembly everywhere else.
+
 ## [0.66.1] - 2026-09-07
 
 ### Fixed

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -367,20 +367,23 @@ class Settings(BaseSettings):
         return _format_csp(directives)
 
     @property
-    def widget_sandbox_content_security_policy(self) -> str:
-        """CSP for the widget sandbox worker bundle ONLY (applied per-response).
+    def wasm_worker_content_security_policy(self) -> str:
+        """CSP for the WebAssembly worker bundles ONLY (applied per-response).
 
-        Dashboard widgets are evaluated by QuickJS compiled to WebAssembly
-        (``frontend/src/lib/widgets/runtime/sandbox.worker.ts``). A worker takes
-        its policy from the response that served its script rather than from the
-        document that started it, so the WebAssembly source expression is named
-        here — on that one built asset — and the app-wide policy above needs no
-        mention of it.
+        Two workers run WebAssembly: the dashboard widget sandbox, which
+        evaluates widget code with QuickJS
+        (``frontend/src/lib/widgets/runtime/sandbox.worker.ts``), and the direct
+        message ratchet, which runs vodozemac
+        (``frontend/src/crypto/ratchet.worker.ts``). A worker takes its policy
+        from the response that served its script rather than from the document
+        that started it, so the WebAssembly source expression is named here — on
+        those built assets — and the app-wide policy above needs no mention of
+        it.
 
-        The worker is given the three things it uses and nothing else: its own
+        Each worker is given the three things it uses and nothing else: its own
         script, WebAssembly compilation, and a same-origin fetch for the
-        ``.wasm`` file. It has no DOM, loads no styles, images, or fonts, and
-        talks to nobody but the page that started it.
+        ``.wasm`` file. Neither has a DOM, loads styles, images, or fonts, or
+        talks to anybody but the page that started it.
         """
         return _format_csp(
             {

--- a/backend/app/core/config_test.py
+++ b/backend/app/core/config_test.py
@@ -262,23 +262,24 @@ def test_csp_allows_inline_styles_but_not_scripts():
     assert "'unsafe-inline'" not in _directive(csp, "script-src")
 
 
-def test_webassembly_is_named_only_on_the_widget_sandbox_policy():
-    # Dashboard widgets are evaluated by QuickJS compiled to WebAssembly, which
+def test_webassembly_is_named_only_on_the_wasm_worker_policy():
+    # Dashboard widgets are evaluated by QuickJS compiled to WebAssembly and
+    # direct messages are ratcheted by vodozemac compiled to WebAssembly, which
     # needs a source expression the app-wide policy does not carry. It is named
-    # on the worker bundle's own response and nowhere else.
+    # on those workers' own responses and nowhere else.
     settings = _settings()
     assert "'wasm-unsafe-eval'" not in settings.content_security_policy
     assert "'wasm-unsafe-eval'" not in settings.docs_content_security_policy
 
-    sandbox = settings.widget_sandbox_content_security_policy
+    sandbox = settings.wasm_worker_content_security_policy
     assert _directive(sandbox, "script-src") == "script-src 'self' 'wasm-unsafe-eval'"
 
 
-def test_widget_sandbox_policy_grants_only_what_the_worker_uses():
-    # Its own script, WebAssembly, and the same-origin fetch for the .wasm file.
-    # Everything else — DOM-adjacent fetches, frames, workers — falls to
+def test_wasm_worker_policy_grants_only_what_the_workers_use():
+    # Their own script, WebAssembly, and the same-origin fetch for the .wasm
+    # file. Everything else — DOM-adjacent fetches, frames, workers — falls to
     # default-src 'none'.
-    sandbox = _settings().widget_sandbox_content_security_policy
+    sandbox = _settings().wasm_worker_content_security_policy
     assert {part.strip() for part in sandbox.split(";")} == {
         "default-src 'none'",
         "script-src 'self' 'wasm-unsafe-eval'",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -412,23 +412,30 @@ async def insufficient_privilege_handler(
 # Computed once — Settings are fixed for the process lifetime (pentest MED-001).
 _CONTENT_SECURITY_POLICY = settings.content_security_policy
 
-# The widget sandbox worker, and only it, is served with a policy that admits
+# The two WebAssembly workers — the dashboard widget sandbox and the direct
+# message ratchet — and only they, are served with a policy that admits
 # WebAssembly. Vite emits worker bundles into `assets/workers/` with a content
 # hash (see `worker.rolldownOptions` in frontend/vite.config.ts), so the match is
-# by directory + stem; the literal is pinned by tests on both sides.
-_WIDGET_SANDBOX_ASSET_PREFIX = "assets/workers/sandbox.worker-"
-_WIDGET_SANDBOX_CSP = settings.widget_sandbox_content_security_policy
+# by directory + stem; the literals are pinned by tests on both sides.
+_WASM_WORKER_ASSET_PREFIXES = (
+    "assets/workers/sandbox.worker-",
+    "assets/workers/ratchet.worker-",
+)
+_WASM_WORKER_CSP = settings.wasm_worker_content_security_policy
 
 
-def _is_widget_sandbox_asset(path: str) -> bool:
-    """True for the one built file that carries the widget sandbox policy.
+def _is_wasm_worker_asset(path: str) -> bool:
+    """True for the built files that carry the WebAssembly worker policy.
 
     The hash varies per build, so the tail is open — but only as far as the one
     filename: anything nested below that name is an ordinary asset.
     """
-    if not path.startswith(_WIDGET_SANDBOX_ASSET_PREFIX) or not path.endswith(".js"):
+    if not path.endswith(".js"):
         return False
-    return "/" not in path[len(_WIDGET_SANDBOX_ASSET_PREFIX) :]
+    return any(
+        path.startswith(prefix) and "/" not in path[len(prefix) :]
+        for prefix in _WASM_WORKER_ASSET_PREFIXES
+    )
 
 
 # Emit HSTS only when the public origin is HTTPS (pentest SEC-16): the header is
@@ -733,8 +740,8 @@ async def serve_spa(full_path: str) -> FileResponse:
             headers = {"Cache-Control": "public, max-age=31536000, immutable"}
             # The middleware sets the app-wide policy with setdefault, so this
             # per-asset one wins where it applies.
-            if _is_widget_sandbox_asset(full_path):
-                headers["Content-Security-Policy"] = _WIDGET_SANDBOX_CSP
+            if _is_wasm_worker_asset(full_path):
+                headers["Content-Security-Policy"] = _WASM_WORKER_CSP
             return FileResponse(static_file, headers=headers)
         return FileResponse(
             static_file,

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -62,46 +62,51 @@ async def test_responses_carry_content_security_policy(client: AsyncClient) -> N
     assert "object-src 'none'" in csp
 
 
-# --- Widget sandbox worker asset (WebAssembly is named on this one response) ---
+# --- WebAssembly worker assets (WebAssembly is named on these responses only) ---
 
 
 @pytest.mark.unit
-def test_widget_sandbox_match_names_one_file() -> None:
-    match = main_module._is_widget_sandbox_asset
+def test_wasm_worker_match_names_only_those_files() -> None:
+    match = main_module._is_wasm_worker_asset
+    # The widget sandbox (QuickJS) and the direct message ratchet (vodozemac).
     assert match("assets/workers/sandbox.worker-DQURGIoN.js")
+    assert match("assets/workers/ratchet.worker-DQURGIoN.js")
 
-    # Every other built file is an ordinary asset: a second worker, anything
-    # nested under a directory that merely starts with the name, the sourcemap,
-    # and the app's own chunks.
+    # Every other built file is an ordinary asset: a third worker, a worker
+    # whose name merely starts the same way, anything nested under a directory
+    # that starts with the name, the sourcemap, and the app's own chunks.
     assert not match("assets/workers/other.worker-DQURGIoN.js")
+    assert not match("assets/workers/worker-DQURGIoN.js")
     assert not match("assets/workers/sandbox.worker-DQURGIoN/payload.js")
+    assert not match("assets/workers/ratchet.worker-DQURGIoN/payload.js")
     assert not match("assets/workers/sandbox.worker-DQURGIoN.js.map")
     assert not match("assets/index-lSaaosYz.js")
     assert not match("assets/workers/")
 
 
 @pytest.mark.integration
-async def test_only_the_widget_sandbox_asset_carries_its_policy(
-    client: AsyncClient,
+@pytest.mark.parametrize("stem", ["sandbox.worker", "ratchet.worker"])
+async def test_only_the_wasm_worker_assets_carry_their_policy(
+    client: AsyncClient, stem: str
 ) -> None:
     # End-to-end through the SPA file route: the worker bundle answers with the
-    # sandbox policy, and the chunk next to it answers with the app-wide one.
-    worker = main_module.static_path / "assets" / "workers" / "sandbox.worker-t3st.js"
+    # WebAssembly policy, and the chunk next to it answers with the app-wide one.
+    worker = main_module.static_path / "assets" / "workers" / f"{stem}-t3st.js"
     ordinary = main_module.static_path / "assets" / "index-t3st.js"
     worker.parent.mkdir(parents=True, exist_ok=True)
     ordinary.parent.mkdir(parents=True, exist_ok=True)
-    worker.write_text("// widget sandbox worker\n")
+    worker.write_text("// wasm worker\n")
     ordinary.write_text("// app chunk\n")
     try:
-        sandbox_resp = await client.get(f"/assets/workers/{worker.name}")
+        worker_resp = await client.get(f"/assets/workers/{worker.name}")
         other_resp = await client.get(f"/assets/{ordinary.name}")
     finally:
         worker.unlink(missing_ok=True)
         ordinary.unlink(missing_ok=True)
 
-    assert sandbox_resp.status_code == 200
-    sandbox_csp = sandbox_resp.headers.get("content-security-policy", "")
-    assert sandbox_csp == settings.widget_sandbox_content_security_policy
+    assert worker_resp.status_code == 200
+    worker_csp = worker_resp.headers.get("content-security-policy", "")
+    assert worker_csp == settings.wasm_worker_content_security_policy
 
     assert other_resp.status_code == 200
     other_csp = other_resp.headers.get("content-security-policy", "")

--- a/backend/app/main_test.py
+++ b/backend/app/main_test.py
@@ -91,8 +91,11 @@ async def test_only_the_wasm_worker_assets_carry_their_policy(
 ) -> None:
     # End-to-end through the SPA file route: the worker bundle answers with the
     # WebAssembly policy, and the chunk next to it answers with the app-wide one.
+    # Both filenames carry the stem: the cases share one static directory and can
+    # run on different xdist workers, so a name common to both would be deleted
+    # out from under whichever case is still reading it.
     worker = main_module.static_path / "assets" / "workers" / f"{stem}-t3st.js"
-    ordinary = main_module.static_path / "assets" / "index-t3st.js"
+    ordinary = main_module.static_path / "assets" / f"index-{stem}-t3st.js"
     worker.parent.mkdir(parents=True, exist_ok=True)
     ordinary.parent.mkdir(parents=True, exist_ok=True)
     worker.write_text("// wasm worker\n")

--- a/frontend/src/crypto/client.ts
+++ b/frontend/src/crypto/client.ts
@@ -14,6 +14,7 @@
  * Tests that exercise the ratchet itself import `./engine` directly.
  */
 
+import type { RatchetMethod } from "./ratchet.worker";
 import type {
   AccountCreated,
   Decrypted,
@@ -22,7 +23,6 @@ import type {
   KeysGenerated,
   OutboundSession,
 } from "./types";
-import type { RatchetMethod } from "./worker";
 
 type Pending = {
   resolve: (value: unknown) => void;
@@ -62,7 +62,7 @@ export function ratchetSupported(): boolean {
 function ensureWorker(): Worker {
   if (typeof Worker === "undefined") throw new RatchetUnavailableError();
   if (worker === null) {
-    worker = new Worker(new URL("./worker.ts", import.meta.url), {
+    worker = new Worker(new URL("./ratchet.worker.ts", import.meta.url), {
       type: "module",
     });
     worker.onmessage = (event: MessageEvent<{ id: number; result?: unknown; error?: string }>) => {

--- a/frontend/src/crypto/ratchet.worker.test.ts
+++ b/frontend/src/crypto/ratchet.worker.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Where this worker's bundle lands is part of its contract.
+ *
+ * The ratchet is vodozemac compiled to WebAssembly, and a worker carries the
+ * Content-Security-Policy of the response that served its script rather than
+ * the document's. The backend attaches a policy that admits WebAssembly by
+ * matching the built file's path (`_WASM_WORKER_ASSET_PREFIXES` in
+ * `backend/app/main.py`). Vite decides that path from two things — the worker
+ * output pattern and this file's name — so both are pinned here, and the
+ * backend pins the literal it matches. A rename on either side fails a test
+ * rather than quietly serving a policy that refuses to compile the ratchet.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/** Keep in step with `_WASM_WORKER_ASSET_PREFIXES` in backend/app/main.py. */
+const WORKER_OUTPUT = "assets/workers/[name]-[hash].js";
+
+const resolve = (relative: string) => fileURLToPath(new URL(relative, import.meta.url));
+
+describe("ratchet worker asset", () => {
+  it("is emitted into the directory the backend matches", () => {
+    const config = readFileSync(resolve("../../vite.config.ts"), "utf8");
+    expect(config).toContain(`entryFileNames: "${WORKER_OUTPUT}"`);
+  });
+
+  it("keeps the entry name the backend matches", () => {
+    // `[name]` resolves to the worker entry's basename, so the built file is
+    // `assets/workers/ratchet.worker-<hash>.js`.
+    expect(existsSync(resolve("./ratchet.worker.ts"))).toBe(true);
+    expect(WORKER_OUTPUT.replace("[name]", "ratchet.worker")).toBe(
+      "assets/workers/ratchet.worker-[hash].js"
+    );
+  });
+
+  it("is the entry the client starts", () => {
+    const client = readFileSync(resolve("./client.ts"), "utf8");
+    expect(client).toContain('new URL("./ratchet.worker.ts", import.meta.url)');
+  });
+});

--- a/frontend/src/crypto/ratchet.worker.ts
+++ b/frontend/src/crypto/ratchet.worker.ts
@@ -4,6 +4,11 @@
  * Key material stays in this context: the main thread posts a request and
  * receives a result, and the pickles it holds are ciphertext it cannot open
  * without the pickle key, which never leaves here either.
+ *
+ * The filename is part of the contract: vodozemac is WebAssembly, and a worker
+ * takes its policy from the response that served its own script, so the backend
+ * matches this bundle's built path to answer with a policy that admits
+ * WebAssembly compilation. See `ratchet.worker.test.ts`.
  */
 
 import {

--- a/frontend/src/lib/widgets/runtime/sandbox.worker.test.ts
+++ b/frontend/src/lib/widgets/runtime/sandbox.worker.test.ts
@@ -3,7 +3,7 @@
  *
  * The response that serves it carries its own Content-Security-Policy, which
  * the backend attaches by matching the built file's path
- * (`_WIDGET_SANDBOX_ASSET_PREFIX` in `backend/app/main.py`). Vite decides that
+ * (`_WASM_WORKER_ASSET_PREFIXES` in `backend/app/main.py`). Vite decides that
  * path from two things — the worker output pattern and this file's name — so
  * both are pinned here, and the backend pins the literal it matches. A rename
  * on either side fails a test rather than quietly serving the wrong header.
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-/** Keep in step with `_WIDGET_SANDBOX_ASSET_PREFIX` in backend/app/main.py. */
+/** Keep in step with `_WASM_WORKER_ASSET_PREFIXES` in backend/app/main.py. */
 const WORKER_OUTPUT = "assets/workers/[name]-[hash].js";
 
 const resolve = (relative: string) => fileURLToPath(new URL(relative, import.meta.url));

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -111,9 +111,10 @@ export default defineConfig({
   },
   worker: {
     // Worker bundles land in their own directory so a served response can be
-    // matched by path. The backend keys the widget sandbox's policy off
-    // `assets/workers/sandbox.worker-` — see `_WIDGET_SANDBOX_ASSET` in
-    // backend/app/main.py, which is pinned by tests on both sides.
+    // matched by path. The backend keys the WebAssembly workers' policy off
+    // `assets/workers/sandbox.worker-` and `assets/workers/ratchet.worker-` —
+    // see `_WASM_WORKER_ASSET_PREFIXES` in backend/app/main.py, which is pinned
+    // by tests on both sides.
     rolldownOptions: {
       output: {
         entryFileNames: "assets/workers/[name]-[hash].js",


### PR DESCRIPTION
## Problem

*My Messages* fails on every deployed install — never in development — with `[messages] this device could not be set up` and, in the console:

```
WebAssembly.instantiateStreaming(): Compiling or instantiating WebAssembly module
violates the following Content Security policy directive because 'unsafe-eval' is
not an allowed source of script in the following Content Security Policy directive:
"script-src 'self' https://challenges.cloudflare.com".
```

The ratchet is vodozemac compiled to WebAssembly, run in a dedicated worker. A worker takes its CSP from the response that served **its own script**, not from the document that started it. That bundle fell through to the SPA catch-all in `serve_spa`, so it got the app-wide policy, whose `script-src` names no WebAssembly source expression — the browser refused to compile it before the worker had done anything. The Vite dev server sets no CSP at all, which is why this only ever failed in production.

The codebase already solves this once, for the QuickJS widget sandbox: that bundle is served a narrow policy of its own. The ratchet worker never got the same treatment.

## Changes

Generalize the widget-sandbox exception to cover both WebAssembly workers, rather than weaken the app-wide policy — which still forbids WebAssembly everywhere else.

- [config.py](backend/app/core/config.py) — `widget_sandbox_content_security_policy` → `wasm_worker_content_security_policy`. The policy body is byte-identical (`default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'`); only its docstring grew to name both workers. Each gets its own script, WebAssembly compilation, and the same-origin fetch for its `.wasm` — nothing else.
- [main.py](backend/app/main.py) — `_WIDGET_SANDBOX_ASSET_PREFIX` → `_WASM_WORKER_ASSET_PREFIXES` (`sandbox.worker-`, `ratchet.worker-`), `_is_widget_sandbox_asset` → `_is_wasm_worker_asset`. The "one filename, nothing nested below it" rule is preserved per prefix.
- [ratchet.worker.ts](frontend/src/crypto/ratchet.worker.ts) — renamed from `worker.ts`. Vite names the bundle after the entry, so the old name emitted `assets/workers/worker-<hash>.js`; matching on `worker-` would hand `'wasm-unsafe-eval'` to any future worker chunk. `ratchet.worker.ts` matches the existing `sandbox.worker.ts` convention and keeps the prefix specific.
- [client.ts](frontend/src/crypto/client.ts) — follows the rename (type import and the `new Worker(new URL(...))`).
- [vite.config.ts](frontend/vite.config.ts) — comment names both prefixes and the new backend constant.

### Tests

- [ratchet.worker.test.ts](frontend/src/crypto/ratchet.worker.test.ts) — new, mirroring `sandbox.worker.test.ts`: pins the worker output pattern, the entry filename, and the `new URL` in `client.ts`, so a rename fails a test instead of quietly serving a policy that refuses to compile the ratchet.
- [main_test.py](backend/app/main_test.py) — the matcher test now asserts both bundles match and that `worker-<hash>.js` and `other.worker-<hash>.js` do **not**, so the too-broad prefix would fail. The end-to-end test is parametrized over both stems.
- [config_test.py](backend/app/core/config_test.py) — renamed with the property; still asserts `'wasm-unsafe-eval'` appears on neither the app-wide nor the docs policy.

## Testing

- `cd frontend && pnpm build` — emits exactly the two files the backend matches: `dist/assets/workers/ratchet.worker-DHQdE9zX.js` and `dist/assets/workers/sandbox.worker-B_oSbfku.js`. The ratchet bundle is self-contained and its `instantiateStreaming` fetches `assets/initiative_ratchet_bg-*.wasm` same-origin, so `connect-src 'self'` covers it and the policy grants nothing beyond what it uses.
- `cd backend && pytest -n 0 app/main_test.py app/core/config_test.py` — 78 passed.
- `cd backend && ruff check app` — clean.
- `cd frontend && pnpm vitest run src/crypto src/lib/widgets/runtime/sandbox.worker.test.ts` — 103 passed.
- `cd frontend && pnpm typecheck` and `pnpm biome check` on the changed files — clean.