### PR TITLE
Stop carrying an APK forward onto releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -319,43 +319,6 @@ jobs:
           name: android-apk
           path: artifacts
 
-      # A web-only release builds no APK (see the `decide` job), but somebody landing on the
-      # release page still needs one to install. Carry the newest APK published on an earlier
-      # release forward onto this one — it is precisely the native build this web bundle
-      # expects, and its filename keeps its own version so it reads as a carried-over build
-      # rather than a fresh one.
-      #
-      # Strictly `skipped`, never merely "not success": skipped is the `decide` job stating
-      # the native shell did not change, which is what makes the older APK the correct one.
-      # A *cancelled* build means MIN_NATIVE_VERSION did move, so the older APK is below this
-      # bundle's floor and would refuse it — better to attach nothing than the wrong app.
-      - name: Carry forward the previous release's APK
-        id: carry_apk
-        if: ${{ needs.build-android.result == 'skipped' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          CURRENT_TAG: ${{ github.ref_name }}
-        run: |
-          mkdir -p artifacts
-          # Releases come back newest-first; take the first published one carrying an APK,
-          # skipping this release's own tag so a re-run doesn't just re-attach its own asset.
-          tag=$(gh api "repos/${GH_REPO}/releases?per_page=50" --jq "
-            map(select(.draft | not)
-                | select(.tag_name != \"${CURRENT_TAG}\")
-                | select(any(.assets[]; .name | endswith(\".apk\"))))
-            | .[0].tag_name // empty")
-          if [ -z "$tag" ]; then
-            echo "No earlier release carries an APK — this release ships Docker-only."
-            echo "carried=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          gh release download "$tag" --repo "$GH_REPO" --pattern '*.apk' --dir artifacts
-          echo "Carried the APK forward from $tag:"
-          ls -1 artifacts
-          echo "carried=true" >> "$GITHUB_OUTPUT"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       - name: Extract version from tag
         id: version
         run: |
@@ -375,8 +338,6 @@ jobs:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           APK_BUILT: ${{ needs.build-android.result == 'success' }}
-          APK_CARRIED: ${{ steps.carry_apk.outputs.carried }}
-          APK_CARRIED_FROM: ${{ steps.carry_apk.outputs.tag }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "Extracting changelog for version $VERSION"
@@ -401,17 +362,17 @@ jobs:
           fi
 
           # The native app is only rebuilt when the native shell changed (see the `decide`
-          # job). Web-only releases carry the previous APK forward, so every release has one
-          # to install; installed apps pick the new web bundle up over the air regardless.
+          # job). Web-only releases ship no new APK — existing installs update over the air,
+          # and an updater tracking these releases falls back to the last one that carried an
+          # APK. Attaching an older APK here instead reads as a new version to those updaters,
+          # which then reinstall the app they already have.
           if [ "$APK_BUILT" = "true" ]; then
-            ANDROID_NOTE="Download the APK from the assets below and install it on your Android device."
-          elif [ "$APK_CARRIED" = "true" ]; then
-            ANDROID_NOTE="No new app build this release — the APK below is the current native app, carried forward from ${APK_CARRIED_FROM}. Installed apps pick this release up automatically over the air on next launch."
+            ANDROID_SECTION="### Android App
+          Download the APK from the assets below and install on your Android device."
           else
-            ANDROID_NOTE="No app build is available for this release. Installed apps update automatically over the air on next launch."
+            ANDROID_SECTION="### Android App
+          No new app build this release — installed apps update automatically over the air on next launch."
           fi
-          ANDROID_SECTION="### Android App
-          $ANDROID_NOTE"
 
           # Build full release body with changelog + download info
           cat > release_body.md << ENDOFBODY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Every release now has an Android app to download.** Initiative only rebuilds the app when a release changes its native shell, so every other release published nothing to install — anyone landing on the release page, or any updater watching those releases, found no APK at all. Each release now carries the current app forward as an attachment, still named for the version it was built from. Phones that already have it are unaffected either way: they pick up each new release over the air.
-
 - **Direct messages could not set up a device on a deployed server.** Opening *My Messages* failed with *this device could not be set up*, on every install, while working perfectly in development. The encryption the messages run on is WebAssembly, and a browser only compiles WebAssembly a page's security policy makes room for — the worker that ratchets messages was served without that room, so the browser refused to compile it before it had done anything. It is now served the same narrow policy the dashboard widget sandbox already had: its own script, WebAssembly, and nothing else. The app-wide policy is unchanged, and still forbids WebAssembly everywhere else.
 
 ## [0.66.1] - 2026-09-07

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Initiative is a **PWA** — open it over HTTPS and install it from the browser (
 
 [<img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" width="240">](https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fadd%2Fhttps%3A%2F%2Fgithub.com%2FMorelitea%2Finitiative)
 
-Or grab the APK from the [latest release](https://github.com/Morelitea/initiative/releases/latest). Full instructions: [Installing the app](https://morelitea.github.io/initiative/en/getting-started/install-the-app/).
+Or take the newest [release](https://github.com/Morelitea/initiative/releases) with an `.apk` attached — the app is only rebuilt when the native shell changes, so most releases carry none. Full instructions: [Installing the app](https://morelitea.github.io/initiative/en/getting-started/install-the-app/).
 
 ---
 

--- a/docs/en/getting-started/install-the-app.md
+++ b/docs/en/getting-started/install-the-app.md
@@ -32,7 +32,7 @@ There's a proper Android app as well. Same Initiative inside, but it can do the 
 
 [![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png){ width="240" }](https://apps.obtainium.imranr.dev/redirect?r=obtainium%3A%2F%2Fadd%2Fhttps%3A%2F%2Fgithub.com%2FMorelitea%2Finitiative)
 
-[Obtainium](https://github.com/ImranR98/Obtainium) is a free app that watches a project's releases and keeps you updated from them. Install Obtainium first, then tap that button and it fills in the rest. If you'd rather do it by hand, the APK is attached to [every release](https://github.com/Morelitea/initiative/releases/latest).
+[Obtainium](https://github.com/ImranR98/Obtainium) is a free app that watches a project's releases and keeps you updated from them. Install Obtainium first, then tap that button and it fills in the rest, including working back to the most recent release that actually carries an app. Doing it by hand instead: take the newest [release](https://github.com/Morelitea/initiative/releases) with an `.apk` on it. That often isn't the top one: the app is only rebuilt when it changes, and the releases in between are web-only.
 
 Either way Android will check that you meant to install something from outside the Play Store. You did. Allow it for whichever app is doing the installing.
 
@@ -47,7 +47,7 @@ Every so often a release changes the app's native shell rather than the web part
 ??? techspec "How the over-the-air update works"
     Each Docker image ships the Capacitor web bundle that matches its version, served from `/api/v1/native/bundle/`. On launch the app compares the served version with the one it's running, downloads the difference, verifies its checksum, and swaps it in behind the splash screen.
 
-    An over-the-air update can only replace web assets, never native code. Each bundle therefore declares a `minNativeVersion`, and the app refuses any bundle that needs a newer shell than the installed APK — prompting for a store or APK update instead. Release CI rebuilds the APK only when that floor moves, and carries the current one forward onto every other release so there is always one to install.
+    An over-the-air update can only replace web assets, never native code. Each bundle therefore declares a `minNativeVersion`, and the app refuses any bundle that needs a newer shell than the installed APK — prompting for a store or APK update instead. Release CI rebuilds the APK only when that floor moves, so most releases attach none at all. An updater watching the releases falls back to the last one that did — which is the build you want, because it is still the shell this bundle runs on. Re-attaching that same APK to later releases would be worse than attaching nothing: an updater reads the release, not the file, so it would see a new version each time and reinstall the app you already have.
 
 ## On iPhone
 


### PR DESCRIPTION
## Problem

Reverts the carry-forward added in #1445. It doesn't work, confirmed by hand: uploading 0.66.0's APK to the 0.66.1 release made Obtainium see a **new version** and offer to install the app the phone already had.

The reasoning behind #1445 was wrong at the root. An updater tracking a GitHub repo keys the version off **the release**, not off the attached file — so re-attaching the same APK under a new tag is indistinguishable from shipping a new build, however the file is named. Naming it `initiative-0.66.0.apk` reads as a carried-forward build to a human and as nothing at all to Obtainium.

## Attaching nothing is the better failure

Obtainium's `fallbackToOlderReleases` defaults to **`true`** ([source_provider.dart:616-622](https://github.com/ImranR98/Obtainium/blob/main/lib/providers/source_provider.dart)), so a release with no APK isn't a dead end: it walks back to the last release that carried one. That build is the correct one anyway — it's the native shell the new web bundle runs on, which is precisely why CI skipped rebuilding it.

So the original complaint ("a web-only release has nothing to install") was already handled by the updater, and the fix made things worse than the gap it closed.

## Changes

- [docker-publish.yml](.github/workflows/docker-publish.yml) — the carry-forward step, its `APK_CARRIED*` env vars, and the third release-body case are gone. The file is now identical to its pre-#1445 state apart from a comment recording why not to reintroduce this.
- [install-the-app.md](docs/en/getting-started/install-the-app.md) — no longer claims the APK is attached to every release. Says the newest release with an `.apk` often isn't the top one and that this is normal; the `techspec` block explains why re-attaching would be worse than attaching nothing.
- [README.md](README.md) — same correction; the manual-download link goes to the releases list rather than `/releases/latest`, which can resolve to a release with no APK.
- [CHANGELOG.md](CHANGELOG.md) — drops the `[Unreleased]` entry for the reverted behaviour. It never shipped, so there's nothing to tell users.

The Obtainium button itself is unchanged and still correct.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` → parses.
- `git diff 26f69ed9c^ -- .github/workflows/docker-publish.yml` → the only remaining delta is the explanatory comment, confirming a clean revert of the mechanism.
- `zensical build` → **No issues found**.
- Obtainium's fallback default read from source rather than assumed.

No `backend/` or `frontend/` source changed.