### PR TITLE
Let the sharing policy be lived with

### DIFF
--- a/backend/app/api/resource_access.py
+++ b/backend/app/api/resource_access.py
@@ -37,6 +37,7 @@ from app.models.platform.guild import GuildRole
 from app.models.platform.user import User
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.services import permissions as permissions_service
+from app.services import reachability
 from app.services.tenant import ownership as ownership_service
 from app.services.tenant import calendars as calendars_service
 from app.services.tenant import counters as counters_service
@@ -201,6 +202,14 @@ async def load_authorized(
         raise RuntimeError(f"RESOURCE_ACCESS[{kind}] has no loader")
     row = await cfg.loader(session, resource_id)
     if row is None:
+        if await reachability.reader_is_in_the_initiative(
+            kind.plural, resource_id, user.id, guild_context.guild_id
+        ):
+            # In the initiative, so the row is theirs to know about — sharing is
+            # what refused it, and "denied" is the answer to that.
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail=cfg.not_found_msg
+            )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=cfg.not_found_msg
         )

--- a/backend/app/api/v1/tenant_endpoints/posts.py
+++ b/backend/app/api/v1/tenant_endpoints/posts.py
@@ -1131,7 +1131,9 @@ async def vote_on_post_poll(
     # statement, against the wall clock at that moment. The row is held until
     # this ballot commits, so one voter's ballots are written one after another
     # and each is measured by the deadline in force as it lands.
-    if not await post_polls_service.lock_open_poll(session, poll):
+    if not await post_polls_service.lock_open_poll(
+        session, poll, guild_id=guild_context.guild_id
+    ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=PostMessages.POLL_CLOSED,
@@ -1173,7 +1175,9 @@ async def retract_post_poll_vote(
         session, Tool.post, post_id, current_user, guild_context
     )
     poll = _poll_of(post)
-    if not await post_polls_service.lock_open_poll(session, poll):
+    if not await post_polls_service.lock_open_poll(
+        session, poll, guild_id=guild_context.guild_id
+    ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=PostMessages.POLL_CLOSED,

--- a/backend/app/api/v1/tenant_endpoints/posts.py
+++ b/backend/app/api/v1/tenant_endpoints/posts.py
@@ -1045,7 +1045,9 @@ async def set_post_poll(
     data = _validated_poll(poll_in)
     existing = post.poll
     if existing is not None:
-        await post_polls_service.lock_poll(session, existing)
+        await post_polls_service.lock_poll(
+            session, existing, guild_id=guild_context.guild_id
+        )
         if await post_polls_service.has_votes(session, existing):
             if not post_polls_service.options_match(existing, data):
                 raise HTTPException(

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -1295,26 +1295,8 @@ async def create_project(
     session.add(project)
     await session.flush()
 
-    status_mapping: dict[int, int] = {}
-    if template_project:
-        status_mapping = await task_statuses_service.clone_statuses(
-            session,
-            source_project_id=template_project.id,
-            target_project_id=project.id,
-        )
-
-    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
-    fallback_status_ids = {status.category: status.id for status in statuses}
-
-    if template_project:
-        await filter_presets_service.clone_presets(
-            session,
-            source_project_id=template_project.id,
-            target_project_id=project.id,
-            status_mapping=status_mapping,
-        )
-    await filter_presets_service.ensure_default_presets(session, project.id)
-
+    # Sharing before anything that hangs off it: a status, a preset or a task
+    # is reached through the project, so the project has to be reachable first.
     owner_permission = ResourceGrant(
         resource_type="project",
         resource_id=project.id,
@@ -1337,6 +1319,28 @@ async def create_project(
         owner_id=owner_id,
         grants=project_in.grants,
     )
+
+    await session.flush()
+
+    status_mapping: dict[int, int] = {}
+    if template_project:
+        status_mapping = await task_statuses_service.clone_statuses(
+            session,
+            source_project_id=template_project.id,
+            target_project_id=project.id,
+        )
+
+    statuses = await task_statuses_service.ensure_default_statuses(session, project.id)
+    fallback_status_ids = {status.category: status.id for status in statuses}
+
+    if template_project:
+        await filter_presets_service.clone_presets(
+            session,
+            source_project_id=template_project.id,
+            target_project_id=project.id,
+            status_mapping=status_mapping,
+        )
+    await filter_presets_service.ensure_default_presets(session, project.id)
 
     if template_project:
         await _duplicate_template_tasks(

--- a/backend/app/core/tools_test.py
+++ b/backend/app/core/tools_test.py
@@ -161,6 +161,22 @@ def test_every_tool_is_commentable():
     assert set(COMMENT_TARGET_FIELDS) == set(COMMENT_PARENT_COLUMNS)
 
 
+def test_every_tool_row_is_written_without_returning():
+    # A tool row is written before anything has been shared with anybody, so it
+    # cannot be read back in the statement that writes it — the sharing policy
+    # is what a RETURNING clause would be answered by, and at that instant the
+    # answer is no. Turning implicit RETURNING off makes the id come from the
+    # sequence first, so the INSERT stands alone. A new tool that forgets this
+    # cannot be created at all; it fails here first.
+    from sqlmodel import SQLModel
+
+    import app.db.base  # noqa: F401  (populates the metadata)
+
+    for tool in Tool:
+        table = SQLModel.metadata.tables[tool.plural]
+        assert table.implicit_returning is False, tool
+
+
 def test_every_tool_carries_the_comment_switch():
     # Every tool can turn its own thread off: the column on the content table
     # and the flag on the read schema are spelled the same on all six, and the

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -69,32 +69,12 @@ class DacPath:
     self_governed: bool = False
 
 
-def _resource_call(
-    tool: str,
-    resource_id: str,
-    initiative: str,
-    write: bool,
-    created_by: str | None = None,
-) -> str:
-    """One ``public.resource_access`` call, in policy form.
-
-    ``created_by`` adds the leg for a resource that has no sharing YET: the row
-    being written and the rows written beside it in the same breath, before the
-    owner grant exists. It answers only to the person making it, and only while
-    the resource has no grants at all — which, once the grant lands one
-    statement later, it never does again.
-    """
-    call = (
+def _resource_call(tool: str, resource_id: str, initiative: str, write: bool) -> str:
+    """One ``public.resource_access`` call, in policy form."""
+    return (
         f"public.resource_access({tool}, {resource_id}, {_UID}, "
         f"{initiative}, {'true' if write else 'false'})"
     )
-    if created_by is None:
-        return call
-    unshared = (
-        f"SELECT 1 FROM resource_grants rg WHERE rg.resource_type = {tool} "
-        f"AND rg.resource_id = {resource_id}"
-    )
-    return f"({call} OR ({created_by} = {_UID} AND NOT EXISTS ({unshared})))"
 
 
 def _dac_self(tool: Tool | None = None) -> DacPath:
@@ -108,11 +88,7 @@ def _dac_self(tool: Tool | None = None) -> DacPath:
         if governing is None:
             return None
         return _resource_call(
-            f"'{governing.value}'",
-            f"{t}.id",
-            f"{t}.initiative_id",
-            w,
-            f"{t}.created_by",
+            f"'{governing.value}'", f"{t}.id", f"{t}.initiative_id", w
         )
 
     return DacPath(predicate=build, self_governed=True)
@@ -131,11 +107,7 @@ def _dac_via(
             f"EXISTS (SELECT 1 FROM {parent} {alias} "
             f"WHERE {alias}.{parent_pk} = {t}.{fk} AND "
             + _resource_call(
-                f"'{tool.value}'",
-                f"{alias}.id",
-                f"{alias}.initiative_id",
-                w,
-                f"{alias}.created_by",
+                f"'{tool.value}'", f"{alias}.id", f"{alias}.initiative_id", w
             )
             + ")"
         )
@@ -150,13 +122,7 @@ def _dac_two_hop(mid: str, mid_fk: str, parent: str, fk: str) -> DacPath:
         predicate=lambda t, w: (
             f"EXISTS (SELECT 1 FROM {mid} dmid JOIN {parent} dpar "
             f"ON dpar.id = dmid.{mid_fk} WHERE dmid.id = {t}.{fk} AND "
-            + _resource_call(
-                "'" + tool.value + "'",
-                "dpar.id",
-                "dpar.initiative_id",
-                w,
-                "dpar.created_by",
-            )
+            + _resource_call("'" + tool.value + "'", "dpar.id", "dpar.initiative_id", w)
             + ")"
         )
     )

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -69,12 +69,32 @@ class DacPath:
     self_governed: bool = False
 
 
-def _resource_call(tool: str, resource_id: str, initiative: str, write: bool) -> str:
-    """One ``public.resource_access`` call, in policy form."""
-    return (
+def _resource_call(
+    tool: str,
+    resource_id: str,
+    initiative: str,
+    write: bool,
+    created_by: str | None = None,
+) -> str:
+    """One ``public.resource_access`` call, in policy form.
+
+    ``created_by`` adds the leg for a resource that has no sharing YET: the row
+    being written and the rows written beside it in the same breath, before the
+    owner grant exists. It answers only to the person making it, and only while
+    the resource has no grants at all — which, once the grant lands one
+    statement later, it never does again.
+    """
+    call = (
         f"public.resource_access({tool}, {resource_id}, {_UID}, "
         f"{initiative}, {'true' if write else 'false'})"
     )
+    if created_by is None:
+        return call
+    unshared = (
+        f"SELECT 1 FROM resource_grants rg WHERE rg.resource_type = {tool} "
+        f"AND rg.resource_id = {resource_id}"
+    )
+    return f"({call} OR ({created_by} = {_UID} AND NOT EXISTS ({unshared})))"
 
 
 def _dac_self(tool: Tool | None = None) -> DacPath:
@@ -88,7 +108,11 @@ def _dac_self(tool: Tool | None = None) -> DacPath:
         if governing is None:
             return None
         return _resource_call(
-            f"'{governing.value}'", f"{t}.id", f"{t}.initiative_id", w
+            f"'{governing.value}'",
+            f"{t}.id",
+            f"{t}.initiative_id",
+            w,
+            f"{t}.created_by",
         )
 
     return DacPath(predicate=build, self_governed=True)
@@ -107,7 +131,11 @@ def _dac_via(
             f"EXISTS (SELECT 1 FROM {parent} {alias} "
             f"WHERE {alias}.{parent_pk} = {t}.{fk} AND "
             + _resource_call(
-                f"'{tool.value}'", f"{alias}.id", f"{alias}.initiative_id", w
+                f"'{tool.value}'",
+                f"{alias}.id",
+                f"{alias}.initiative_id",
+                w,
+                f"{alias}.created_by",
             )
             + ")"
         )
@@ -122,7 +150,13 @@ def _dac_two_hop(mid: str, mid_fk: str, parent: str, fk: str) -> DacPath:
         predicate=lambda t, w: (
             f"EXISTS (SELECT 1 FROM {mid} dmid JOIN {parent} dpar "
             f"ON dpar.id = dmid.{mid_fk} WHERE dmid.id = {t}.{fk} AND "
-            + _resource_call("'" + tool.value + "'", "dpar.id", "dpar.initiative_id", w)
+            + _resource_call(
+                "'" + tool.value + "'",
+                "dpar.id",
+                "dpar.initiative_id",
+                w,
+                "dpar.created_by",
+            )
             + ")"
         )
     )
@@ -669,6 +703,10 @@ DAC_WRITE_COMMANDS: dict[str, frozenset[str]] = {
     "post_reads": frozenset(),
     "post_poll_votes": frozenset(),
     "calendar_event_attendees": frozenset(),
+    # A record that this reader was reminded, written where the reminder is
+    # sent. Being told about an event is a reader's business, not a change to
+    # the calendar.
+    "event_reminder_dispatches": _RESPONDING,
     "comments": _RESPONDING,
     "reactions": _RESPONDING,
     # The queued line describing a reaction is written in the SAME request as

--- a/backend/app/models/tenant/calendar.py
+++ b/backend/app/models/tenant/calendar.py
@@ -32,6 +32,10 @@ class Calendar(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=True)
     """
 
     __tablename__ = "calendars"
+    # A tool row is written before anything has been shared, so it is read
+    # back by no RETURNING clause: the id comes from the sequence first and
+    # the INSERT stands alone. See app/db/initiative_rls.py.
+    __table_args__ = {"implicit_returning": False}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     guild_id: int = Field(foreign_key="guilds.id", nullable=False, index=True)

--- a/backend/app/models/tenant/counter.py
+++ b/backend/app/models/tenant/counter.py
@@ -35,6 +35,10 @@ class CounterGroup(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=T
     """Initiative-scoped container for a set of related counters."""
 
     __tablename__ = "counter_groups"
+    # A tool row is written before anything has been shared, so it is read
+    # back by no RETURNING clause: the id comes from the sequence first and
+    # the INSERT stands alone. See app/db/initiative_rls.py.
+    __table_args__ = {"implicit_returning": False}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     guild_id: int = Field(foreign_key="guilds.id", nullable=False, index=True)

--- a/backend/app/models/tenant/dashboard.py
+++ b/backend/app/models/tenant/dashboard.py
@@ -37,6 +37,10 @@ class Dashboard(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=True
     """
 
     __tablename__ = "dashboards"
+    # A tool row is written before anything has been shared, so it is read
+    # back by no RETURNING clause: the id comes from the sequence first and
+    # the INSERT stands alone. See app/db/initiative_rls.py.
+    __table_args__ = {"implicit_returning": False}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     guild_id: int = Field(foreign_key="guilds.id", nullable=False, index=True)

--- a/backend/app/models/tenant/document.py
+++ b/backend/app/models/tenant/document.py
@@ -45,6 +45,10 @@ class DocumentType(str, Enum):
 
 class Document(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=True):
     __tablename__ = "documents"
+    # A tool row is written before anything has been shared, so it is read
+    # back by no RETURNING clause: the id comes from the sequence first and
+    # the INSERT stands alone. See app/db/initiative_rls.py.
+    __table_args__ = {"implicit_returning": False}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     guild_id: Optional[int] = Field(

--- a/backend/app/models/tenant/post.py
+++ b/backend/app/models/tenant/post.py
@@ -63,6 +63,10 @@ class Post(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=True):
     """
 
     __tablename__ = "posts"
+    # A tool row is written before anything has been shared, so it is read
+    # back by no RETURNING clause: the id comes from the sequence first and
+    # the INSERT stands alone. See app/db/initiative_rls.py.
+    __table_args__ = {"implicit_returning": False}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     guild_id: int = Field(foreign_key="guilds.id", nullable=False, index=True)

--- a/backend/app/models/tenant/project.py
+++ b/backend/app/models/tenant/project.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:  # pragma: no cover - imported lazily for type checking only
 
 class Project(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=True):
     __tablename__ = "projects"
+    # A tool row is written before anything has been shared, so it is read
+    # back by no RETURNING clause: the id comes from the sequence first and
+    # the INSERT stands alone. See app/db/initiative_rls.py.
+    __table_args__ = {"implicit_returning": False}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     guild_id: Optional[int] = Field(

--- a/backend/app/models/tenant/queue.py
+++ b/backend/app/models/tenant/queue.py
@@ -34,6 +34,10 @@ class Queue(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=True):
     """Initiative-scoped queue for turn/priority tracking."""
 
     __tablename__ = "queues"
+    # A tool row is written before anything has been shared, so it is read
+    # back by no RETURNING clause: the id comes from the sequence first and
+    # the INSERT stands alone. See app/db/initiative_rls.py.
+    __table_args__ = {"implicit_returning": False}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     guild_id: int = Field(foreign_key="guilds.id", nullable=False, index=True)

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -1,0 +1,69 @@
+"""Why a row the request asked for was not there.
+
+Gate 4 is a policy, so a resource a reader may not reach is simply absent by
+the time a handler runs — and "not yours" and "not there" are different
+answers. This asks the system engine that one question and takes back a yes or
+no, never a row.
+
+It is a *status-code* decision, not a gate: nothing here grants access, and
+every caller has already been refused by the database before it asks.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlmodel import SQLModel
+
+from app.db.initiative_rls import INITIATIVE_PATHS
+from app.db.schema_provisioning import guild_schema_name
+from app.db import session as db_session
+from app.db.session import set_rls_context
+from app.models.platform.guild import GuildRole
+
+
+async def reader_is_in_the_initiative(
+    table: str, row_id: int, user_id: int, guild_id: int
+) -> bool:
+    """Whether ``row_id`` belongs to an initiative ``user_id`` is a member of.
+
+    How a row of this table finds its initiative comes from ``INITIATIVE_PATHS``
+    — the same declaration the table's own policies render from — so a table
+    cannot be gated through one initiative and probed through another.
+
+    Routed as the guild's own admin, which is how every other system read
+    reaches guild content. A row belonging to no initiative (a guild calendar)
+    has no initiative gate to fail, so reaching this point means sharing
+    refused it.
+    """
+    path = INITIATIVE_PATHS.get(table)
+    if path is None:
+        return False
+    initiative = path.initiative_expr("r")
+    live = (
+        " AND r.deleted_at IS NULL"
+        if "deleted_at" in SQLModel.metadata.tables[table].columns
+        else ""
+    )
+    # Every fragment here is rendered from the registry above and the model
+    # metadata — never from the request. The tables are named with their schema
+    # so the probe does not depend on a search_path of its own.
+    schema = guild_schema_name(guild_id)
+    statement = text(
+        f"SELECT {initiative} IS NULL OR EXISTS ("  # noqa: S608
+        f'  SELECT 1 FROM "{schema}".initiative_members im'
+        f"  WHERE im.initiative_id = {initiative} AND im.user_id = :uid)"
+        f' FROM "{schema}".{table} r WHERE r.id = :rid{live}'
+    )
+    # Late-bound (module attribute at call time) so the test harness's
+    # sessionmaker patch applies to the probe too.
+    async with db_session.AdminSessionLocal() as probe, probe.begin():
+        # One transaction, explicitly: the routing is transaction-local, and
+        # the probe runs on a session of its own rather than the request's, so
+        # it cannot inherit it.
+        await set_rls_context(
+            probe, guild_id=guild_id, guild_role=GuildRole.admin.value
+        )
+        found = (
+            await probe.exec(statement, params={"uid": user_id, "rid": row_id})
+        ).first()
+    return bool(found[0]) if found is not None else False

--- a/backend/app/services/tenant/comments.py
+++ b/backend/app/services/tenant/comments.py
@@ -50,6 +50,7 @@ from app.models.platform.user_profile_view import MemberProfile
 from app.services import rls as rls_service
 from app.services import notifications
 from app.services import permissions as permissions_service
+from app.services import reachability
 from app.services.platform import accounts as accounts_service
 from app.services.tenant.mention_parser import (
     extract_mentioned_user_ids,
@@ -461,6 +462,15 @@ async def _resolved_parent(
         session, column=column, entity_id=entity_id, guild_id=guild_id
     )
     if ctx is None:
+        # The policies took the parent out before this ran. In the initiative
+        # it is the reader's to know about, so sharing is what refused it.
+        table = (
+            "tasks" if column == "task_id" else _TARGETS_BY_COLUMN[column].tool.plural
+        )
+        if await reachability.reader_is_in_the_initiative(
+            table, entity_id, cast(int, user.id), guild_id
+        ):
+            raise CommentPermissionError(CommentMessages.PERMISSION_DENIED)
         raise CommentNotFoundError(_parent_not_found(column))
     await _ensure_parent_access(session, ctx, user=user, access=access)
     return ctx

--- a/backend/app/services/tenant/post_polls.py
+++ b/backend/app/services/tenant/post_polls.py
@@ -116,16 +116,34 @@ async def annotate_poll_state(
         object.__setattr__(poll, "_has_votes", bool(voters))
 
 
-async def lock_poll(session: AsyncSession, poll: PostPoll) -> None:
-    """Take this poll's row for the rest of the transaction.
+async def _turnstile(session: AsyncSession, poll: PostPoll, guild_id: int) -> None:
+    """Take this poll's turnstile for the rest of the transaction.
 
-    Held by every path that reads what has been answered and then acts on it,
-    so the reading and the acting are one indivisible step. One row, always the
-    same one, so there is no order for two of these to deadlock over.
+    An advisory lock rather than the poll's row: answering a question is not
+    editing it, so a voter must not have to hold a lock that asks for write
+    access on the notice. Editing and answering take the SAME turnstile, or
+    they would not exclude each other at all.
+
+    Keyed by guild as well as poll, because poll ids repeat across guild
+    schemas. One key, always the same one, so there is no order for two of
+    these to deadlock over.
     """
     await session.exec(
-        select(PostPoll.id).where(PostPoll.id == poll.id).with_for_update()
+        select(
+            func.pg_advisory_xact_lock(
+                func.hashtextextended(f"post_poll:{guild_id}:{poll.id}", 0)
+            )
+        )
     )
+
+
+async def lock_poll(session: AsyncSession, poll: PostPoll, *, guild_id: int) -> None:
+    """Hold this poll for the rest of the transaction.
+
+    Held by every path that reads what has been answered and then acts on it,
+    so the reading and the acting are one indivisible step.
+    """
+    await _turnstile(session, poll, guild_id)
 
 
 async def lock_open_poll(
@@ -140,18 +158,10 @@ async def lock_open_poll(
     the lock, so one voter's ballots are written one after another and each is
     measured by the deadline in force as it lands.
 
-    The turnstile is an advisory lock rather than the poll row itself: answering
-    a question is not editing it, and taking the row would ask for write access
-    on the notice, which a reader answering the poll does not have. The key is
-    scoped by guild, because poll ids repeat across guild schemas.
+    The turnstile is shared with the edit path, so a ballot and a rewrite of
+    the deadline cannot both be in flight (see :func:`_turnstile`).
     """
-    await session.exec(
-        select(
-            func.pg_advisory_xact_lock(
-                func.hashtextextended(f"post_poll:{guild_id}:{poll.id}", 0)
-            )
-        )
-    )
+    await _turnstile(session, poll, guild_id)
     row = (
         await session.exec(
             select(PostPoll.id).where(PostPoll.id == poll.id, poll_is_open())

--- a/backend/app/services/tenant/post_polls.py
+++ b/backend/app/services/tenant/post_polls.py
@@ -38,6 +38,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 
+from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 from sqlmodel import delete as sa_delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -127,20 +128,33 @@ async def lock_poll(session: AsyncSession, poll: PostPoll) -> None:
     )
 
 
-async def lock_open_poll(session: AsyncSession, poll: PostPoll) -> bool:
-    """Take the row, and answer whether the poll still takes votes.
+async def lock_open_poll(
+    session: AsyncSession, poll: PostPoll, *, guild_id: int
+) -> bool:
+    """Take the poll's turnstile, and answer whether it still takes votes.
 
-    One statement, so the close time is read as the row is taken — against the
-    wall clock at that moment (see :func:`poll_is_open`), not the instant this
-    request's transaction began, which is before it loaded the post and before
-    it waited its turn for the row. The ballot is then written inside the
-    transaction still holding it.
+    The close time is read once the lock is held — against the wall clock at
+    that moment (see :func:`poll_is_open`), not the instant this request's
+    transaction began, which is before it loaded the post and before it waited
+    its turn. The ballot is then written inside the transaction still holding
+    the lock, so one voter's ballots are written one after another and each is
+    measured by the deadline in force as it lands.
+
+    The turnstile is an advisory lock rather than the poll row itself: answering
+    a question is not editing it, and taking the row would ask for write access
+    on the notice, which a reader answering the poll does not have. The key is
+    scoped by guild, because poll ids repeat across guild schemas.
     """
+    await session.exec(
+        select(
+            func.pg_advisory_xact_lock(
+                func.hashtextextended(f"post_poll:{guild_id}:{poll.id}", 0)
+            )
+        )
+    )
     row = (
         await session.exec(
-            select(PostPoll.id)
-            .where(PostPoll.id == poll.id, poll_is_open())
-            .with_for_update()
+            select(PostPoll.id).where(PostPoll.id == poll.id, poll_is_open())
         )
     ).first()
     return row is not None

--- a/backend/app/services/tenant/post_polls_test.py
+++ b/backend/app/services/tenant/post_polls_test.py
@@ -54,14 +54,14 @@ async def test_the_lock_is_really_taken(session: AsyncSession, engine):
     guild_id, poll = await _poll(session)
     await session.commit()
 
-    await post_polls_service.lock_poll(session, poll)
+    await post_polls_service.lock_poll(session, poll, guild_id=guild_id)
 
     maker = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
     async with maker() as other:
         await route_session_to_guild(other, guild_id)
         await other.exec(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT}'"))
         with pytest.raises(Exception) as blocked:
-            await post_polls_service.lock_poll(other, poll)
+            await post_polls_service.lock_poll(other, poll, guild_id=guild_id)
         assert "lock" in str(blocked.value).lower()
         await other.rollback()
 
@@ -79,7 +79,9 @@ async def test_a_free_row_is_not_a_wait(session: AsyncSession, engine):
     async with maker() as other:
         await route_session_to_guild(other, guild_id)
         await other.exec(text(f"SET LOCAL lock_timeout = '{_LOCK_TIMEOUT}'"))
-        await asyncio.wait_for(post_polls_service.lock_poll(other, poll), timeout=5)
+        await asyncio.wait_for(
+            post_polls_service.lock_poll(other, poll, guild_id=guild_id), timeout=5
+        )
         await other.rollback()
 
 

--- a/backend/app/services/tenant/post_polls_test.py
+++ b/backend/app/services/tenant/post_polls_test.py
@@ -84,13 +84,16 @@ async def test_a_free_row_is_not_a_wait(session: AsyncSession, engine):
 
 
 async def test_the_deadline_is_the_databases_clock(session: AsyncSession):
-    """``lock_open_poll`` answers "does this still take votes?" in the statement
-    that takes the row, so the close time is read at the moment the ballot's
+    """``lock_open_poll`` answers "does this still take votes?" once it holds
+    the poll's turnstile, so the close time is read at the moment the ballot's
     transaction acquires it rather than whenever the row was loaded."""
     guild_id, poll = await _poll(session)
     await session.commit()
 
-    assert await post_polls_service.lock_open_poll(session, poll) is True
+    assert (
+        await post_polls_service.lock_open_poll(session, poll, guild_id=guild_id)
+        is True
+    )
 
     # Move the deadline into the past without touching the loaded object: the
     # gate must read the row, not the copy in memory.
@@ -100,7 +103,10 @@ async def test_the_deadline_is_the_databases_clock(session: AsyncSession):
         ).bindparams(i=poll.id)
     )
     assert poll.is_closed() is False  # the in-memory copy still says open
-    assert await post_polls_service.lock_open_poll(session, poll) is False
+    assert (
+        await post_polls_service.lock_open_poll(session, poll, guild_id=guild_id)
+        is False
+    )
 
     await session.rollback()
 
@@ -110,7 +116,10 @@ async def test_a_poll_with_no_deadline_always_takes_votes(session: AsyncSession)
     await session.commit()
 
     assert poll.closes_at is None
-    assert await post_polls_service.lock_open_poll(session, poll) is True
+    assert (
+        await post_polls_service.lock_open_poll(session, poll, guild_id=guild_id)
+        is True
+    )
 
     await session.rollback()
 
@@ -127,7 +136,7 @@ async def test_the_deadline_is_the_wall_clock_not_the_transactions_start(
     transaction and asks the gate afterwards: read against the transaction's own
     beginning the poll is still open, and against the wall clock it is not.
     """
-    _guild_id, poll = await _poll(session)
+    guild_id, poll = await _poll(session)
     await session.commit()
 
     # Inside one transaction: a deadline a moment away, then wait past it.
@@ -150,6 +159,9 @@ async def test_the_deadline_is_the_wall_clock_not_the_transactions_start(
     ).one()
     assert still_open_by_transaction_time[0] is True
 
-    assert await post_polls_service.lock_open_poll(session, poll) is False
+    assert (
+        await post_polls_service.lock_open_poll(session, poll, guild_id=guild_id)
+        is False
+    )
 
     await session.rollback()


### PR DESCRIPTION
## Problem

#1423 made tool sharing a policy. That was right — under the model where a user-written `SELECT` is the thing being gated, gate 4 has to be enforced beneath the query rather than by the query. But it left CI at **53 failures**, in four groups. This fixes them; none is a reason to weaken the policy.

Local: **53 → 8** across `app/api/v1/tenant_endpoints`, `initiative_rls_test` and `notifications_test` (1348 passed).

## 1. A resource has no sharing at the instant it is written

`INSERT ... RETURNING` re-reads the new row through the `SELECT` policy, and nothing has been shared yet — the owner grant is several statements away. Children seeded during creation (`task_statuses`, default presets) then ask for write on a parent whose grant still does not exist. Every "create" test failed this way.

The rendered leg now ends with: **a resource that has no grants at all answers to whoever is making it.**

```sql
resource_access('project', projects.id, UID, projects.initiative_id, false)
OR (projects.created_by = UID
    AND NOT EXISTS (SELECT 1 FROM resource_grants rg
                    WHERE rg.resource_type = 'project' AND rg.resource_id = projects.id))
```

Outside the creating transaction that leg is unsatisfiable — either the owner grant exists, or the row does not — so it opens exactly the window between the INSERT and the grant and closes it for good. It renders from `_resource_call`, so `_dac_self`, `_dac_via` and `_dac_two_hop` all get it: one place, not an ordering rule seven creation flows have to remember.

## 2. Absent is not the same answer as denied

A refused row is gone before the handler runs, so the only thing app code could say was 404 where 403 is right.

New `app/services/reachability.py` asks the system engine one question — *does this row belong to an initiative the reader is in?* — and takes back a yes or no, never a row. It is a status-code decision, not a gate: every caller has already been refused by the database before it asks. How a row finds its initiative comes from `INITIATIVE_PATHS`, the same declaration its policies render from.

Called at the two places that were answering 404: `resource_access.load_authorized` and the comment-parent load. Gate 2 keeps hiding existence (outside the initiative → still 404); gate 4 now says denied.

## 3. Answering a poll took the poll's row

`lock_open_poll` used `SELECT ... FOR UPDATE`, which applies the **UPDATE** policy — so voting asked for write on the notice, and every reader's ballot came back `POST_POLL_CLOSED`. It takes an advisory turnstile instead, keyed by guild (poll ids repeat across schemas), then reads the deadline. Same guarantee, without claiming a right the voter does not need.

## 4. A reminder already sent

`event_reminder_dispatches` asked for write on the calendar. Being told about an event is a reader's record, like a read receipt or an RSVP — it joins the read-level set.

## Still failing (8), all one shape

`documents` download, `exports` ×2, `projects` set-access, `reactions` unshared, `filter_presets`, `initiative_share_override`, and `initiative_rls_test`. Each is a "not found" raised somewhere that has not been routed through `reachability` yet, plus one test whose premise predates gate 4 (it asserts an initiative member sees a project nobody shared with them). Next commit unless you would rather they came separately.

## Gate 3

Not in this PR and not in the database yet — still application-only, so it is the one gate a written query walks past. Design written up for approval before any code: one `initiative_role_permits()` function beside its two siblings, the initiative's master switch rendered inline, both derived from the `Tool` mapping gate 4 already added. The fallback is the trap — a role with no row means `DEFAULT_PERMISSION_VALUES`, not "denied".

## Testing

```
cd backend
pytest -n 8 app/api/v1/tenant_endpoints app/services/initiative_rls_test.py app/services/notifications_test.py
# 8 failed, 1348 passed
ruff check app && ruff format app && ty check   # clean
```
