### PR TITLE
Answer for the rows the policies removed

### DIFF
--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -151,7 +151,11 @@ def _dac_self(tool: Tool | None = None) -> DacPath:
             f"{t}.initiative_id",
             command,
             w,
-            creating=command == "INSERT",
+            # An INSERT is the resource being made only where the table IS the
+            # resource. A caller that names the tool reached it under an alias
+            # (a reaction on a notice), and there the INSERT is the reaction's:
+            # the notice already exists and answers for itself.
+            creating=command == "INSERT" and tool is None,
         )
 
     return DacPath(predicate=build, self_governed=True)

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+from sqlalchemy import ColumnElement, Select
 from sqlmodel import SQLModel, select
 
 from app.db import session as db_session
@@ -28,7 +29,7 @@ def _model_for(table: str) -> Optional[type[SQLModel]]:
     return None
 
 
-def _comment_initiative():
+def _comment_initiative() -> ColumnElement[Optional[int]]:
     """A comment's initiative, through whichever parent it names.
 
     A comment hangs off exactly one of them, so the parents are tried in the
@@ -65,7 +66,7 @@ def _comment_initiative():
     return sa_func.coalesce(*lookups)
 
 
-def _initiative_query(model: Any, row_id: int):
+def _initiative_query(model: Any, row_id: int) -> Select[tuple[Optional[int]]]:
     """A select yielding ``row_id``'s initiative, or nothing if it is not there.
 
     Most tables carry ``initiative_id``. A task does not — it belongs to a

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -11,14 +11,43 @@ every caller has already been refused by the database before it asks.
 
 from __future__ import annotations
 
-from sqlalchemy import text
-from sqlmodel import SQLModel
+from typing import Any, Optional
 
-from app.db.initiative_rls import INITIATIVE_PATHS
-from app.db.schema_provisioning import guild_schema_name
+from sqlmodel import SQLModel, select
+
 from app.db import session as db_session
 from app.db.session import set_rls_context
 from app.models.platform.guild import GuildRole
