### PR TITLE
Bound the teardown's locks, and finish the gate-3 fallout

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/counters_test.py
+++ b/backend/app/api/v1/tenant_endpoints/counters_test.py
@@ -6,7 +6,12 @@ from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.models.platform.guild import GuildRole
-from app.testing import Actor, create_counter_group, create_initiative
+from app.testing import (
+    Actor,
+    create_counter_group,
+    create_initiative,
+    grant_role_permission,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -734,9 +739,11 @@ async def test_duplicate_counter_group_custom_name(client: AsyncClient, acting_u
 
 @pytest.mark.integration
 async def test_duplicate_counter_group_read_user_becomes_owner(
-    client: AsyncClient, acting_user
+    client: AsyncClient, session: AsyncSession, acting_user
 ):
-    """A read-only user can duplicate and owns the copy (read suffices to copy)."""
+    """A read-only user owns the copy they make: read on the source is what
+    lets them copy FROM it, and the right to create one is what lets them make
+    it — the same gate the New button answers to."""
     admin = await acting_user(guild_role=GuildRole.admin, initiative=True)
     member = await acting_user(
         guild_role=GuildRole.member,
@@ -744,6 +751,7 @@ async def test_duplicate_counter_group_read_user_becomes_owner(
         initiative=admin.initiative,
         initiative_role="member",
     )
+    await grant_role_permission(session, admin.initiative, "create_counter_groups")
     source = await _create_group(client, admin, name="Shared")
     sid = source["id"]
     await _add_counter(client, admin, sid, name="A", position="0")

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -172,7 +172,7 @@ async def _get_document_or_404(
     document_id: int,
     guild_id: int,
     populate_existing: bool = False,
-    user_id: int | None = None,
+    user_id: int,
 ) -> Document:
     document = await documents_service.get_document(
         session,
@@ -181,19 +181,13 @@ async def _get_document_or_404(
         populate_existing=populate_existing,
     )
     if not document:
-        # With a reader named, a document in their own initiative is refused
-        # rather than reported missing.
-        if user_id is not None:
-            raise await reachability.missing_or_denied(
-                "documents",
-                document_id,
-                user_id,
-                guild_id,
-                not_found=DocumentMessages.NOT_FOUND,
-                denied=DocumentMessages.NO_ACCESS,
-            )
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail=DocumentMessages.NOT_FOUND
+        raise await reachability.missing_or_denied(
+            "documents",
+            document_id,
+            user_id,
+            guild_id,
+            not_found=DocumentMessages.NOT_FOUND,
+            denied=DocumentMessages.NO_ACCESS,
         )
     return document
 
@@ -935,7 +929,10 @@ async def create_document(
     await session.commit()
 
     hydrated = await _get_document_or_404(
-        session, document_id=document.id, guild_id=guild_context.guild_id
+        session,
+        document_id=document.id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     return serialize_document(
         hydrated,
@@ -1092,7 +1089,10 @@ async def upload_document_file(
     await session.commit()
 
     hydrated = await _get_document_or_404(
-        session, document_id=document.id, guild_id=guild_context.guild_id
+        session,
+        document_id=document.id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     return serialize_document(
         hydrated,
@@ -1125,7 +1125,10 @@ async def upload_document_version(
 ) -> DocumentFileVersionRead:
     """Upload a new version of a file document. Requires write access."""
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     if document.document_type != DocumentType.file:
         raise HTTPException(
@@ -1252,7 +1255,10 @@ async def list_document_versions(
 ) -> List[DocumentFileVersionRead]:
     """List all stored versions of a file document, newest first. Read access."""
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     if document.document_type != DocumentType.file:
         raise HTTPException(
@@ -1284,7 +1290,10 @@ async def delete_document_version(
     """Delete a version of a file document. Owner only. Deleting the current
     version promotes the previous one; deleting the last version is blocked."""
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     if document.document_type != DocumentType.file:
         raise HTTPException(
@@ -1376,7 +1385,10 @@ async def read_document(
     ] = True,
 ) -> DocumentRead:
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, access="read")
     return serialize_document(
@@ -1401,7 +1413,10 @@ async def get_backlinks(
     Only returns documents the current user has permission to access.
     """
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, access="read")
 
@@ -1432,7 +1447,10 @@ async def update_document(
     guild_context: GuildContextDep,
 ) -> DocumentRead:
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_write_access(document, current_user)
     updated = False
@@ -1528,7 +1546,10 @@ async def update_document(
                 guild_context.guild_id, document.id
             )
     hydrated = await _get_document_or_404(
-        session, document_id=document.id, guild_id=guild_context.guild_id
+        session,
+        document_id=document.id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     attachments_service.delete_uploads_by_urls(removed_upload_urls)
     return serialize_document(
@@ -1553,7 +1574,10 @@ async def duplicate_document(
     payload: DocumentDuplicateRequest | None = Body(default=None),
 ) -> DocumentRead:
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, access="write")
     payload = payload or DocumentDuplicateRequest()
@@ -1579,7 +1603,10 @@ async def duplicate_document(
             detail=AttachmentMessages.STORAGE_QUOTA_EXCEEDED,
         )
     hydrated = await _get_document_or_404(
-        session, document_id=duplicated.id, guild_id=guild_context.guild_id
+        session,
+        document_id=duplicated.id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     return serialize_document(
         hydrated,
@@ -1603,7 +1630,10 @@ async def copy_document(
     guild_context: GuildContextDep,
 ) -> DocumentRead:
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     # Templates are starter content meant to be copied — read on the source is enough.
     # Non-templates still require write to prevent silent fork-and-edit of someone else's work.
@@ -1644,7 +1674,10 @@ async def copy_document(
             detail=AttachmentMessages.STORAGE_QUOTA_EXCEEDED,
         )
     hydrated = await _get_document_or_404(
-        session, document_id=duplicated.id, guild_id=guild_context.guild_id
+        session,
+        document_id=duplicated.id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     return serialize_document(
         hydrated,
@@ -1672,7 +1705,10 @@ async def delete_document(
     from app.services.tenant.soft_delete import soft_delete_entity
 
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, require_owner=True)
     retention_days = await guilds_service.get_guild_retention_days(
@@ -1699,7 +1735,10 @@ async def notify_mentions(
     if not mentioned_user_ids:
         return
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_write_access(document, current_user)
     initiative = document.initiative
@@ -1749,7 +1788,10 @@ async def generate_summary(
     (not file uploads like PDFs).
     """
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, access="read")
 
@@ -1787,7 +1829,10 @@ async def set_document_properties(
     each property definition's type and options.
     """
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, access="write")
 
@@ -1819,6 +1864,7 @@ async def set_document_properties(
         document_id=document_id,
         guild_id=guild_context.guild_id,
         populate_existing=True,
+        user_id=current_user.id,
     )
     return serialize_document(
         refreshed,
@@ -1845,7 +1891,10 @@ async def set_document_grants(
         session, Tool.document, document_id, current_user, guild_context, grants
     )
     hydrated = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     return serialize_document(
         hydrated,
@@ -1942,9 +1991,6 @@ async def download_document_file(
         session, current_user, guild_id, document_id
     )
     if document is None:
-        # Existence is never confirmed across a guild or an initiative — but
-        # inside the reader's own initiative the document IS theirs to know
-        # about, so sharing refusing it is "denied" rather than "missing".
         raise await reachability.missing_or_denied(
             "documents",
             document_id,
@@ -2043,7 +2089,10 @@ async def record_document_view(
 ) -> RecentViewWrite:
     """Record a recent-view for the layout tabs bar."""
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, access="read")
     record = await recent_views_service.record_view(
@@ -2069,7 +2118,10 @@ async def clear_document_view(
     guild_context: GuildContextDep,
 ) -> None:
     document = await _get_document_or_404(
-        session, document_id=document_id, guild_id=guild_context.guild_id
+        session,
+        document_id=document_id,
+        guild_id=guild_context.guild_id,
+        user_id=current_user.id,
     )
     _require_document_access(document, current_user, access="read")
     await recent_views_service.clear_view(

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -92,6 +92,7 @@ from app.services.tenant import my_tools as my_tools_service
 from app.services import notifications as notifications_service
 from app.services.platform import accounts as accounts_service
 from app.services import permissions as permissions_service
+from app.services import reachability
 from app.services.tenant import search as search_service
 from app.services.tenant import properties as properties_service
 from app.services.tenant import recent_views as recent_views_service
@@ -171,6 +172,7 @@ async def _get_document_or_404(
     document_id: int,
     guild_id: int,
     populate_existing: bool = False,
+    user_id: int | None = None,
 ) -> Document:
     document = await documents_service.get_document(
         session,
@@ -179,6 +181,17 @@ async def _get_document_or_404(
         populate_existing=populate_existing,
     )
     if not document:
+        # With a reader named, a document in their own initiative is refused
+        # rather than reported missing.
+        if user_id is not None:
+            raise await reachability.missing_or_denied(
+                "documents",
+                document_id,
+                user_id,
+                guild_id,
+                not_found=DocumentMessages.NOT_FOUND,
+                denied=DocumentMessages.NO_ACCESS,
+            )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=DocumentMessages.NOT_FOUND
         )
@@ -1928,11 +1941,19 @@ async def download_document_file(
     document, guild_role = await _load_download_document(
         session, current_user, guild_id, document_id
     )
-    if (
-        document is None
-        or document.document_type != DocumentType.file
-        or document.file_url is None
-    ):
+    if document is None:
+        # Existence is never confirmed across a guild or an initiative — but
+        # inside the reader's own initiative the document IS theirs to know
+        # about, so sharing refusing it is "denied" rather than "missing".
+        raise await reachability.missing_or_denied(
+            "documents",
+            document_id,
+            int(current_user.id),
+            int(guild_id),
+            not_found=DocumentMessages.NOT_FOUND,
+            denied=DocumentMessages.NO_ACCESS,
+        )
+    if document.document_type != DocumentType.file or document.file_url is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=DocumentMessages.NOT_FOUND
         )

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -2042,7 +2042,16 @@ async def download_document_file_version(
     document, guild_role = await _load_download_document(
         session, current_user, guild_id, document_id
     )
-    if document is None or document.document_type != DocumentType.file:
+    if document is None:
+        raise await reachability.missing_or_denied(
+            "documents",
+            document_id,
+            int(current_user.id),
+            int(guild_id),
+            not_found=DocumentMessages.NOT_FOUND,
+            denied=DocumentMessages.NO_ACCESS,
+        )
+    if document.document_type != DocumentType.file:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=DocumentMessages.NOT_FOUND
         )

--- a/backend/app/api/v1/tenant_endpoints/documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_test.py
@@ -428,6 +428,40 @@ async def test_download_guild_member_without_permission_returns_403(
 
 
 @pytest.mark.integration
+async def test_version_download_answers_like_the_file_download(
+    client: AsyncClient, session: AsyncSession, acting_user
+) -> None:
+    """Both download routes load the document the same way, so an initiative
+    member the sharing does not reach is answered the same way by each."""
+    owner = await acting_user(guild_role=GuildRole.member, initiative=True)
+    other = await acting_user(
+        guild_role=GuildRole.member,
+        guild=owner.guild,
+        initiative=owner.initiative,
+        initiative_role="member",
+    )
+
+    doc = await _create_file_document(
+        session,
+        initiative=owner.initiative,
+        owner=owner.user,
+        filename="dl_version_no_perm.pdf",
+    )
+    try:
+        current = await client.get(
+            other.g(f"/documents/{doc.id}/download"), headers=other.headers
+        )
+        stored = await client.get(
+            other.g(f"/documents/{doc.id}/versions/1/download"),
+            headers=other.headers,
+        )
+        assert current.status_code == 403
+        assert stored.status_code == current.status_code
+    finally:
+        (_uploads_dir() / "dl_version_no_perm.pdf").unlink(missing_ok=True)
+
+
+@pytest.mark.integration
 async def test_download_non_guild_member_returns_404(
     client: AsyncClient, session: AsyncSession, acting_user
 ) -> None:

--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -2520,9 +2520,10 @@ async def test_empty_initiative_backup_is_manifest_only_zip(
     import json
 
     a = await acting_user(guild_role=GuildRole.member, initiative=True)
-    # The factory pre-enables queues/counter groups; turn queues off so the
-    # inventory shows a deliberately disabled tool.
+    # The factory switches every tool on; turn two off so the inventory has
+    # deliberately disabled ones to report.
     a.initiative.queues_enabled = False
+    a.initiative.calendars_enabled = False
     session.add(a.initiative)
     await session.commit()
     resp = await client.get(

--- a/backend/app/api/v1/tenant_endpoints/filter_presets_test.py
+++ b/backend/app/api/v1/tenant_endpoints/filter_presets_test.py
@@ -117,7 +117,9 @@ async def test_initiative_manager_may_manage_without_a_grant(
         initiative=owner.initiative,
         initiative_role="project_manager",
     )
-    await _grant(session, owner.project, pm.user, ResourceAccessLevel.read)
+    # Manager standing reaches the initiative; sharing still decides what may
+    # change, so managing this project's presets takes a write grant on it.
+    await _grant(session, owner.project, pm.user, ResourceAccessLevel.write)
     await _seed(session, owner.project)
 
     response = await client.post(

--- a/backend/app/services/import_engine/backup.py
+++ b/backend/app/services/import_engine/backup.py
@@ -421,6 +421,10 @@ async def _apply_file_entry(
                     initiative_id=initiative.id,
                 )
             )
+            # Sharing before the content it governs — a flush orders its
+            # statements by table, not by the order things were added.
+            await session.flush()
+
             for tag_name in entry.tags:
                 resolved = await ensure_tag(
                     session,

--- a/backend/app/services/import_engine/importers/calendar.py
+++ b/backend/app/services/import_engine/importers/calendar.py
@@ -104,6 +104,11 @@ class CalendarImporter:
             )
         )
 
+        # The sharing has to be in the database before the content it governs:
+        # a flush orders its statements by table, not by the order things were
+        # added.
+        await session.flush()
+
         created = 0
         failed = 0
         tags_created = 0

--- a/backend/app/services/import_engine/importers/counter_group.py
+++ b/backend/app/services/import_engine/importers/counter_group.py
@@ -74,6 +74,11 @@ class CounterGroupImporter:
             )
         )
 
+        # The sharing has to be in the database before the content it governs:
+        # a flush orders its statements by table, not by the order things were
+        # added.
+        await session.flush()
+
         for c in env.counters:
             try:
                 view_mode = CounterViewMode(c.view_mode)

--- a/backend/app/services/import_engine/importers/document.py
+++ b/backend/app/services/import_engine/importers/document.py
@@ -106,6 +106,11 @@ class DocumentImporter:
             )
         )
 
+        # The sharing has to be in the database before the content it governs:
+        # a flush orders its statements by table, not by the order things were
+        # added.
+        await session.flush()
+
         tags_created = 0
         tags_matched = 0
         for tag_name in env.tags:

--- a/backend/app/services/import_engine/importers/post.py
+++ b/backend/app/services/import_engine/importers/post.py
@@ -100,6 +100,11 @@ class PostImporter:
             )
         )
 
+        # The sharing has to be in the database before the content it governs:
+        # a flush orders its statements by table, not by the order things were
+        # added.
+        await session.flush()
+
         if env.poll is not None:
             session.add(
                 PostPoll(

--- a/backend/app/services/import_engine/importers/queue.py
+++ b/backend/app/services/import_engine/importers/queue.py
@@ -78,6 +78,11 @@ class QueueImporter:
             )
         )
 
+        # The sharing has to be in the database before the content it governs:
+        # a flush orders its statements by table, not by the order things were
+        # added.
+        await session.flush()
+
         tags_created = 0
         tags_matched = 0
         dropped_members = 0

--- a/backend/app/services/initiative_rls_test.py
+++ b/backend/app/services/initiative_rls_test.py
@@ -12,7 +12,9 @@ from sqlalchemy import text
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.tools import Tool
 from app.db.session import set_rls_context
+from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.platform.guild import GuildRole
 from app.models.tenant.project import Project
 from app.testing import (
@@ -41,8 +43,20 @@ async def test_non_admin_member_sees_only_their_initiatives_content(
     init_a = await create_initiative(session, guild, owner, name="Alpha")
     init_b = await create_initiative(session, guild, owner, name="Bravo")
     await create_initiative_member(session, init_a, member)  # member of Alpha only
-    await create_project(session, init_a, owner, name="A-Proj")
+    proj_a = await create_project(session, init_a, owner, name="A-Proj")
     await create_project(session, init_b, owner, name="B-Proj")
+    # Shared with Alpha, so the sharing gate admits it and what this measures is
+    # the initiative one: Bravo's project stays hidden either way.
+    session.add(
+        ResourceGrant(
+            resource_type=Tool.project.value,
+            resource_id=proj_a.id,
+            all_initiative_members=True,
+            level=ResourceAccessLevel.read,
+            guild_id=guild.id,
+            initiative_id=init_a.id,
+        )
+    )
     await session.commit()
 
     # Act as the guild role with this member's (non-admin) context — RLS applies.

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -93,6 +93,29 @@ def _initiative_query(model: Any, row_id: int) -> Select[tuple[Optional[int]]]:
     return statement
 
 
+async def missing_or_denied(
+    table: str,
+    row_id: int,
+    user_id: int,
+    guild_id: int,
+    *,
+    not_found: str,
+    denied: str,
+) -> Exception:
+    """The exception for a row the request could not see.
+
+    "Denied" where the reader is in its initiative and a later gate refused it,
+    "not found" otherwise — so the initiative boundary still says nothing about
+    what is behind it. Returns the exception rather than raising, so a caller
+    reads as ``raise await missing_or_denied(...)``.
+    """
+    from fastapi import HTTPException, status
+
+    if await reader_is_in_the_initiative(table, row_id, user_id, guild_id):
+        return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=denied)
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found)
+
+
 async def reader_is_in_the_initiative(
     table: str, row_id: int, user_id: int, guild_id: int
 ) -> bool:

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -104,10 +104,9 @@ async def missing_or_denied(
 ) -> Exception:
     """The exception for a row the request could not see.
 
-    "Denied" where the reader is in its initiative and a later gate refused it,
-    "not found" otherwise — so the initiative boundary still says nothing about
-    what is behind it. Returns the exception rather than raising, so a caller
-    reads as ``raise await missing_or_denied(...)``.
+    ``denied`` where the reader is in the row's initiative, ``not_found``
+    otherwise. Returns the exception rather than raising it, so a caller reads
+    as ``raise await missing_or_denied(...)``.
     """
     from fastapi import HTTPException, status
 

--- a/backend/app/services/tenant/counters.py
+++ b/backend/app/services/tenant/counters.py
@@ -298,6 +298,12 @@ async def duplicate_counter_group(
                 )
             )
 
+    # The sharing has to be IN the database before the counters are, because a
+    # counter is reached through its group: adding it to the session is not
+    # enough, since a flush orders its statements by table rather than by the
+    # order things were added.
+    await session.flush()
+
     for counter in getattr(source, "counters", None) or []:
         if counter.deleted_at is not None:
             continue

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -428,12 +428,20 @@ async def create_initiative(
     """
     await route_session_to_guild(session, guild.id)
 
-    defaults = {
+    from app.core.tools import Tool as _Tool
+
+    defaults: dict[str, Any] = {
         "name": f"Test Initiative {datetime.now(timezone.utc).timestamp()}",
         "description": "A test initiative",
         "guild_id": guild.id,
-        "queues_enabled": True,
-        "counter_groups_enabled": True,
+        # Every tool the initiative can switch on, switched on — derived from
+        # the enum, so a new tool is usable the day it exists. A test about a
+        # tool being OFF says so by overriding its own switch.
+        **{
+            tool.view_permission: True
+            for tool in _Tool
+            if tool.view_permission in Initiative.model_fields
+        },
     }
 
     initiative_data = {**defaults, **overrides}

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -716,21 +716,25 @@ async def session(engine) -> AsyncGenerator[AsyncSession, None]:
     # create-guild endpoint's trailing SELECT left held). Clean up on a fresh
     # connection: drop the per-guild schemas/roles provisioned during the test
     # (cluster-global roles must not leak between tests), then truncate public.
-    async with engine.begin() as conn:
-        await conn.exec_driver_sql("SET lock_timeout = '10s'")
-        # Per-guild schema/role cleanup only matters if THIS test provisioned a
-        # guild schema (tracked in _provisioned_guild_ids). Most tests don't, so
-        # skip the two catalog scans + DROPs entirely for them.
-        roles: list[str] = []
-        if _provisioned_guild_ids:
-            for (schema,) in (
-                await conn.execute(
-                    text(
-                        "SELECT nspname FROM pg_namespace WHERE nspname ~ '^guild_[0-9]+$'"
+    # Per-guild schema/role cleanup only matters if THIS test provisioned a
+    # guild schema (tracked in _provisioned_guild_ids). Most tests don't, so
+    # skip the two catalog scans + DROPs entirely for them.
+    roles: list[str] = []
+    schemas: list[str] = []
+    if _provisioned_guild_ids:
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql("SET lock_timeout = '10s'")
+            schemas = [
+                schema
+                for (schema,) in (
+                    await conn.execute(
+                        text(
+                            "SELECT nspname FROM pg_namespace "
+                            "WHERE nspname ~ '^guild_[0-9]+$'"
+                        )
                     )
-                )
-            ).all():
-                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+                ).all()
+            ]
             # Only the suite's own prefixed roles (test_guild_<id>) — never a
             # co-located dev DB's unprefixed guild_<id> roles (they share this
             # cluster-global catalog but belong to that database).
@@ -744,11 +748,24 @@ async def session(engine) -> AsyncGenerator[AsyncSession, None]:
                     )
                 ).all()
             ]
-        # Truncate the SHARED (public-schema) tables to reset state — one
-        # multi-table TRUNCATE (a single round-trip) instead of one statement
-        # per table. Only shared tables exist in public since the v0.53.5
-        # baseline squash; tenant content lives in the per-test guild schemas
-        # dropped above.
+
+    # One schema per transaction. A guild schema holds ~60 tables and their
+    # indexes, policies and triggers, and DROP ... CASCADE takes a lock on each;
+    # dropping several alongside the TRUNCATE below put hundreds of locks in one
+    # transaction, which several xdist workers doing it at once can exhaust
+    # (``max_locks_per_transaction`` sizes one shared table for the cluster).
+    for schema in schemas:
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql("SET lock_timeout = '10s'")
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+
+    # Truncate the SHARED (public-schema) tables to reset state — one
+    # multi-table TRUNCATE (a single round-trip) instead of one statement
+    # per table. Only shared tables exist in public since the v0.53.5
+    # baseline squash; tenant content lives in the per-test guild schemas
+    # dropped above.
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql("SET lock_timeout = '10s'")
         await conn.execute(text("SET session_replication_role = 'replica'"))
         shared_tables = ", ".join(
             f'"{table.name}"'


### PR DESCRIPTION
## Problem

CI on `dev` after #1454, two jobs telling two different stories:

- **direct**: 16 failed, 5060 passed — the real functional list
- **through the pooler**: 388 failed, 730 errors — `out of shared memory / max_locks_per_transaction`

## The pooler job

Not gate 3. The per-test teardown dropped every guild schema **and** truncated the shared tables in **one** transaction. A guild schema holds ~60 tables plus their indexes, policies and triggers, and `DROP ... CASCADE` locks each; several xdist workers doing that at once exhaust the cluster's one shared lock table.

One schema per transaction now, and the `TRUNCATE` in its own. Nothing about what is dropped changes — only how much is held at once.

## Creation ordering, again

Every importer built the tool row, added its owner grant *to the session*, then added the content underneath it. A flush orders its statements by table rather than by the order things were added, so the content could land first and be refused by the gate its own parent had not yet passed. The same shape was in `duplicate_counter_group`. Both now flush the sharing before the contents.

## Two behaviour calls

- **Duplicating needs the tool's create right.** Making a copy is making one, so it answers to the same gate as the New button. Read on the source is what lets you copy *from* it.
- **Manager standing reaches the initiative; sharing still decides what may change.** A project manager editing a project's presets holds a write grant on it. This used to pass only because `resource_access` ignored the grant's level.

## Test factory

`create_initiative` switches on every tool an initiative can, derived from the enum. Content of a tool the factory never enabled was unreachable for a reason the test never meant — a test about a tool being *off* says so by overriding its own switch, which two now do explicitly.

## Denied, not missing

A shared `reachability.missing_or_denied` answers for a row the policies removed: **denied** where the reader is in its initiative, **missing** otherwise — so the initiative boundary still says nothing about what is behind it. Wired into the document loader and the download path.

## Testing

```
cd backend
pytest -n 4 app/api/v1/tenant_endpoints/{imports,exports,counters,filter_presets,documents,queues}_test.py
pytest -n 0 app/services/initiative_rls_test.py app/services/tenant/comments_test.py
ruff check app && ruff format app && ty check   # clean
```

Green locally: imports 33, documents 37, counters 28, queues 38, exports (the inventory one), comments RLS legs, smart chips, `initiative_rls`, `filter_presets`.

## Still to do

Four of the sixteen are the same 403-vs-404 shape at endpoints with their own bespoke loaders — `exports` ×2, `projects` set-access, `initiative_share_override`, and the guild-calendar case. Each needs `missing_or_denied` wiring like the document paths above. They are a status code, not a gate: the row is correctly hidden either way.
