### PR TITLE
Fix 500 when editing a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Editing a comment reported an error it had not had.** Saving a change to a comment came back as a server error, on every surface a comment lives on, even though the edit itself had gone through — so the edit looked broken, retrying looked broken, and the only way past it was to delete the comment and write it again. The reply now carries the edited comment back whole, author and reactions included, the way posting one always did.
+
 - **Direct messages could not set up a device on a deployed server.** Opening *My Messages* failed with *this device could not be set up*, on every install, while working perfectly in development. The encryption the messages run on is WebAssembly, and a browser only compiles WebAssembly a page's security policy makes room for — the worker that ratchets messages was served without that room, so the browser refused to compile it before it had done anything. It is now served the same narrow policy the dashboard widget sandbox already had: its own script, WebAssembly, and nothing else. The app-wide policy is unchanged, and still forbids WebAssembly everywhere else.
 
 ## [0.66.1] - 2026-09-07

--- a/backend/app/api/v1/tenant_endpoints/comments.py
+++ b/backend/app/api/v1/tenant_endpoints/comments.py
@@ -357,8 +357,10 @@ async def update_comment(
     # Note: Content validation (empty string) is handled by Pydantic schema (422).
     # CommentValidationError from service indicates data integrity issues (500).
 
+    # No refresh here: the service already flushed the edit and loaded the
+    # author, and a bare refresh() expires every attribute including that
+    # relationship — serializing would then lazy-load it mid-request.
     await session.commit()
-    await session.refresh(comment)
     response = comments_service.serialize_comment(comment, viewer_id=current_user.id)
     await _broadcast_comment(session, guild_context.guild_id, comment, "updated")
     return response

--- a/backend/app/api/v1/tenant_endpoints/comments_test.py
+++ b/backend/app/api/v1/tenant_endpoints/comments_test.py
@@ -502,3 +502,101 @@ class TestToolCommentSwitch:
             json={"comments_enabled": False},
         )
         assert denied.status_code == 403, denied.text
+
+
+@pytest.mark.integration
+class TestEditingAComment:
+    """The edit reply is the client's read-back: it has to carry the whole
+    comment, author and reactions included, on every surface."""
+
+    @pytest.mark.parametrize("tool", list(Tool))
+    async def test_author_edits_and_gets_the_whole_comment_back(
+        self, client, session, acting_user, tool
+    ):
+        a = await acting_user(guild_role=GuildRole.member, initiative=True)
+        entity = await _tool_entity(session, tool, a.initiative, a.user)
+
+        posted = await client.post(
+            a.g("/comments/"),
+            headers=a.headers,
+            json={"content": "Before", _param(tool): entity.id},
+        )
+        assert posted.status_code == 201, posted.text
+        comment_id = posted.json()["id"]
+
+        edited = await client.patch(
+            a.g(f"/comments/{comment_id}"),
+            headers=a.headers,
+            json={"content": "After"},
+        )
+        assert edited.status_code == 200, edited.text
+        body = edited.json()
+        assert body["content"] == "After"
+        assert body["author"] is not None
+        assert body["author"]["id"] == a.user.id
+        assert body[_param(tool)] == entity.id
+        if tool is Tool.project:
+            assert body["project_id"] == entity.id
+
+        listed = await client.get(
+            a.g("/comments/"), headers=a.headers, params={_param(tool): entity.id}
+        )
+        assert [c["content"] for c in listed.json()] == ["After"]
+
+    async def test_an_edit_keeps_the_reactions(self, client, session, acting_user):
+        a = await acting_user(guild_role=GuildRole.member, initiative=True)
+        project = await _tool_entity(session, Tool.project, a.initiative, a.user)
+        task = await create_task(session, project)
+
+        posted = await client.post(
+            a.g("/comments/"),
+            headers=a.headers,
+            json={"content": "Before", "task_id": task.id},
+        )
+        assert posted.status_code == 201, posted.text
+        comment_id = posted.json()["id"]
+
+        reacted = await client.put(
+            a.g(f"/reactions/comment/{comment_id}"),
+            headers=a.headers,
+            json={"emoji": "🎉"},
+        )
+        assert reacted.status_code == 200, reacted.text
+
+        edited = await client.patch(
+            a.g(f"/comments/{comment_id}"),
+            headers=a.headers,
+            json={"content": "After"},
+        )
+        assert edited.status_code == 200, edited.text
+        body = edited.json()
+        assert body["author"] is not None
+        # A task comment reports its task's project, same as the list reply.
+        assert body["project_id"] == project.id
+        assert [(g["emoji"], g["count"]) for g in body["reactions"]] == [("🎉", 1)]
+
+    async def test_only_the_author_may_edit(self, client, session, acting_user):
+        a = await acting_user(guild_role=GuildRole.member, initiative=True)
+        project = await _tool_entity(session, Tool.project, a.initiative, a.user)
+        b = await acting_user(
+            guild_role=GuildRole.member,
+            guild=a.guild,
+            initiative=a.initiative,
+            initiative_role="member",
+        )
+        await _grant(session, Tool.project, project, b.user, ResourceAccessLevel.write)
+
+        posted = await client.post(
+            a.g("/comments/"),
+            headers=a.headers,
+            json={"content": "Mine", "project_id": project.id},
+        )
+        assert posted.status_code == 201, posted.text
+
+        denied = await client.patch(
+            a.g(f"/comments/{posted.json()['id']}"),
+            headers=b.headers,
+            json={"content": "Yours"},
+        )
+        assert denied.status_code == 403
+        assert denied.json()["detail"] == CommentMessages.AUTHOR_ONLY_EDIT