+
+
+def _model_for(table: str) -> Optional[type[SQLModel]]:
+    """The mapped class behind a table name, or None for a table with none."""
+    for mapper in SQLModel._sa_registry.mappers:
+        if mapper.local_table is not None and mapper.local_table.name == table:
+            return mapper.class_
+    return None
+
+
+def _initiative_query(model: Any, row_id: int):
+    """A select yielding ``row_id``'s initiative, or nothing if it is not there.
+
+    Most tables carry ``initiative_id``. A task does not — it belongs to a
+    project — so it is read through the join its own policies use.
+    """
+    live = getattr(model, "deleted_at", None)
+    if hasattr(model, "initiative_id"):
+        statement = select(model.initiative_id).where(model.id == row_id)
+    else:
+        from app.models.tenant.project import Project
+
+        statement = (
+            select(Project.initiative_id)
+            .join(model, model.project_id == Project.id)
+            .where(model.id == row_id)
+        )
+    if live is not None:
+        statement = statement.where(live.is_(None))
+    return statement
 
 
 async def reader_is_in_the_initiative(
@@ -26,44 +55,37 @@ async def reader_is_in_the_initiative(
 ) -> bool:
     """Whether ``row_id`` belongs to an initiative ``user_id`` is a member of.
 
-    How a row of this table finds its initiative comes from ``INITIATIVE_PATHS``
-    — the same declaration the table's own policies render from — so a table
-    cannot be gated through one initiative and probed through another.
-
     Routed as the guild's own admin, which is how every other system read
     reaches guild content. A row belonging to no initiative (a guild calendar)
-    has no initiative gate to fail, so reaching this point means sharing
+    has no initiative gate to fail, so reaching this point means a later gate
     refused it.
     """
-    path = INITIATIVE_PATHS.get(table)
-    if path is None:
+    from app.models.tenant.initiative import InitiativeMember
+
+    model = _model_for(table)
+    if model is None:
         return False
-    initiative = path.initiative_expr("r")
-    live = (
-        " AND r.deleted_at IS NULL"
-        if "deleted_at" in SQLModel.metadata.tables[table].columns
-        else ""
-    )
-    # Every fragment here is rendered from the registry above and the model
-    # metadata — never from the request. The tables are named with their schema
-    # so the probe does not depend on a search_path of its own.
-    schema = guild_schema_name(guild_id)
-    statement = text(
-        f"SELECT {initiative} IS NULL OR EXISTS ("  # noqa: S608
-        f'  SELECT 1 FROM "{schema}".initiative_members im'
-        f"  WHERE im.initiative_id = {initiative} AND im.user_id = :uid)"
-        f' FROM "{schema}".{table} r WHERE r.id = :rid{live}'
-    )
+
     # Late-bound (module attribute at call time) so the test harness's
     # sessionmaker patch applies to the probe too.
     async with db_session.AdminSessionLocal() as probe, probe.begin():
-        # One transaction, explicitly: the routing is transaction-local, and
-        # the probe runs on a session of its own rather than the request's, so
-        # it cannot inherit it.
+        # One transaction, explicitly: the routing is transaction-local, and the
+        # probe runs on a session of its own rather than the request's.
         await set_rls_context(
             probe, guild_id=guild_id, guild_role=GuildRole.admin.value
         )
-        found = (
-            await probe.exec(statement, params={"uid": user_id, "rid": row_id})
+        found = (await probe.exec(_initiative_query(model, row_id))).first()
+        if found is None:
+            return False
+        initiative_id = found[0] if isinstance(found, tuple) else found
+        if initiative_id is None:
+            return True
+        member = (
+            await probe.exec(
+                select(InitiativeMember.user_id).where(
+                    InitiativeMember.initiative_id == initiative_id,
+                    InitiativeMember.user_id == user_id,
+                )
+            )
         ).first()
-    return bool(found[0]) if found is not None else False
+    return member is not None

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -28,14 +28,56 @@ def _model_for(table: str) -> Optional[type[SQLModel]]:
     return None
 
 
+def _comment_initiative():
+    """A comment's initiative, through whichever parent it names.
+
+    A comment hangs off exactly one of them, so the parents are tried in the
+    order they are declared for the policies and the first that answers wins.
+    A comment on a task is the one whose parent is not a tool entity: a task
+    belongs to a project.
+    """
+    from sqlalchemy import func as sa_func
+
+    from app.core.tools import Tool
+    from app.db.initiative_rls import COMMENT_PARENT_COLUMNS
+    from app.models.tenant.comment import Comment
+    from app.models.tenant.project import Project
+    from app.models.tenant.task import Task
+
+    lookups = []
+    for column in COMMENT_PARENT_COLUMNS:
+        if column == "task_id":
+            lookups.append(
+                select(Project.initiative_id)
+                .join(Task, Task.project_id == Project.id)
+                .where(Task.id == Comment.task_id)
+                .scalar_subquery()
+            )
+            continue
+        parent = _model_for(Tool(column.removesuffix("_id")).plural)
+        if parent is None:  # pragma: no cover - a tool always has a table
+            continue
+        lookups.append(
+            select(parent.initiative_id)
+            .where(parent.id == getattr(Comment, column))
+            .scalar_subquery()
+        )
+    return sa_func.coalesce(*lookups)
+
+
 def _initiative_query(model: Any, row_id: int):
     """A select yielding ``row_id``'s initiative, or nothing if it is not there.
 
     Most tables carry ``initiative_id``. A task does not — it belongs to a
-    project — so it is read through the join its own policies use.
+    project — and a comment names one of several parents, so each is read
+    through the same chain its own policies use.
     """
+    from app.models.tenant.comment import Comment
+
     live = getattr(model, "deleted_at", None)
-    if hasattr(model, "initiative_id"):
+    if model is Comment:
+        statement = select(_comment_initiative()).where(Comment.id == row_id)
+    elif hasattr(model, "initiative_id"):
         statement = select(model.initiative_id).where(model.id == row_id)
     else:
         from app.models.tenant.project import Project

--- a/backend/app/services/rls_test.py
+++ b/backend/app/services/rls_test.py
@@ -305,7 +305,11 @@ async def test_check_initiative_permission_falls_back_to_default(session: AsyncS
     await create_guild_membership(
         session, user=admin, guild=guild, role=GuildRole.admin
     )
-    initiative = await create_initiative(session, guild, admin)
+    # The product's own defaults are what this checks, so the factory's
+    # ordinary-member convenience is turned off.
+    initiative = await create_initiative(
+        session, guild, admin, member_tool_access=False
+    )
 
     member = await create_user(session, email="member@example.com")
     await create_guild_membership(session, user=member, guild=guild)

--- a/backend/app/services/tenant/comments.py
+++ b/backend/app/services/tenant/comments.py
@@ -508,6 +508,12 @@ async def get_comment_with_parent(
     )
     comment = (await session.exec(stmt)).one_or_none()
     if not comment:
+        # The policies took it out before this ran. In the initiative it is
+        # theirs to know about, so a later gate is what refused it.
+        if await reachability.reader_is_in_the_initiative(
+            "comments", comment_id, cast(int, user.id), guild_id
+        ):
+            raise CommentPermissionError(CommentMessages.PERMISSION_DENIED)
         raise CommentNotFoundError(CommentMessages.NOT_FOUND)
 
     column, entity_id = _comment_target(comment)


### PR DESCRIPTION
## Problem

Follow-up to #1453, which landed before these three. Two are bugs in that change; one is a regression that reached `dev` earlier and CI was already failing on.

## 1. A dynamic-SQL site on the request path

`sql_injection_guard_test` has two arms and both were failing on `dev`: `services/reachability.py` (from #1451) built its statement with an f-string, and the guard's rule is that endpoints and non-DB services contain **zero** dynamic-SQL sites — the allowlist is for the provisioning layer and admin jobs, not the request path.

Rewritten as ORM: the row's initiative through the mapped class, membership through a bound comparison. Nothing left to review, and the 403/404 behaviour is unchanged.

## 2. Reacting to a notice asked for the right to create one

`_dac_self` is used two ways — as a table's own path, where `INSERT` means *this resource is being created*, and as a nested leg for reactions, where `INSERT` means *a reaction is being written* and the notice already exists. Both were treated as creation, so a reaction asked gate 3 for `create_posts` (default false) and refused every reader.

`creating` is now true only where the tool is resolved from the table name. A caller that names the tool reached it under an alias, and there the row being written is not it.

## 3. A hidden comment still reported as absent

The probe answered for a missing *parent*, but a comment whose own row the policies removed fell through to 404. It now reads a comment's initiative through whichever of its parents it names — the same chain its own policies follow — so a reader in the initiative is told the thread is denied rather than missing.

## Also

`rls_test`'s permission-fallback check asserts the product's own defaults, which the test factory now deviates from deliberately (an ordinary member may use the initiative's tools, since that is who the sharing picker offers). It passes `member_tool_access=False` so it tests the defaults rather than the harness.

## Testing

```
cd backend
pytest -n 0 app/db/sql_injection_guard_test.py                 # 2 passed
pytest -n 0 app/api/v1/tenant_endpoints/reactions_test.py::TestReactionAccess  # 8 passed
pytest -n 4 app/api/v1/tenant_endpoints/posts_test.py …reactions_test.py       # 89 passed
pytest -n 0 app/services/rls_test.py                           # 18 passed
ruff check app && ruff format app && ty check                  # clean
```

A full run across `tenant_endpoints`, `services`, `db` and `core` is in flight. The fallout from #1453 went 49 → 20 with the test factory carrying gate 3; what I expect to remain is the 403-vs-404 residue at endpoints that raise their own "not found" without going through `resource_access.load_authorized` — documents download, exports, `set_project_access`, smart chips, `initiative_share_override`, `filter_presets`. Those are a status code, not a gate: the row is correctly hidden either way. I will post the count and fix them here.
