### PR TITLE
Refuse commits under the wrong git identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,3 +353,12 @@ jobs:
             exit 1
           fi
           echo "Generated types are up to date."
+
+  git-hooks:
+    name: Git Hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Test the git identity guard
+        run: ./scripts/git-identity-guard_test.sh

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,5 +1,7 @@
 set -e
 
+. ./scripts/git-identity-guard.sh
+
 # Frontend: biome check/format on staged web files (via lint-staged)
 cd frontend && pnpm lint-staged
 cd ..

--- a/frontend/.husky/pre-merge-commit
+++ b/frontend/.husky/pre-merge-commit
@@ -1,0 +1,3 @@
+set -e
+
+. ./scripts/git-identity-guard.sh

--- a/scripts/git-identity-guard.sh
+++ b/scripts/git-identity-guard.sh
@@ -1,0 +1,27 @@
+# Refuse a commit stamped with an identity other than the configured one.
+#
+# Environment variables (GIT_AUTHOR_EMAIL, GIT_COMMITTER_EMAIL) and `git -c`
+# take precedence over every config file, so this reads the identity git has
+# actually resolved for the commit rather than the config value.
+
+configured_email=$(git config --get user.email || true)
+
+if [ -n "$configured_email" ]; then
+  author_email=$(git var GIT_AUTHOR_IDENT | sed -e 's/.*<//' -e 's/>.*//')
+  committer_email=$(git var GIT_COMMITTER_IDENT | sed -e 's/.*<//' -e 's/>.*//')
+
+  for entry in "author:$author_email" "committer:$committer_email"; do
+    role=${entry%%:*}
+    found=${entry#*:}
+    if [ "$found" != "$configured_email" ]; then
+      echo "" >&2
+      echo "  Commit refused: $role email is <$found>," >&2
+      echo "  but git config user.email is <$configured_email>." >&2
+      echo "" >&2
+      echo "  Something is overriding the git identity. Clear it with:" >&2
+      echo "    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL" >&2
+      echo "" >&2
+      exit 1
+    fi
+  done
+fi

--- a/scripts/git-identity-guard.sh
+++ b/scripts/git-identity-guard.sh
@@ -1,27 +1,43 @@
 # Refuse a commit stamped with an identity other than the configured one.
 #
-# Environment variables (GIT_AUTHOR_EMAIL, GIT_COMMITTER_EMAIL) and `git -c`
-# take precedence over every config file, so this reads the identity git has
-# actually resolved for the commit rather than the config value.
+# Git resolves the author and committer from GIT_AUTHOR_EMAIL /
+# GIT_COMMITTER_EMAIL and from `git -c user.email=` ahead of any config file,
+# so the identity a commit ends up with is not necessarily the configured one.
+# The resolved identity is read back through `git var`.
+#
+# `git -c` reaches hooks as GIT_CONFIG_PARAMETERS, and GIT_CONFIG_COUNT carries
+# the same kind of injected values, so the baseline is read with both cleared —
+# otherwise it would shift in step with the identity it is meant to check.
 
-configured_email=$(git config --get user.email || true)
+configured_email=$(env -u GIT_CONFIG_PARAMETERS -u GIT_CONFIG_COUNT \
+  git config --get user.email || true)
 
-if [ -n "$configured_email" ]; then
-  author_email=$(git var GIT_AUTHOR_IDENT | sed -e 's/.*<//' -e 's/>.*//')
-  committer_email=$(git var GIT_COMMITTER_IDENT | sed -e 's/.*<//' -e 's/>.*//')
-
-  for entry in "author:$author_email" "committer:$committer_email"; do
-    role=${entry%%:*}
-    found=${entry#*:}
-    if [ "$found" != "$configured_email" ]; then
-      echo "" >&2
-      echo "  Commit refused: $role email is <$found>," >&2
-      echo "  but git config user.email is <$configured_email>." >&2
-      echo "" >&2
-      echo "  Something is overriding the git identity. Clear it with:" >&2
-      echo "    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL" >&2
-      echo "" >&2
-      exit 1
-    fi
-  done
+if [ -z "$configured_email" ]; then
+  echo "" >&2
+  echo "  Commit refused: no user.email is configured." >&2
+  echo "" >&2
+  echo "  Set the identity this machine commits under:" >&2
+  echo "    git config --global user.email you@example.com" >&2
+  echo "    git config --global user.name 'Your Name'" >&2
+  echo "" >&2
+  exit 1
 fi
+
+author_email=$(git var GIT_AUTHOR_IDENT | sed -e 's/.*<//' -e 's/>.*//')
+committer_email=$(git var GIT_COMMITTER_IDENT | sed -e 's/.*<//' -e 's/>.*//')
+
+for entry in "author:$author_email" "committer:$committer_email"; do
+  role=${entry%%:*}
+  found=${entry#*:}
+  if [ "$found" != "$configured_email" ]; then
+    echo "" >&2
+    echo "  Commit refused: $role email is <$found>," >&2
+    echo "  but the configured user.email is <$configured_email>." >&2
+    echo "" >&2
+    echo "  Something is overriding the git identity. Check for" >&2
+    echo "  GIT_AUTHOR_EMAIL / GIT_COMMITTER_EMAIL in the environment," >&2
+    echo "  or a 'git -c user.email=' on the command line." >&2
+    echo "" >&2
+    exit 1
+  fi
+done

--- a/scripts/git-identity-guard_test.sh
+++ b/scripts/git-identity-guard_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Exercises scripts/git-identity-guard.sh against the ways git can be told to
+# use an identity other than the configured one. Run it directly:
+#   ./scripts/git-identity-guard_test.sh
+set -u
+
+# Ignore the machine's own git config so every case is decided by the
+# per-test repo alone, and 'unset' genuinely means unset.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+GUARD=$(cd "$(dirname "$0")" && pwd)/git-identity-guard.sh
+CONFIGURED=configured@example.com
+OTHER=someone-else@example.com
+passed=0
+failed=0
+
+new_repo() {
+  d=$(mktemp -d)
+  git init -q "$d"
+  git -C "$d" symbolic-ref HEAD refs/heads/main
+  git -C "$d" config user.name tester
+  git -C "$d" config user.email "$CONFIGURED"
+  mkdir -p "$d/hooks"
+  for hook in pre-commit pre-merge-commit; do
+    printf '#!/usr/bin/env sh\nset -e\n. "%s"\n' "$GUARD" > "$d/hooks/$hook"
+    chmod +x "$d/hooks/$hook"
+  done
+  git -C "$d" config core.hooksPath ./hooks
+  echo "$d"
+}
+
+check() {
+  description=$1 expected=$2 actual=$3
+  if [ "$expected" = "$actual" ]; then
+    printf '  ok    %s\n' "$description"
+    passed=$((passed + 1))
+  else
+    printf '  FAIL  %s (expected commit %s, got %s)\n' \
+      "$description" "$expected" "$actual"
+    failed=$((failed + 1))
+  fi
+}
+
+# Returns "allowed" or "refused" for a commit attempt in repo $1.
+attempt() {
+  repo=$1; shift
+  date > "$repo/file-$RANDOM"
+  git -C "$repo" add -A
+  if "$@" -C "$repo" commit -qm "commit" >/dev/null 2>&1; then
+    echo allowed
+  else
+    echo refused
+  fi
+}
+
+echo "git-identity-guard"
+
+r=$(new_repo)
+check "configured identity is allowed" allowed "$(attempt "$r" git)"
+
+r=$(new_repo)
+check "GIT_AUTHOR_EMAIL override is refused" refused \
+  "$(attempt "$r" env GIT_AUTHOR_EMAIL=$OTHER git)"
+
+r=$(new_repo)
+check "GIT_COMMITTER_EMAIL override is refused" refused \
+  "$(attempt "$r" env GIT_COMMITTER_EMAIL=$OTHER git)"
+
+r=$(new_repo)
+check "GIT_CONFIG_PARAMETERS override is refused" refused \
+  "$(attempt "$r" env "GIT_CONFIG_PARAMETERS='user.email'='$OTHER'" git)"
+
+# `git -c` is the same channel, reached the way a person would reach it.
+r=$(new_repo)
+date > "$r/f"; git -C "$r" add -A
+if git -c "user.email=$OTHER" -C "$r" commit -qm c >/dev/null 2>&1; then
+  cmd_result=allowed
+else
+  cmd_result=refused
+fi
+check "git -c user.email override is refused" refused "$cmd_result"
+
+r=$(new_repo)
+git -C "$r" config --unset user.email
+check "missing user.email is refused" refused "$(attempt "$r" git)"
+
+# Merge commits run pre-merge-commit, not pre-commit.
+r=$(new_repo)
+attempt "$r" git >/dev/null
+git -C "$r" checkout -qb side
+date > "$r/side-file"; git -C "$r" add -A
+git -C "$r" commit -qm side >/dev/null 2>&1
+git -C "$r" checkout -q main
+date > "$r/main-file"; git -C "$r" add -A
+git -C "$r" commit -qm main >/dev/null 2>&1
+if git -C "$r" -c "user.email=$CONFIGURED" merge --no-ff -m merge side >/dev/null 2>&1
+then merge_clean=allowed; else merge_clean=refused; fi
+check "clean merge commit is allowed" allowed "$merge_clean"
+
+r=$(new_repo)
+attempt "$r" git >/dev/null
+git -C "$r" checkout -qb side
+date > "$r/side-file"; git -C "$r" add -A
+git -C "$r" commit -qm side >/dev/null 2>&1
+git -C "$r" checkout -q main
+date > "$r/main-file"; git -C "$r" add -A
+git -C "$r" commit -qm main >/dev/null 2>&1
+if GIT_AUTHOR_EMAIL=$OTHER git -C "$r" merge --no-ff -m merge side >/dev/null 2>&1
+then merge_bad=allowed; else merge_bad=refused; fi
+check "merge under an override is refused" refused "$merge_bad"
+
+echo
+echo "  $passed passed, $failed failed"
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
## Problem

Git resolves a commit's author and committer from the environment
(`GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_EMAIL`) and from `git -c` ahead of every
config file, so `user.email` in `~/.gitconfig` is not the last word on who a
commit gets attributed to. GitHub credits a commit by author email alone.

Two commits already on `dev` — `b3379850c` and `120ac5092` — carry an author
email that belongs to a different account than the machine that wrote them, and
show up on the PR under that account. Nothing flagged it at commit time.

## Changes

- [scripts/git-identity-guard.sh](scripts/git-identity-guard.sh) — reads the
  identity git has actually resolved for the commit (`git var GIT_AUTHOR_IDENT`
  / `GIT_COMMITTER_IDENT`) and compares it to `git config --get user.email`,
  which consults config files only. A mismatch aborts the commit and prints
  both addresses.
- [frontend/.husky/pre-commit](frontend/.husky/pre-commit) — sources the guard,
  ahead of the lint steps so a rejection is immediate.
- [frontend/.husky/pre-merge-commit](frontend/.husky/pre-merge-commit) — new;
  merges do not fire `pre-commit`, and that path creates commits too.

The guard lives in `scripts/` with the other cross-cutting shell helpers; only
the two hook files sit under `frontend/.husky/`, since husky owns
`core.hooksPath`.

Comparing against local config rather than a hardcoded address keeps this
machine-agnostic: each checkout holds its committer to whatever identity that
machine has configured, so it needs no per-developer setup and does not have to
be updated when someone joins.

## Testing

- `GIT_AUTHOR_EMAIL=<other> git commit` → refused, `HEAD` unchanged, and the
  refusal came before `lint-staged` ran.
- `GIT_COMMITTER_EMAIL=<other>` → refused the same way.
- Unmodified environment → guard passes; this PR's own commit went through it
  and is stamped with the configured identity.
- Guard sourced directly from `pre-merge-commit` → refuses on the same input.

No frontend or backend sources are touched, so the typecheck / ruff / test
gates do not apply.

## Known limits

- `git commit --no-verify` skips hooks entirely.
- The hooks only run where the commit is made; a commit created off this machine
  is unaffected.
- The two existing commits are already merged, so correcting their attribution
  would mean rewriting shared history. Left alone.