### PR TITLE
Always attach an APK to releases, document the apps

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -319,6 +319,38 @@ jobs:
           name: android-apk
           path: artifacts
 
+      # A web-only release builds no APK (see the `decide` job), but somebody landing on the
+      # release page still needs one to install. Carry the newest APK published on an earlier
+      # release forward onto this one — it is precisely the native build this web bundle
+      # expects, and its filename keeps its own version so it reads as a carried-over build
+      # rather than a fresh one.
+      - name: Carry forward the previous release's APK
+        id: carry_apk
+        if: ${{ needs.build-android.result != 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          CURRENT_TAG: ${{ github.ref_name }}
+        run: |
+          mkdir -p artifacts
+          # Releases come back newest-first; take the first published one carrying an APK,
+          # skipping this release's own tag so a re-run doesn't just re-attach its own asset.
+          tag=$(gh api "repos/${GH_REPO}/releases?per_page=50" --jq "
+            map(select(.draft | not)
+                | select(.tag_name != \"${CURRENT_TAG}\")
+                | select(any(.assets[]; .name | endswith(\".apk\"))))
+            | .[0].tag_name // empty")
+          if [ -z "$tag" ]; then
+            echo "No earlier release carries an APK — this release ships Docker-only."
+            echo "carried=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh release download "$tag" --repo "$GH_REPO" --pattern '*.apk' --dir artifacts
+          echo "Carried the APK forward from $tag:"
+          ls -1 artifacts
+          echo "carried=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Extract version from tag
         id: version
         run: |
@@ -338,6 +370,8 @@ jobs:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           APK_BUILT: ${{ needs.build-android.result == 'success' }}
+          APK_CARRIED: ${{ steps.carry_apk.outputs.carried }}
+          APK_CARRIED_FROM: ${{ steps.carry_apk.outputs.tag }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "Extracting changelog for version $VERSION"
@@ -362,14 +396,17 @@ jobs:
           fi
 
           # The native app is only rebuilt when the native shell changed (see the `decide`
-          # job). Web-only releases ship no new APK — existing installs update over the air.
+          # job). Web-only releases carry the previous APK forward, so every release has one
+          # to install; installed apps pick the new web bundle up over the air regardless.
           if [ "$APK_BUILT" = "true" ]; then
-            ANDROID_SECTION="### Android App
-          Download the APK from the assets below and install on your Android device."
+            ANDROID_NOTE="Download the APK from the assets below and install it on your Android device."
+          elif [ "$APK_CARRIED" = "true" ]; then
+            ANDROID_NOTE="No new app build this release — the APK below is the current native app, carried forward from ${APK_CARRIED_FROM}. Installed apps pick this release up automatically over the air on next launch."
           else
-            ANDROID_SECTION="### Android App
-          No new app build this release — installed apps update automatically over the air on next launch."
+            ANDROID_NOTE="No app build is available for this release. Installed apps update automatically over the air on next launch."
           fi
+          ANDROID_SECTION="### Android App
+          $ANDROID_NOTE"
 
           # Build full release body with changelog + download info
           cat > release_body.md << ENDOFBODY

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -324,9 +324,14 @@ jobs:
       # release forward onto this one — it is precisely the native build this web bundle
       # expects, and its filename keeps its own version so it reads as a carried-over build
       # rather than a fresh one.
+      #
+      # Strictly `skipped`, never merely "not success": skipped is the `decide` job stating
+      # the native shell did not change, which is what makes the older APK the correct one.
+      # A *cancelled* build means MIN_NATIVE_VERSION did move, so the older APK is below this
+      # bundle's floor and would refuse it — better to attach nothing than the wrong app.
       - name: Carry forward the previous release's APK
         id: carry_apk
-        if: ${{ needs.build-android.result != 'success' }}
+        if: ${{ needs.build-android.result == 'skipped' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every release now has an Android app to download.** Initiative only rebuilds the app when a release changes its native shell, so every other release published nothing to install — anyone landing on the release page, or any updater watching those releases, found no APK at all. Each release now carries the current app forward as an attachment, still named for the version it was built from. Phones that already have it are unaffected either way: they pick up each new release over the air.
+
 - **Direct messages could not set up a device on a deployed server.** Opening *My Messages* failed with *this device could not be set up*, on every install, while working perfectly in development. The encryption the messages run on is WebAssembly, and a browser only compiles WebAssembly a page's security policy makes room for — the worker that ratchets messages was served without that room, so the browser refused to compile it before it had done anything. It is now served the same narrow policy the dashboard widget sandbox already had: its own script, WebAssembly, and nothing else. The app-wide policy is unchanged, and still forbids WebAssembly everywhere else.
 
 ## [0.66.1] - 2026-09-07

--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Images support `linux/amd64` and `linux/arm64` architectures.
 
 ---
 
+## Apps
+
+Initiative is a **PWA** — open it over HTTPS and install it from the browser (address-bar install icon on desktop Chrome/Edge, **Add tab to taskbar** in Firefox on Windows, **Add to Home Screen** on iOS Safari, **Install app** on Android Chrome). It gets its own window, stays signed in, and serves recently viewed projects and tasks offline.
+
+**Android** also has a native Capacitor app, which adds push notifications. It pulls each new web bundle from your server over the air, so you only reinstall when the native shell changes.
+
+[<img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" width="240">](https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fadd%2Fhttps%3A%2F%2Fgithub.com%2FMorelitea%2Finitiative)
+
+Or grab the APK from the [latest release](https://github.com/Morelitea/initiative/releases/latest). Full instructions: [Installing the app](https://morelitea.github.io/initiative/en/getting-started/install-the-app/).
+
+---
+
 ## Configuration
 
 ### Key Environment Variables

--- a/docs/en/getting-started/index.md
+++ b/docs/en/getting-started/index.md
@@ -12,7 +12,7 @@ You don't need experience with project management software. You don't need to kn
 
 - **A browser.** Computer, tablet, phone, whatever's nearest. There is nothing to install.
 - **Either a web address or an invite link** for your group's Initiative. Somebody in the group usually sends you one. If *you* are the one setting this up for everybody, you want the [administrator guide](../admin/index.md) instead, and our sympathies.
-- **Optional: the mobile app**, if you'd like notifications on your phone.
+- **Optional: [the app](install-the-app.md)**, if you'd like an icon on your home screen, or notifications on your phone.
 
 !!! info "Nobody's set anything up yet?"
     Then somebody has to run it somewhere. Hosting it yourself is free and open source; a paid hosted version is on the way for people who'd rather not. See [Self-host or let us host it](../self-host-or-hosted.md).

--- a/docs/en/getting-started/install-the-app.md
+++ b/docs/en/getting-started/install-the-app.md
@@ -1,0 +1,58 @@
+---
+icon: lucide/smartphone
+---
+
+# Installing the app
+
+Initiative runs in a browser, and using it that way forever is a completely respectable life choice. But you can also give it its own icon, its own window, and — on Android — notifications that arrive when you aren't looking.
+
+Two ways to do that. Neither takes longer than finding the charger.
+
+## Install it from the browser
+
+Initiative is a **progressive web app**, which is a dreadful name for a nice thing: the website installs itself. Same app, same account, no store, no download.
+
+| Where you are | What to tap |
+|---|---|
+| **iPhone or iPad (Safari)** | Share button, then **Add to Home Screen** |
+| **Android (Chrome)** | The ⋮ menu, then **Install app** or **Add to Home screen** |
+| **Chrome or Edge on a computer** | The install icon at the right-hand end of the address bar |
+| **Firefox on Windows** | **Add tab to taskbar**, in that same corner of the address bar |
+
+Firefox on Linux has the same button, once `browser.taskbarTabs.enabled` is switched on in `about:config`. On a Mac, Safari is the one that does this — Firefox there still keeps Initiative in a tab, which works perfectly well and simply looks less like an app.
+
+After that it opens in its own window with no browser furniture around it, stays signed in, and will still show you the projects and tasks you looked at recently when the train goes into a tunnel. Changing anything still wants a connection.
+
+!!! warning "The install option isn't there"
+    Browsers only offer this over a secure `https://` address. If your group's Initiative is on plain `http://`, the option quietly won't appear — nothing is broken and you haven't missed a setting. It's a question for whoever set the server up.
+
+## The Android app
+
+There's a proper Android app as well. Same Initiative inside, but it can do the thing a browser tab can't: **push notifications**, arriving on your phone while the app is shut. If your community's administrator has [set that up](../admin/push-notifications.md), this is the version you want.
+
+[![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png){ width="240" }](https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fadd%2Fhttps%3A%2F%2Fgithub.com%2FMorelitea%2Finitiative)
+
+[Obtainium](https://github.com/ImranR98/Obtainium) is a free app that watches a project's releases and keeps you updated from them. Install Obtainium first, then tap that button and it fills in the rest. If you'd rather do it by hand, the APK is attached to [every release](https://github.com/Morelitea/initiative/releases/latest).
+
+Either way Android will check that you meant to install something from outside the Play Store. You did. Allow it for whichever app is doing the installing.
+
+The first launch asks which Initiative it's talking to, because there are a lot of them and it can't guess. See [the mobile app](signing-in.md#the-mobile-app).
+
+### It keeps itself current
+
+When your community's server moves to a new version, the app fetches the matching update in the background and offers to reload. You don't reinstall anything and you don't visit a store.
+
+Every so often a release changes the app's native shell rather than the web part, and then it'll say so and point you at a new APK. That's the only time it needs you.
+
+??? techspec "How the over-the-air update works"
+    Each Docker image ships the Capacitor web bundle that matches its version, served from `/api/v1/native/bundle/`. On launch the app compares the served version with the one it's running, downloads the difference, verifies its checksum, and swaps it in behind the splash screen.
+
+    An over-the-air update can only replace web assets, never native code. Each bundle therefore declares a `minNativeVersion`, and the app refuses any bundle that needs a newer shell than the installed APK — prompting for a store or APK update instead. Release CI rebuilds the APK only when that floor moves, and carries the current one forward onto every other release so there is always one to install.
+
+## On iPhone
+
+The home-screen install in the table above is the iPhone version — the icon, the standalone window, all of it. Notifications reach you by email and in the app's own bell.
+
+## Next
+
+Now go and find where everything lives: [take the quick tour](a-quick-tour.md).

--- a/docs/en/getting-started/signing-in.md
+++ b/docs/en/getting-started/signing-in.md
@@ -33,6 +33,8 @@ Nothing arriving? Check spam first — it's usually spam. Reset links also go st
 
 ## The mobile app
 
+Haven't got it yet? [Installing the app](install-the-app.md) covers both the Android app and the home-screen version for everything else.
+
 The app needs one extra step the first time, because it has to be told *which* Initiative it's talking to. There are a lot of them out there and it has no way of guessing which one is yours.
 
 1. Open the app. You'll get a **Connect to Server** screen.

--- a/zensical.toml
+++ b/zensical.toml
@@ -45,6 +45,7 @@ nav = [
     "en/getting-started/index.md",
     "en/getting-started/create-account.md",
     "en/getting-started/signing-in.md",
+    "en/getting-started/install-the-app.md",
     "en/getting-started/a-quick-tour.md",
     "en/getting-started/your-first-community.md",
   ] },


### PR DESCRIPTION
## Problem

Two gaps, both about getting Initiative onto a phone.

**Releases sometimes had nothing to install.** The native app is only rebuilt when a release moves `MIN_NATIVE_VERSION` (see the `decide` job), so every web-only release shipped Docker-only. Anyone landing on that release page found no APK, and an updater watching the releases — Obtainium, for instance — saw a release with no asset to track. v0.66.1 is exactly this case.

**Neither the PWA nor the Android app was documented.** The help center mentioned "the mobile app" in passing and never said where to get it; the README didn't mention either.

## Changes

- [docker-publish.yml](.github/workflows/docker-publish.yml) — the `release` job gains a **Carry forward the previous release's APK** step, run whenever `build-android` produced none. It resolves the newest published release carrying a `*.apk`, skipping this release's own tag so a re-run doesn't just re-attach its own asset, and drops it where `action-gh-release` already picks it up. The release body's Android section gains a third case naming the tag the APK came from.
- [install-the-app.md](docs/en/getting-started/install-the-app.md) — new Getting started page: per-platform PWA install, the HTTPS requirement (the install option silently isn't offered on a plain-`http://` deployment, which is a real self-hoster trap), the Android app with an Obtainium button, OTA updates, and a `techspec` block on the bundle/`minNativeVersion` mechanism.
- [zensical.toml](zensical.toml), [getting-started/index.md](docs/en/getting-started/index.md), [signing-in.md](docs/en/getting-started/signing-in.md) — nav entry and cross-links.
- [README.md](README.md) — short `## Apps` section with the Obtainium badge.

### Two accuracy notes

- **No web push exists in the codebase** — push is FCM through the native app only. The page says so plainly rather than letting a reader assume a home-screen install gets notifications.
- **Firefox does support web apps now.** Firefox 143 shipped Taskbar Tabs, enabled by default on Windows (**Add tab to taskbar** in the address bar), available-but-off by default on Linux, and unsupported on macOS per Mozilla's own source docs. An earlier draft said Firefox didn't do this at all.

The Obtainium link uses the `apps.obtainium.imranr.dev/redirect` wrapper because GitHub and the docs both strip a raw `obtainium://` href, and the short `add/<repo-url>` form so Obtainium infers the GitHub source rather than embedding a 1.2 kB encoded JSON blob.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-publish.yml'))"` → parses.
- Ran the carry-forward `jq` against the live repo with `CURRENT_TAG=v0.66.1`: resolves to `v0.66.0`, the correct fallback.
- `curl` on both the Obtainium badge and the redirect endpoint → `200`.
- `zensical build` → **No issues found**.
- Nav/file agreement check from the docs skill → both directions empty.

No `backend/` or `frontend/` source changed, so those suites don't apply.