### PR DESCRIPTION
## Problem

`PATCH /api/v1/g/{guild}/comments/{id}` returned **500** while the edit itself
committed successfully — so the comment changed in the database, the client saw
an error, and retrying re-applied the edit while still looking broken. From the
UI, editing a comment looked entirely broken; the reported workaround was to
delete and re-post.

The endpoint called a bare `await session.refresh(comment)` after the commit.
Without `attribute_names` that expires *every* attribute and reloads only the
columns, so the `author` relationship came back unloaded — and
`CommentRead.model_validate` then tripped a lazy load from Pydantic's sync
validation inside the async request:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for CommentRead
  Error extracting attribute: MissingGreenlet: greenlet_spawn has not been called
```

The service's `update_comment` already flushes and does
`refresh(comment, attribute_names=["author"])` plus `attach_reactions`, so the
endpoint's refresh was redundant as well as harmful. The create path has never
had one — it commits and serializes — which is why posting worked and only
editing broke.

The edit path had **no test coverage anywhere in the suite**: no endpoint test,
no service test, nothing calling `update_comment`. That is why this shipped.

## Changes

- Drop the bare refresh in `update_comment` in [comments.py](backend/app/api/v1/tenant_endpoints/comments.py), making the edit path match the create path.
- Add `TestEditingAComment` to [comments_test.py](backend/app/api/v1/tenant_endpoints/comments_test.py):
  - `test_author_edits_and_gets_the_whole_comment_back` — parametrized over every `Tool`; asserts the reply carries `author` and the parent id. This is the direct repro (fails on the old code with the exact reported traceback).
  - `test_an_edit_keeps_the_reactions` — a task comment with a reaction; asserts the edit reply still carries the chip and the resolved `project_id`, guarding the `_reactions` / `_task_project_id` stamps the serializer depends on.
  - `test_only_the_author_may_edit` — a co-member with write access gets 403 `COMMENT_AUTHOR_ONLY_EDIT`.
- `CHANGELOG.md` entry under `[Unreleased]` → Fixed.

No schema changes, so no migration and no Orval regeneration.

## Testing

- `pytest -n 0 app/api/v1/tenant_endpoints/comments_test.py::TestEditingAComment` — 9 passed (all 9 fail on `dev` without the fix).
- `pytest app/api/v1/tenant_endpoints/comments_test.py app/api/v1/tenant_endpoints/reactions_test.py app/services/tenant/comments_test.py` — passed (serial).
- `ruff check app` — clean; `ruff format --check` on the changed files — clean.

Note: running those endpoint suites under `-n 4` shows 8 failures
(`TestToolComments::test_member_without_grant_is_denied` for all tools, and
`reactions_test.py::TestReactionAccess::test_unshared_member_reaches_nothing`,
all 404-vs-403). I verified these fail identically on a stashed clean `dev`, so
they are pre-existing test-isolation flakiness under xdist and unrelated to this
change.

Fixes #1436