### PR TITLE
Read a task's fields off the table

### DIFF
--- a/backend/app/schemas/field_catalog.py
+++ b/backend/app/schemas/field_catalog.py
@@ -34,6 +34,11 @@ class FieldDescription(SanitizedBaseModel):
     multiple: bool
     #: Whether a list may be ordered by this field.
     sortable: bool
+    #: The values this field accepts, when it accepts a closed set of them —
+    #: read off the column that stores them. A client offers these rather than
+    #: keeping its own copy, so a value added by a migration shows up on its
+    #: own. Empty for a field whose values a lookup has to enumerate.
+    options: List[str] = []
 
 
 class FieldCatalogResponse(SanitizedBaseModel):

--- a/backend/app/services/fields/__init__.py
+++ b/backend/app/services/fields/__init__.py
@@ -6,9 +6,7 @@ from app.services.fields.registry import (
     allowed_fields,
     allowed_ops,
     dataset,
-    dataset_names,
     describe,
-    field,
     sort_expression,
     sort_fields,
 )
@@ -31,9 +29,7 @@ __all__ = [
     "allowed_fields",
     "allowed_ops",
     "dataset",
-    "dataset_names",
     "describe",
-    "field",
     "sort_expression",
     "sort_fields",
 ]

--- a/backend/app/services/fields/derive.py
+++ b/backend/app/services/fields/derive.py
@@ -118,12 +118,12 @@ def options_for(col: Any) -> tuple[str, ...]:
     return ()
 
 
-def derive_columns(
+def derive_fields(
     model: type[DeclarativeBase],
     *,
     internal: frozenset[str] = frozenset(),
 ) -> tuple[FieldSpec, ...]:
-    """Every column of *model*, as fields.
+    """Everything *model* itself implies: its columns, and its tags.
 
     *internal* names the columns that are a feature's own state rather than
     anything a reader would filter by — a recurrence rule's strategy and
@@ -148,20 +148,28 @@ def derive_columns(
                 options=options_for(col),
             )
         )
-    return tuple(specs)
+    tags = _tag_field(model)
+    return tuple(specs) + ((tags,) if tags is not None else ())
 
 
-def tag_field(target: str) -> FieldSpec:
-    """The ``tag_ids`` filter for a taggable entity.
+def _tag_field(model: type[DeclarativeBase]) -> Optional[FieldSpec]:
+    """The ``tag_ids`` filter, for a model that has tags.
 
-    Every tool is taggable and each one binds to tags the same way, so the
-    junction table named in ``TAG_LINKS`` is the only thing that differs between
-    one of these and the next. Written once here rather than once per dataset.
+    Nearly everything is taggable and everything taggable binds the same way,
+    so no dataset says it has tags: the junction named in ``TAG_LINKS`` for
+    this model is the whole of the difference between one of these and the
+    next. A model with no entry gets no tag field, which is the same answer it
+    would have given by hand.
     """
     from app.models.tenant.tag import Tag
     from app.services.tenant.tags import TAG_LINKS
 
-    link = TAG_LINKS[target]
+    link = next(
+        (spec for spec in TAG_LINKS.values() if spec.entity is model),
+        None,
+    )
+    if link is None:
+        return None
 
     def resolve_tag_ids(op: Any, value: Any, ctx: Any) -> Any:
         if not value:

--- a/backend/app/services/fields/derive.py
+++ b/backend/app/services/fields/derive.py
@@ -1,0 +1,185 @@
+"""Read a table's fields off the table.
+
+A model already says almost everything a filter needs to know. A foreign key
+names the table it points at, which is what decides the picker — an integer that
+references ``users`` is a person, not a number. A SQL ``Enum`` carries its own
+values, so a closed vocabulary needs no second copy. A column's SQL type says
+whether it orders, and whether it can be compared at all.
+
+So none of that is declared per dataset here. A dataset names its model and the
+handful of things a table genuinely cannot say — which columns are a feature's
+private state, and which fields are computed rather than stored — and gets the
+rest. That is what keeps the second dataset from costing what the first one did.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Date,
+    DateTime,
+    Enum as SAEnum,
+    Integer,
+    LargeBinary,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.types import TypeDecorator
+from sqlalchemy.orm import DeclarativeBase
+from sqlmodel import select
+
+from app.schemas.query import FilterOp
+from app.services.fields.spec import ControlKind, FieldSpec, column, computed
+
+#: Which picker a reference gets, by the table it references.
+#:
+#: The one place this is decided, for every dataset: a column referencing
+#: ``users`` is filled by a member picker whether it is a task's author, a
+#: document's owner, or a column added next year. A reference to anything absent
+#: here has no picker, so it is filterable by a stored definition and not
+#: offered as a control — the safe default for a table nobody has taught the UI
+#: to browse.
+FK_CONTROLS: dict[str, ControlKind] = {
+    "users": ControlKind.member,
+    "projects": ControlKind.project,
+    "initiatives": ControlKind.initiative,
+    "task_statuses": ControlKind.task_status,
+    "tags": ControlKind.tag,
+}
+
+#: Types that carry no filterable value. Structured blobs and binary: there is
+#: nothing a comparison operator would mean against them.
+_OPAQUE = (JSON, LargeBinary)
+
+#: Types that hold a value but make a poor ordering. Long-form prose sorts
+#: alphabetically by its first character, which is never what anybody wanted.
+_UNSORTABLE = (Text,)
+
+
+def _base_type(sql_type: Any) -> Any:
+    """The type underneath any decorating wrappers.
+
+    SQLModel gives a plain ``str`` field its own ``AutoString``, which wraps a
+    ``String`` rather than subclassing it. Asking the wrapper what it is gets no
+    answer, so unwrap first and ask the type that does the storing.
+    """
+    while isinstance(sql_type, TypeDecorator):
+        sql_type = sql_type.impl_instance
+    return sql_type
+
+
+def _referenced_table(col: Any) -> Optional[str]:
+    for fk in col.foreign_keys:
+        return fk.target_fullname.split(".")[0]
+    return None
+
+
+def control_for(col: Any) -> Optional[ControlKind]:
+    """Which control fills this column, or ``None`` if none can.
+
+    Asked in the order the answers are trustworthy: what a column *references*
+    beats what it is stored as, because both a person and a project are stored
+    as an integer.
+    """
+    referenced = _referenced_table(col)
+    if referenced is not None:
+        return FK_CONTROLS.get(referenced)
+
+    sql_type = _base_type(col.type)
+    if isinstance(sql_type, _OPAQUE):
+        return None
+    # Before String: a SQL enum is one, and its values are the point.
+    if isinstance(sql_type, SAEnum):
+        return ControlKind.select
+    if isinstance(sql_type, Boolean):
+        return ControlKind.boolean
+    if isinstance(sql_type, (DateTime, Date)):
+        return ControlKind.date
+    if isinstance(sql_type, (Integer, Numeric)):
+        return ControlKind.number
+    if isinstance(sql_type, String):
+        return ControlKind.text
+    return None
+
+
+def options_for(col: Any) -> tuple[str, ...]:
+    """A closed vocabulary's values, straight from the column that stores them.
+
+    This is what lets a client offer the real choices without keeping its own
+    copy of them — and pick up a new one the migration that adds it.
+    """
+    sql_type = _base_type(col.type)
+    if isinstance(sql_type, SAEnum) and sql_type.enums:
+        return tuple(sql_type.enums)
+    return ()
+
+
+def derive_columns(
+    model: type[DeclarativeBase],
+    *,
+    internal: frozenset[str] = frozenset(),
+) -> tuple[FieldSpec, ...]:
+    """Every column of *model*, as fields.
+
+    *internal* names the columns that are a feature's own state rather than
+    anything a reader would filter by — a recurrence rule's strategy and
+    counter, say. They stay filterable by a stored definition and are not
+    offered as controls, which is the same treatment a column gets when its
+    meaning is real but its audience is the code.
+    """
+    specs = []
+    for col in model.__table__.columns:
+        control = control_for(col)
+        if control is None:
+            continue
+        specs.append(
+            column(
+                col.name,
+                getattr(model, col.name),
+                kind=control,
+                sortable=not isinstance(_base_type(col.type), _UNSORTABLE)
+                and _referenced_table(col) is None,
+                nullable=bool(col.nullable),
+                offer=col.name not in internal,
+                options=options_for(col),
+            )
+        )
+    return tuple(specs)
+
+
+def tag_field(target: str) -> FieldSpec:
+    """The ``tag_ids`` filter for a taggable entity.
+
+    Every tool is taggable and each one binds to tags the same way, so the
+    junction table named in ``TAG_LINKS`` is the only thing that differs between
+    one of these and the next. Written once here rather than once per dataset.
+    """
+    from app.models.tenant.tag import Tag
+    from app.services.tenant.tags import TAG_LINKS
+
+    link = TAG_LINKS[target]
+
+    def resolve_tag_ids(op: Any, value: Any, ctx: Any) -> Any:
+        if not value:
+            return None
+        subq = (
+            select(link.entity_column())
+            .join(Tag, Tag.id == link.junction.tag_id)
+            .where(
+                link.junction.tag_id.in_(tuple(value)),
+                Tag.guild_id == ctx.guild_id,
+            )
+            .distinct()
+        )
+        return link.entity.id.in_(subq)
+
+    return computed(
+        "tag_ids",
+        resolve_tag_ids,
+        kind=ControlKind.tag,
+        ops=frozenset({FilterOp.in_}),
+    )

--- a/backend/app/services/fields/registry.py
+++ b/backend/app/services/fields/registry.py
@@ -26,14 +26,7 @@ from typing import Any, Callable
 
 from app.services.fields import tasks as tasks_dataset
 from app.schemas.query import FilterOp
-from app.services.fields.spec import (
-    Dataset,
-    FieldContext,
-    FieldSpec,
-    SortContext,
-    offered_ops,
-    offers_multiple,
-)
+from app.services.fields.spec import Dataset, FieldContext, FieldSpec, SortContext
 
 #: Every dataset, by the name a consumer refers to it by. One entry per
 #: declaration module; the module owns its fields, this owns the set.
@@ -58,15 +51,6 @@ def _built() -> dict[str, Dataset]:
 def dataset(name: str) -> Dataset:
     """The named dataset, or ``KeyError`` — callers name a constant, not input."""
     return _built()[name]
-
-
-def dataset_names() -> tuple[str, ...]:
-    return tuple(_built())
-
-
-def field(dataset_name: str, field_name: str) -> FieldSpec | None:
-    """One field's declaration, or ``None`` if this dataset has no such field."""
-    return dataset(dataset_name).by_name.get(field_name)
 
 
 def allowed_fields(dataset_name: str, ctx: FieldContext) -> dict[str, Any]:
@@ -156,16 +140,15 @@ def describe(dataset_name: str) -> list[dict[str, Any]]:
     engine accepts — never the engine's full set, which includes shapes that are
     correct to compile and pointless to draw.
     """
-    data = dataset(dataset_name)
-    sortable = {spec.name for spec in data.fields if spec.sortable}
     return [
         {
             "name": spec.name,
             "type": spec.type.value,
             "kind": spec.kind.value,
-            "ops": sorted(op.value for op in offered_ops(spec)),
-            "multiple": offers_multiple(spec),
-            "sortable": spec.name in sortable,
+            "ops": sorted(op.value for op in spec.offered_ops),
+            "multiple": spec.multiple,
+            "sortable": spec.sortable,
+            "options": list(spec.options),
         }
-        for spec in data.offered
+        for spec in dataset(dataset_name).offered
     ]

--- a/backend/app/services/fields/registry_test.py
+++ b/backend/app/services/fields/registry_test.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 import pytest
 from sqlalchemy.dialects import postgresql
 
-from app.models.tenant.task import Task
+from app.models.tenant.task import Task, TaskAssignee
 from app.schemas.query import FilterOp
+from app.services.fields.derive import derive_fields
 from app.services.fields import (
     FieldContext,
     allowed_fields,
@@ -87,6 +88,15 @@ class TestCoverage:
     def test_the_columns_left_out_are_left_out_for_a_reason(self):
         resolved = allowed_fields("tasks", _ctx())
         assert set(NOT_FILTERABLE).isdisjoint(resolved)
+
+    def test_a_taggable_model_gets_its_tag_filter_without_asking(self):
+        """Nearly everything is taggable and everything taggable binds the same
+        way, so no dataset declares that it has tags. The model's entry in the
+        tag registry is the whole of the difference between one and the next."""
+        assert "tag_ids" in {spec.name for spec in derive_fields(Task)}
+
+    def test_a_model_with_no_tags_gets_no_tag_filter(self):
+        assert "tag_ids" not in {spec.name for spec in derive_fields(TaskAssignee)}
 
     def test_a_decorated_string_column_is_still_a_column(self):
         """SQLModel wraps a plain ``str`` field in its own type rather than
@@ -340,8 +350,8 @@ class TestDescription:
 
 class TestOperatorEnforcement:
     def test_a_field_declares_only_operators_its_resolver_handles(self):
-        """``_status_category`` and ``_tag_ids`` build an ``IN`` over their
-        value, so ``in_`` is the one operator each of them answers."""
+        """The status-category and tag resolvers each build an ``IN`` over
+        their value, so ``in_`` is the one operator each of them answers."""
         ops = allowed_ops("tasks")
         assert ops["status_category"] == {FilterOp.in_}
         assert ops["tag_ids"] == {FilterOp.in_}

--- a/backend/app/services/fields/registry_test.py
+++ b/backend/app/services/fields/registry_test.py
@@ -65,23 +65,45 @@ VIRTUAL_FIELDS = {
 }
 
 
+#: Columns a comparison cannot be built against, and why. Everything else on
+#: the model becomes a field without anybody listing it.
+NOT_FILTERABLE = {
+    "recurrence": "a JSON rule — no operator means anything against it",
+    "guild_id": "references a table no picker browses, and a request is "
+    "already scoped to one guild",
+}
+
+
 class TestCoverage:
-    def test_every_model_column_is_filterable(self):
-        """The old builder auto-populated from the model. So does this."""
+    def test_every_model_column_a_control_can_fill_is_filterable(self):
+        """Derived from the model, so a column added tomorrow is filterable
+        the day it is added."""
         resolved = allowed_fields("tasks", _ctx())
         for col in Task.__table__.columns:
+            if col.name in NOT_FILTERABLE:
+                continue
             assert col.name in resolved, f"{col.name} lost its filter field"
+
+    def test_the_columns_left_out_are_left_out_for_a_reason(self):
+        resolved = allowed_fields("tasks", _ctx())
+        assert set(NOT_FILTERABLE).isdisjoint(resolved)
+
+    def test_a_decorated_string_column_is_still_a_column(self):
+        """SQLModel wraps a plain ``str`` field in its own type rather than
+        subclassing the SQL one, so a deriver that asks without unwrapping
+        loses every string on the model."""
+        assert "title" in allowed_fields("tasks", _ctx())
 
     def test_the_virtual_fields_are_all_present(self):
         resolved = allowed_fields("tasks", _ctx())
         assert VIRTUAL_FIELDS <= set(resolved)
 
     def test_nothing_else_crept_in(self):
-        """The set is exactly the columns plus the five — a field nobody asked
-        for is as much a change as a missing one."""
+        """The set is exactly the fillable columns plus the five — a field
+        nobody asked for is as much a change as a missing one."""
         resolved = set(allowed_fields("tasks", _ctx()))
-        expected = {c.name for c in Task.__table__.columns} | VIRTUAL_FIELDS
-        assert resolved == expected
+        columns = {c.name for c in Task.__table__.columns} - set(NOT_FILTERABLE)
+        assert resolved == columns | VIRTUAL_FIELDS
 
     def test_columns_pass_through_and_virtuals_are_callable(self):
         resolved = allowed_fields("tasks", _ctx())
@@ -162,7 +184,9 @@ class TestVirtualFields:
         assert resolve(FilterOp.eq, {"property_id": "abc"}) is None
 
 
-#: What ``_task_sort_fields`` offered before the registry.
+#: What ``_task_sort_fields`` offered before any of this was derived. Ordering
+#: is now read off the column's type, which admits a few more; these are the
+#: ones a caller already relies on and none of them may go.
 SORTABLE_FIELDS = {
     "position",
     "title",
@@ -176,8 +200,21 @@ SORTABLE_FIELDS = {
 
 
 class TestSorting:
-    def test_the_sortable_set_is_unchanged(self):
-        assert set(sort_fields("tasks", _ctx())) == SORTABLE_FIELDS
+    def test_everything_that_was_orderable_still_is(self):
+        assert SORTABLE_FIELDS <= set(sort_fields("tasks", _ctx()))
+
+    def test_a_reference_is_not_an_ordering(self):
+        """Ordering by a foreign key sorts by row id, which is an ordering of
+        the storage rather than of anything a reader can see."""
+        sortable = set(sort_fields("tasks", _ctx()))
+        assert sortable.isdisjoint({"project_id", "task_status_id", "created_by"})
+
+    def test_long_form_text_is_not_an_ordering(self):
+        """A short title orders usefully; a body of prose orders by its first
+        character, which is never what anybody wanted."""
+        sortable = set(sort_fields("tasks", _ctx()))
+        assert "title" in sortable
+        assert "description" not in sortable
 
     def test_a_sortable_column_orders_by_itself(self):
         assert sort_fields("tasks", _ctx())["title"] is Task.title
@@ -264,9 +301,36 @@ class TestDescription:
 
     def test_an_entry_carries_what_a_control_needs(self):
         by_name = {entry["name"]: entry for entry in describe("tasks")}
-        assert by_name["priority"]["kind"] == "priority"
+        assert by_name["priority"]["kind"] == "select"
         assert by_name["assignee_ids"]["kind"] == "member"
         assert by_name["due_date"]["type"] == "date"
+
+    def test_a_reference_takes_its_control_from_the_table_it_points_at(self):
+        """An integer that references ``users`` is a person, not a number.
+        The foreign key says so, so no dataset restates it."""
+        by_name = {entry["name"]: entry for entry in describe("tasks")}
+        assert by_name["created_by"]["kind"] == "member"
+        assert by_name["project_id"]["kind"] == "project"
+        assert by_name["task_status_id"]["kind"] == "task_status"
+
+    def test_a_closed_vocabulary_carries_its_own_values(self):
+        """Straight off the column that stores them, so a client keeps no copy
+        and a value added by a migration is offered without a release."""
+        by_name = {entry["name"]: entry for entry in describe("tasks")}
+        assert by_name["priority"]["options"] == list(
+            Task.__table__.columns["priority"].type.enums
+        )
+        assert by_name["status_category"]["options"] == [
+            "backlog",
+            "todo",
+            "in_progress",
+            "done",
+        ]
+
+    def test_a_field_with_no_closed_set_carries_no_options(self):
+        by_name = {entry["name"]: entry for entry in describe("tasks")}
+        assert by_name["due_date"]["options"] == []
+        assert by_name["assignee_ids"]["options"] == []
 
     def test_it_carries_no_resolvers(self):
         """What a field compiles to is ours; a client gets the description."""

--- a/backend/app/services/fields/spec.py
+++ b/backend/app/services/fields/spec.py
@@ -1,21 +1,9 @@
 """What a field *is* — one declaration, read by every surface that names one.
 
-The filter vocabulary is currently written twice: ``_build_task_filter_fields``
-on the backend and ``conditions.ts`` on the client, with nothing keeping them in
-step. Neither is a description — one compiles a clause, the other draws a
-control — so a field's *type*, the operators it answers, and which control fills
-it are knowledge no single place holds.
-
-This module is that place. A :class:`FieldSpec` says everything about a field
-once:
-
-* how it resolves to SQL — a column, or a callable for the ones needing a
-  subquery;
-* what kind of value it holds, so a consumer knows how to compare and render it;
-* which operators apply, so an unsupported one is refused rather than silently
-  producing nothing;
-* which control picks a value, which is what lets a filter UI be generic instead
-  of carrying a branch per field.
+A :class:`FieldSpec` says everything about a field once: how it resolves to SQL,
+what kind of value it holds, which operators apply, and which control fills it.
+That last one is what lets a filter UI be generic instead of carrying a branch
+per field.
 
 It is a *description*, not a second validator. ``apply_filters`` still owns how a
 clause is assembled and ``parse_conditions`` still owns the payload limits;
@@ -59,22 +47,26 @@ class ControlKind(str, Enum):
     A presentation fact, kept here rather than on the client because it belongs
     to the field: that an assignee is chosen from a member picker is true of the
     field, not of any one screen that offers it.
+
+    **Declared in the order a client lists them** — related controls together,
+    free text last. That ordering is read straight off this enum, so adding a
+    control in the right place is all there is to placing it.
     """
 
-    text = "text"
-    number = "number"
-    date = "date"
-    boolean = "boolean"
+    #: A closed vocabulary, whose values ride along with the field. One control
+    #: for every enum the database already defines, rather than one per list.
     select = "select"
+    task_status = "task_status"
     member = "member"
     tag = "tag"
     project = "project"
     initiative = "initiative"
-    task_status = "task_status"
-    status_category = "status_category"
-    priority = "priority"
     #: Values only a lookup can enumerate (a custom property's options).
     property_value = "property_value"
+    date = "date"
+    boolean = "boolean"
+    number = "number"
+    text = "text"
 
 
 #: Operator sets, named for what they mean rather than listed at each use.
@@ -85,20 +77,46 @@ ORDERED: frozenset[FilterOp] = EQUALITY | frozenset(
 TEXTUAL: frozenset[FilterOp] = EQUALITY | frozenset({FilterOp.ilike})
 MEMBERSHIP: frozenset[FilterOp] = EQUALITY | frozenset({FilterOp.in_})
 
+_IN = frozenset({FilterOp.in_})
+_EQ = frozenset({FilterOp.eq})
+_RANGE = frozenset({FilterOp.lt, FilterOp.lte, FilterOp.gt, FilterOp.gte})
 
-#: What a control offers, by the control it is.
+
+#: What a control offers, and what it holds, by the control it is.
 #:
-#: Derived rather than listed per field: "a member picker is a multi-select of
-#: ids" is true of every member picker, and restating it on each field is the
-#: parallel list this module exists to remove. A field's own ``ops`` stays the
-#: engine's answer; this is intersected with it, so a control can never offer an
-#: operator the engine would refuse.
+#: Both derived from the kind rather than declared per field: "a member picker
+#: is a multi-select of ids referring to people" is true of every member picker,
+#: and restating it on each field is the parallel list this module exists to
+#: remove. A field's own ``ops`` stays the engine's answer; this is intersected
+#: with it, so a control can never offer an operator the engine would refuse.
 #:
 #: ``project`` is deliberately single-valued: a plain top-level equality on
 #: ``project_id`` is the only shape that narrows a request to one project, and
 #: the access path reads exactly that shape.
-UI_OPS: dict["ControlKind", frozenset[FilterOp]] = {}
-UI_MULTIPLE: set["ControlKind"] = set()
+CONTROLS: dict[ControlKind, tuple[FieldType, frozenset[FilterOp]]] = {
+    ControlKind.select: (FieldType.enum, _IN),
+    ControlKind.task_status: (FieldType.reference, _IN),
+    ControlKind.member: (FieldType.reference, _IN),
+    ControlKind.tag: (FieldType.reference, _IN),
+    ControlKind.project: (FieldType.reference, _EQ),
+    ControlKind.initiative: (FieldType.reference, _IN),
+    ControlKind.property_value: (FieldType.text, _EQ),
+    ControlKind.date: (FieldType.date, _RANGE),
+    ControlKind.boolean: (FieldType.boolean, _EQ),
+    ControlKind.number: (FieldType.number, _EQ | _RANGE),
+    ControlKind.text: (FieldType.text, frozenset({FilterOp.ilike})),
+}
+
+#: What a field of each type can be compared with, when nothing narrower is
+#: declared. The engine's answer, not the control's.
+_TYPE_OPS: dict[FieldType, frozenset[FilterOp]] = {
+    FieldType.text: TEXTUAL,
+    FieldType.number: ORDERED,
+    FieldType.date: ORDERED,
+    FieldType.boolean: EQUALITY,
+    FieldType.enum: MEMBERSHIP,
+    FieldType.reference: MEMBERSHIP,
+}
 
 
 @dataclass(frozen=True)
@@ -119,8 +137,7 @@ class FieldContext:
     """What a resolver needs that the field itself cannot know.
 
     Passed per request rather than baked into the declaration, because every one
-    of these is a property of *who is asking* — which is why the old builders
-    took them as arguments and rebuilt their whole dict on every call.
+    of these is a property of *who is asking*.
     """
 
     guild_id: int
@@ -149,23 +166,11 @@ class SortExpression(Protocol):
     def __call__(self, ctx: SortContext) -> Any: ...
 
 
-#: What a control offers, by the control it is. Derived rather than listed per
-#: field: "a member picker is a multi-select of ids" is true of every member
-#: picker, and restating it on each field is the parallel list this module
-#: exists to remove.
-#:
-#: ``project`` is deliberately single-valued. A plain top-level equality on
-#: ``project_id`` is the only shape that narrows a request to one project, and
-#: the access path reads exactly that shape; an ``in_`` there would quietly take
-#: a different branch.
-
-
 @dataclass(frozen=True)
 class FieldSpec:
     """One field, described once."""
 
     name: str
-    type: FieldType
     kind: ControlKind
     ops: frozenset[FilterOp]
     #: The column this field is, when it is one. Mutually exclusive with
@@ -186,8 +191,38 @@ class FieldSpec:
     #: offers "is empty" at all — asking it of a NOT NULL column is a filter
     #: that can only ever match everything.
     nullable: bool = True
-    #: Free-text note for the catalog a client renders.
-    description: Optional[str] = None
+    #: Whether a client offers this field as a control. Off for a field that is
+    #: real but is the code's business rather than a reader's. It stays
+    #: filterable by a stored definition either way — declared on the field
+    #: rather than in a list of names elsewhere, which could name a field that
+    #: no longer exists.
+    offer: bool = True
+    #: The values this field accepts, when it accepts a closed set of them.
+    #: Read off the column that stores them, so a client needs no copy.
+    options: tuple[str, ...] = ()
+
+    @property
+    def type(self) -> FieldType:
+        """What this field holds. A fact about the control that fills it."""
+        return CONTROLS[self.kind][0]
+
+    @property
+    def offered_ops(self) -> frozenset[FilterOp]:
+        """The operators a control offers for this field.
+
+        The control's own set, narrowed to what the engine accepts, plus "is
+        empty" only where the column can actually be empty.
+        """
+        ops = CONTROLS[self.kind][1] & self.ops
+        if self.nullable and FilterOp.is_null in self.ops:
+            ops = ops | frozenset({FilterOp.is_null})
+        return ops
+
+    @property
+    def multiple(self) -> bool:
+        """Whether the control picks several values at once — which is exactly
+        whether it offers ``in_``, rather than a second list saying so."""
+        return FilterOp.in_ in self.offered_ops
 
     def __post_init__(self) -> None:
         if self.column is None and self.resolve is None and self.sort is None:
@@ -198,6 +233,26 @@ class FieldSpec:
             raise ValueError(f"field {self.name!r} is filterable but cannot filter")
         if self.sortable and self.column is None and self.sort is None:
             raise ValueError(f"field {self.name!r} is sortable but cannot sort")
+
+
+#: Columns no dataset offers as a filter, by convention rather than per model.
+#:
+#: Soft-delete and purge bookkeeping, the surrogate key, the tenant key (a
+#: request is already scoped to one guild, so filtering by it narrows nothing),
+#: and the drag-ordering float. None of these means anything to somebody
+#: building a filter, and every table has them.
+HIDDEN_EVERYWHERE: frozenset[str] = frozenset(
+    {
+        "id",
+        "guild_id",
+        "position",
+        "deleted_at",
+        "deleted_by",
+        "purge_at",
+    }
+)
+
+_KIND_ORDER: dict[ControlKind, int] = {kind: i for i, kind in enumerate(ControlKind)}
 
 
 @dataclass(frozen=True)
@@ -220,14 +275,6 @@ class Dataset:
     tool: Optional[Tool] = None
     #: Overrides the name derived from ``tool``. Required when there is no tool.
     name_override: Optional[str] = None
-    #: Fields kept out of what a client offers, beyond the shared conventions.
-    #:
-    #: An exclusion list rather than an inclusion one: a new column should show
-    #: up in the filter UI by default and be *taken out* on purpose, so the way
-    #: to forget a field is to forget to hide it rather than to forget to add
-    #: it. Every field stays filterable by a stored definition either way — this
-    #: only governs what a control offers.
-    hidden: frozenset[str] = frozenset()
 
     @property
     def name(self) -> str:
@@ -254,49 +301,36 @@ class Dataset:
             spec
             for spec in self.fields
             if spec.filterable
+            and spec.offer
             and spec.name not in HIDDEN_EVERYWHERE
-            and spec.name not in self.hidden
-            and offered_ops(spec)
+            and spec.offered_ops
         ]
-        return tuple(sorted(candidates, key=presentation_order))
-
-    def __post_init__(self) -> None:
-        known = self.by_name
-        for name in self.hidden:
-            if name not in known:
-                raise ValueError(f"{self.name}: hidden field {name!r} is not declared")
+        return tuple(sorted(candidates, key=lambda s: (_KIND_ORDER[s.kind], s.name)))
 
 
 def column(
     name: str,
     col: Any,
     *,
-    type: FieldType,
     kind: ControlKind,
     ops: Optional[frozenset[FilterOp]] = None,
     filterable: bool = True,
     sortable: bool = False,
     nullable: bool = True,
+    offer: bool = True,
+    options: tuple[str, ...] = (),
 ) -> FieldSpec:
     """A field that is a column. ``ops`` defaults to what its type supports."""
-    if ops is None:
-        ops = {
-            FieldType.text: TEXTUAL,
-            FieldType.number: ORDERED,
-            FieldType.date: ORDERED,
-            FieldType.boolean: EQUALITY,
-            FieldType.enum: MEMBERSHIP,
-            FieldType.reference: MEMBERSHIP,
-        }[type]
     return FieldSpec(
         name=name,
-        type=type,
         kind=kind,
-        ops=ops,
+        ops=_TYPE_OPS[CONTROLS[kind][0]] if ops is None else ops,
         column=col,
         filterable=filterable,
         sortable=sortable,
         nullable=nullable,
+        offer=offer,
+        options=options,
     )
 
 
@@ -304,11 +338,12 @@ def computed(
     name: str,
     resolver: Callable[..., Any],
     *,
-    type: FieldType,
     kind: ControlKind,
     ops: frozenset[FilterOp],
     filterable: bool = True,
     nullable: bool = False,
+    offer: bool = True,
+    options: tuple[str, ...] = (),
 ) -> FieldSpec:
     """A field that needs a subquery, a lookup, or a literal expanded.
 
@@ -319,132 +354,11 @@ def computed(
     """
     return FieldSpec(
         name=name,
-        type=type,
         kind=kind,
         ops=ops,
         resolve=resolver,
         filterable=filterable,
         nullable=nullable,
+        offer=offer,
+        options=options,
     )
-
-
-def sort_only(
-    name: str,
-    expression: SortExpression,
-    *,
-    type: FieldType,
-    kind: ControlKind,
-) -> FieldSpec:
-    """An ordering that is not a field anybody filters by.
-
-    A derived grouping is the case: it exists to put rows in an order, and
-    there is nothing to compare it against.
-    """
-    return FieldSpec(
-        name=name,
-        type=type,
-        kind=kind,
-        ops=frozenset(),
-        sort=expression,
-        filterable=False,
-        sortable=True,
-    )
-
-
-# --- what a control offers ---------------------------------------------------
-#
-# Populated here rather than at the declaration above because the values need
-# ControlKind and the operator sets, and the declaration needs to be readable
-# next to the type it belongs to.
-
-_IN = frozenset({FilterOp.in_})
-_EQ = frozenset({FilterOp.eq})
-_RANGE = frozenset({FilterOp.lt, FilterOp.lte, FilterOp.gt, FilterOp.gte})
-
-UI_OPS.update(
-    {
-        ControlKind.status_category: _IN,
-        ControlKind.task_status: _IN,
-        ControlKind.priority: _IN,
-        ControlKind.member: _IN,
-        ControlKind.tag: _IN,
-        ControlKind.initiative: _IN,
-        ControlKind.select: _IN,
-        ControlKind.project: _EQ,
-        ControlKind.date: _RANGE,
-        ControlKind.number: _EQ | _RANGE,
-        ControlKind.boolean: _EQ,
-        ControlKind.text: frozenset({FilterOp.ilike}),
-        ControlKind.property_value: _EQ,
-    }
-)
-
-UI_MULTIPLE.update(
-    {
-        ControlKind.status_category,
-        ControlKind.task_status,
-        ControlKind.priority,
-        ControlKind.member,
-        ControlKind.tag,
-        ControlKind.initiative,
-        ControlKind.select,
-    }
-)
-
-
-def offered_ops(spec: FieldSpec) -> frozenset[FilterOp]:
-    """The operators a control offers for this field.
-
-    The control's own set, narrowed to what the engine accepts, plus "is empty"
-    only where the column can actually be empty — offering it on a NOT NULL
-    column is a filter that can only ever match everything.
-    """
-    ops = UI_OPS.get(spec.kind, frozenset()) & spec.ops
-    if spec.nullable and FilterOp.is_null in spec.ops:
-        ops = ops | frozenset({FilterOp.is_null})
-    return ops
-
-
-def offers_multiple(spec: FieldSpec) -> bool:
-    return spec.kind in UI_MULTIPLE
-
-
-#: Columns no dataset offers as a filter, by convention rather than per model.
-#:
-#: Soft-delete and purge bookkeeping, the surrogate key, the tenant key (a
-#: request is already scoped to one guild, so filtering by it narrows nothing),
-#: and the drag-ordering float. None of these means anything to somebody
-#: building a filter, and every table has them.
-HIDDEN_EVERYWHERE: frozenset[str] = frozenset(
-    {
-        "id",
-        "guild_id",
-        "position",
-        "deleted_at",
-        "deleted_by",
-        "purge_at",
-    }
-)
-
-
-#: Ordering for the fields a client lists, by control group then name. Derived
-#: so nobody maintains a running order as fields are added.
-_KIND_ORDER: dict["ControlKind", int] = {
-    ControlKind.status_category: 0,
-    ControlKind.task_status: 1,
-    ControlKind.priority: 2,
-    ControlKind.member: 3,
-    ControlKind.tag: 4,
-    ControlKind.project: 5,
-    ControlKind.initiative: 6,
-    ControlKind.select: 7,
-    ControlKind.property_value: 8,
-    ControlKind.date: 9,
-    ControlKind.boolean: 10,
-    ControlKind.number: 11,
-    ControlKind.text: 12,
-}
-
-
-def presentation_order(spec: FieldSpec) -> tuple[int, str]:
-    return (_KIND_ORDER.get(spec.kind, 99), spec.name)

--- a/backend/app/services/fields/tasks.py
+++ b/backend/app/services/fields/tasks.py
@@ -20,7 +20,7 @@ from app.core.tools import Tool
 from app.models.tenant.project import Project
 from app.models.tenant.task import Task, TaskAssignee, TaskStatus
 from app.schemas.query import FilterOp
-from app.services.fields.derive import derive_columns, options_for, tag_field
+from app.services.fields.derive import derive_fields, options_for
 from app.services.fields.spec import (
     EQUALITY,
     MEMBERSHIP,
@@ -189,7 +189,6 @@ def _computed() -> tuple[FieldSpec, ...]:
             ops=frozenset({FilterOp.in_, FilterOp.is_null}),
             nullable=True,
         ),
-        tag_field("task"),
         computed(
             "initiative_ids",
             _initiative_ids,
@@ -224,5 +223,5 @@ def build() -> Dataset:
         model=Task,
         tool=Tool.project,
         name_override="tasks",
-        fields=derive_columns(Task, internal=_INTERNAL) + _computed(),
+        fields=derive_fields(Task, internal=_INTERNAL) + _computed(),
     )

--- a/backend/app/services/fields/tasks.py
+++ b/backend/app/services/fields/tasks.py
@@ -1,14 +1,10 @@
-"""The task dataset — the fields a task can be filtered by.
+"""The task dataset — what a table cannot say about a task.
 
-Lifted from ``_build_task_filter_fields`` without changing what any of them
-answers. The resolvers are the same clauses; what is new is that each field now
-also says what it *is*, so a client can draw a control for it and a query
-surface can type-check it without either restating this list.
-
-Columns are derived from the model rather than enumerated, which is what the old
-builder did and what keeps a new column filterable the day it is added. The
-override table below is only for the ones whose control cannot be inferred from
-a SQL type — an integer that is a person is not an integer to whoever picks one.
+The columns are not here. They are read off ``Task`` itself, because a foreign
+key already names the picker that fills it and a SQL type already says whether
+it orders. What is left is the part no table carries: the five fields that are a
+subquery rather than a column, and the two columns that exist for a feature's
+own bookkeeping.
 """
 
 from __future__ import annotations
@@ -16,121 +12,33 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import HTTPException, status
-from sqlalchemy import (
-    Boolean,
-    Date,
-    DateTime,
-    Integer,
-    Numeric,
-    case,
-    func,
-    literal,
-    text,
-)
+from sqlalchemy import case, func, literal, text
 from sqlmodel import select
 
 from app.core.messages import TaskMessages
 from app.core.tools import Tool
 from app.models.tenant.project import Project
-from app.models.tenant.tag import Tag, TaskTag
 from app.models.tenant.task import Task, TaskAssignee, TaskStatus
 from app.schemas.query import FilterOp
+from app.services.fields.derive import derive_columns, options_for, tag_field
 from app.services.fields.spec import (
-    ControlKind,
-    Dataset,
     EQUALITY,
-    FieldContext,
-    FieldSpec,
-    FieldType,
     MEMBERSHIP,
     ORDERED,
-    SortContext,
     TEXTUAL,
-    column,
+    ControlKind,
+    Dataset,
+    FieldContext,
+    FieldSpec,
+    SortContext,
     computed,
-    sort_only,
 )
 from app.services.tenant import properties as properties_service
 
-#: Columns worth ordering by. Filterability is the default for a column and
-#: orderability is not — most columns narrow usefully, few of them make a
-#: sensible ordering, and a sort list nobody can read is not a feature.
-_SORTABLE = frozenset(
-    {
-        "position",
-        "title",
-        "due_date",
-        "start_date",
-        "priority",
-        "created_at",
-        "updated_at",
-    }
-)
-
-#: Task fields a filter control does not offer, beyond the shared conventions.
-#:
-#: ``initiative_ids`` exists for the cross-guild "my tasks" views, which already
-#: know their initiative; a dashboard reads its own and a binding cannot say
-#: otherwise. The recurrence columns are a feature's internal state — a JSON
-#: rule, the strategy that applies it, and a counter — not something anybody
-#: filters a board by.
-_HIDDEN = frozenset(
-    {
-        # A property filter names one property and a value for it, so a control
-        # for it has to choose the property first and then offer that
-        # property's own values. Until there is such a control, offering the
-        # field would hand somebody a text box whose contents this resolver
-        # cannot read — it takes an object, not a string. Still filterable by a
-        # stored definition, which is how the tasks page uses it.
-        "property_values",
-        "initiative_ids",
-        "recurrence",
-        "recurrence_strategy",
-        "recurrence_occurrence_count",
-    }
-)
-
-#: Controls that a SQL type cannot imply. Everything absent here is inferred.
-_CONTROL_OVERRIDES: dict[str, tuple[FieldType, ControlKind]] = {
-    "project_id": (FieldType.reference, ControlKind.project),
-    "task_status_id": (FieldType.reference, ControlKind.task_status),
-    "priority": (FieldType.enum, ControlKind.priority),
-    "created_by": (FieldType.reference, ControlKind.member),
-    "deleted_by": (FieldType.reference, ControlKind.member),
-}
-
-
-def _infer(col: Any) -> tuple[FieldType, ControlKind]:
-    """A column's type and control, where the SQL type is enough to say."""
-    sql_type = col.type
-    if isinstance(sql_type, Boolean):
-        return FieldType.boolean, ControlKind.boolean
-    if isinstance(sql_type, (DateTime, Date)):
-        return FieldType.date, ControlKind.date
-    if isinstance(sql_type, (Integer, Numeric)):
-        return FieldType.number, ControlKind.number
-    return FieldType.text, ControlKind.text
-
-
-def _model_columns() -> tuple[FieldSpec, ...]:
-    specs = []
-    for col in Task.__table__.columns:
-        attr = getattr(Task, col.name)
-        field_type, control = _CONTROL_OVERRIDES.get(col.name) or _infer(col)
-        specs.append(
-            column(
-                col.name,
-                attr,
-                type=field_type,
-                kind=control,
-                sortable=col.name in _SORTABLE,
-                nullable=bool(col.nullable),
-            )
-        )
-    return tuple(specs)
-
-
-# --- the fields a column cannot express ------------------------------------
+#: Columns that are the recurrence feature's own state — the strategy that
+#: applies a rule and the counter that tracks it. Real columns, filterable by a
+#: stored definition, and not something anybody narrows a board by.
+_INTERNAL = frozenset({"recurrence_strategy", "recurrence_occurrence_count"})
 
 
 def _status_category(op: FilterOp, value: Any, ctx: FieldContext) -> Any:
@@ -167,21 +75,6 @@ def _assignee_ids(op: FilterOp, value: Any, ctx: FieldContext) -> Any:
     return Task.id.in_(subq)
 
 
-def _tag_ids(op: FilterOp, value: Any, ctx: FieldContext) -> Any:
-    if not value:
-        return None
-    subq = (
-        select(TaskTag.task_id)
-        .join(Tag, Tag.id == TaskTag.tag_id)
-        .where(
-            TaskTag.tag_id.in_(tuple(value)),
-            Tag.guild_id == ctx.guild_id,
-        )
-        .distinct()
-    )
-    return Task.id.in_(subq)
-
-
 def _initiative_ids(op: FilterOp, value: Any, ctx: FieldContext) -> Any:
     if not value:
         return None
@@ -210,18 +103,6 @@ def _property_values(op: FilterOp, value: Any, ctx: FieldContext) -> Any:
     return properties_service.build_single_property_clause(
         "task", pid, op, value.get("value"), defn
     )
-
-
-#: What each resolver actually handles. Narrower than the type would suggest,
-#: and deliberately so: ``_status_category`` and ``_tag_ids`` build an ``IN``
-#: over their value, so ``in_`` is the one operator each of them answers.
-_IN_ONLY = frozenset({FilterOp.in_})
-_IN_OR_EMPTY = frozenset({FilterOp.in_, FilterOp.is_null})
-
-#: A custom property answers whichever operators its own type supports; the
-#: dispatch inside ``build_single_property_clause`` decides, so this one really
-#: is as wide as it looks.
-_ANY_OP = EQUALITY | MEMBERSHIP | ORDERED | TEXTUAL
 
 
 def _date_group(ctx: SortContext) -> Any:
@@ -269,57 +150,72 @@ def _date_group(ctx: SortContext) -> Any:
     )
 
 
-_COMPUTED: tuple[FieldSpec, ...] = (
-    sort_only(
-        "date_group",
-        _date_group,
-        type=FieldType.number,
-        kind=ControlKind.number,
-    ),
-    computed(
-        "status_category",
-        _status_category,
-        type=FieldType.enum,
-        kind=ControlKind.status_category,
-        ops=_IN_ONLY,
-    ),
-    computed(
-        "assignee_ids",
-        _assignee_ids,
-        type=FieldType.reference,
-        kind=ControlKind.member,
-        # The one computed field where "is empty" means something: a task with
-        # no row in task_assignees at all.
-        ops=_IN_OR_EMPTY,
-        nullable=True,
-    ),
-    computed(
-        "tag_ids",
-        _tag_ids,
-        type=FieldType.reference,
-        kind=ControlKind.tag,
-        ops=_IN_ONLY,
-    ),
-    computed(
-        "initiative_ids",
-        _initiative_ids,
-        type=FieldType.reference,
-        kind=ControlKind.initiative,
-        ops=_IN_ONLY,
-    ),
-    computed(
-        "property_values",
-        _property_values,
-        type=FieldType.text,
-        kind=ControlKind.property_value,
-        ops=_ANY_OP,
-        nullable=True,
-    ),
-)
+#: What each resolver actually handles. Narrower than the type would suggest,
+#: and deliberately so: ``_status_category`` builds an ``IN`` over its value, so
+#: ``in_`` is the one operator it answers.
+_IN_ONLY = frozenset({FilterOp.in_})
+
+#: A custom property answers whichever operators its own type supports; the
+#: dispatch inside ``build_single_property_clause`` decides, so this one really
+#: is as wide as it looks.
+_ANY_OP = EQUALITY | MEMBERSHIP | ORDERED | TEXTUAL
+
+
+def _computed() -> tuple[FieldSpec, ...]:
+    return (
+        FieldSpec(
+            name="date_group",
+            kind=ControlKind.number,
+            ops=frozenset(),
+            sort=_date_group,
+            filterable=False,
+            sortable=True,
+        ),
+        computed(
+            "status_category",
+            _status_category,
+            kind=ControlKind.select,
+            ops=_IN_ONLY,
+            # The categories a status can be in, read off the column that
+            # stores them rather than restated here or on the client.
+            options=options_for(TaskStatus.__table__.columns["category"]),
+        ),
+        computed(
+            "assignee_ids",
+            _assignee_ids,
+            kind=ControlKind.member,
+            # The one computed field where "is empty" means something: a task
+            # with no row in task_assignees at all.
+            ops=frozenset({FilterOp.in_, FilterOp.is_null}),
+            nullable=True,
+        ),
+        tag_field("task"),
+        computed(
+            "initiative_ids",
+            _initiative_ids,
+            kind=ControlKind.initiative,
+            ops=_IN_ONLY,
+            # For the cross-guild "my tasks" views, which pass it themselves. A
+            # dashboard already knows its initiative and cannot say otherwise.
+            offer=False,
+        ),
+        computed(
+            "property_values",
+            _property_values,
+            kind=ControlKind.property_value,
+            ops=_ANY_OP,
+            nullable=True,
+            # A property filter names one property and a value for it, so a
+            # control has to choose the property before it can offer values.
+            # Until there is such a control, this is filterable by a stored
+            # definition only — which is how the tasks page uses it.
+            offer=False,
+        ),
+    )
 
 
 def build() -> Dataset:
-    """The dataset, with its model columns resolved.
+    """The dataset, with its columns read off the model.
 
     Built on call rather than at import so the columns are read once the mappers
     are configured, and so a test can rebuild it.
@@ -328,6 +224,5 @@ def build() -> Dataset:
         model=Task,
         tool=Tool.project,
         name_override="tasks",
-        fields=_model_columns() + _COMPUTED,
-        hidden=_HIDDEN,
+        fields=derive_columns(Task, internal=_INTERNAL) + _computed(),
     )

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -1934,23 +1934,25 @@ export interface ContactSectionsResponse {
  * A presentation fact, kept here rather than on the client because it belongs
  * to the field: that an assignee is chosen from a member picker is true of the
  * field, not of any one screen that offers it.
+ *
+ * **Declared in the order a client lists them** — related controls together,
+ * free text last. That ordering is read straight off this enum, so adding a
+ * control in the right place is all there is to placing it.
  */
 export type ControlKind = (typeof ControlKind)[keyof typeof ControlKind];
 
 export const ControlKind = {
-  text: "text",
-  number: "number",
-  date: "date",
-  boolean: "boolean",
   select: "select",
+  task_status: "task_status",
   member: "member",
   tag: "tag",
   project: "project",
   initiative: "initiative",
-  task_status: "task_status",
-  status_category: "status_category",
-  priority: "priority",
   property_value: "property_value",
+  date: "date",
+  boolean: "boolean",
+  number: "number",
+  text: "text",
 } as const;
 
 export type CounterViewMode = (typeof CounterViewMode)[keyof typeof CounterViewMode];
@@ -2957,6 +2959,7 @@ export interface FieldDescription {
   ops: FilterOp[];
   multiple: boolean;
   sortable: boolean;
+  options?: string[];
 }
 
 /**

--- a/frontend/src/components/initiativeTools/dashboards/FilterBuilder.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/FilterBuilder.tsx
@@ -53,10 +53,8 @@ import {
   fieldSpec,
   isGroup,
   isRelativeDate,
+  optionLabelKey,
 } from "@/lib/widgets/conditions";
-
-const STATUS_CATEGORIES = ["backlog", "todo", "in_progress", "done"] as const;
-const PRIORITIES = ["low", "medium", "high", "urgent"] as const;
 
 export interface FilterBuilderProps {
   value: FilterNode[];
@@ -92,14 +90,6 @@ export function FilterBuilder({ value, onChange, initiativeId }: FilterBuilderPr
 
   const options = useMemo(
     () => ({
-      status_category: STATUS_CATEGORIES.map((category) => ({
-        value: category,
-        label: t(`tasks:statusCategory.${category}` as const),
-      })),
-      priority: PRIORITIES.map((priority) => ({
-        value: priority,
-        label: t(`tasks:priority.${priority}` as const),
-      })),
       project: (projects.data?.items ?? [])
         .filter((project) => project.initiative_id === initiativeId)
         .map((project) => ({ value: String(project.id), label: project.name })),
@@ -222,8 +212,6 @@ export function FilterBuilder({ value, onChange, initiativeId }: FilterBuilderPr
 }
 
 type Options = {
-  status_category: { value: string; label: string }[];
-  priority: { value: string; label: string }[];
   project: { value: string; label: string }[];
   tag: { value: string; label: string }[];
   member: { value: string; label: string }[];
@@ -317,7 +305,7 @@ function ValueControl({
   options: Options;
   onChange: (value: ConditionValue) => void;
 }) {
-  const { t } = useTranslation(["dashboards", "common"]);
+  const { t } = useTranslation(["dashboards", "tasks", "common"]);
   const spec = fieldSpec(fields, leaf.field);
 
   // "Is empty" compares against nothing, so there is nothing to choose.
@@ -325,16 +313,19 @@ function ValueControl({
 
   if (spec?.multiple) {
     const list = Array.isArray(leaf.value) ? leaf.value.map(String) : [];
+    // A closed vocabulary carries its own values; everything else is a lookup
+    // this screen already loads.
     const optionList =
-      spec.kind === "status_category"
-        ? options.status_category
-        : spec.kind === "priority"
-          ? options.priority
-          : spec.kind === "member"
-            ? options.member
-            : spec.kind === "tag"
-              ? options.tag
-              : [];
+      spec.kind === "select"
+        ? (spec.options ?? []).map((value) => ({
+            value,
+            label: t(optionLabelKey(leaf.field, value), { defaultValue: value }),
+          }))
+        : spec.kind === "member"
+          ? options.member
+          : spec.kind === "tag"
+            ? options.tag
+            : [];
     return (
       <MultiSelect
         selectedValues={list}

--- a/frontend/src/lib/widgets/conditions.ts
+++ b/frontend/src/lib/widgets/conditions.ts
@@ -85,7 +85,28 @@ export interface FilterFieldSpec {
   ops: readonly FilterOp[];
   /** Whether the control picks several values at once. */
   multiple?: boolean;
+  /** The values this field accepts, when it accepts a closed set of them.
+   *  Sent by the server, read off the column that stores them — so a value
+   *  added by a migration is offered here without a frontend release. */
+  options?: readonly string[];
 }
+
+/** Where a closed vocabulary's labels live, by the field that holds it.
+ *
+ *  The *values* arrive from the server; only their wording is ours, and these
+ *  two vocabularies are already translated for the task UI. A field absent here
+ *  renders its raw value, which is what a newly added enum should do until
+ *  somebody writes words for it. */
+const OPTION_LABEL_NAMESPACES: Record<string, string> = {
+  status_category: "tasks:statusCategory",
+  priority: "tasks:priority",
+};
+
+/** The translation key for one option of a closed vocabulary. */
+export const optionLabelKey = (field: string, value: string | number): string => {
+  const namespace = OPTION_LABEL_NAMESPACES[field];
+  return namespace ? `${namespace}.${value}` : String(value);
+};
 
 /** The server's description, in the shape the controls read.
  *
@@ -98,6 +119,7 @@ export const toFilterFieldSpec = (described: FieldDescription): FilterFieldSpec 
   kind: described.kind,
   ops: described.ops,
   multiple: described.multiple,
+  options: described.options,
 });
 
 /**

--- a/frontend/src/lib/widgets/provenance.ts
+++ b/frontend/src/lib/widgets/provenance.ts
@@ -37,6 +37,7 @@ import {
   fieldSpec,
   isGroup,
   isRelativeDate,
+  optionLabelKey,
 } from "@/lib/widgets/conditions";
 import { type EntityKind, entityParams } from "@/lib/widgets/sources";
 
@@ -143,11 +144,8 @@ const describeValues = (
 
   for (const value of values) {
     switch (spec?.kind) {
-      case "status_category":
-        named.push(t(`tasks:statusCategory.${value}`, { defaultValue: String(value) }));
-        break;
-      case "priority":
-        named.push(t(`tasks:priority.${value}`, { defaultValue: String(value) }));
+      case "select":
+        named.push(t(optionLabelKey(leaf.field, value), { defaultValue: String(value) }));
         break;
       case "member": {
         // "me" is the DSL's own token for the requesting user, and it is the


### PR DESCRIPTION
Follow-up to #1455. That PR declared, per dataset, three things the model already carried: which control fills a column, whether it orders, and the values of a closed vocabulary. This derives all three.

## Problem

`tasks.py` held three hand-kept lists — `_CONTROL_OVERRIDES`, `_SORTABLE`, `_infer` — restating facts the table already stores. Worse, `spec.py` had grown its own parallel lists: a `UI_MULTIPLE` set that was exactly "the controls whose operator set is `in_`", a `_KIND_ORDER` map paralleling the `ControlKind` enum, and a `FieldType` on every declaration that was a pure function of the control kind. A registry built to delete parallel lists had accumulated four of its own.

Meanwhile the frontend still hardcoded `PRIORITIES` and `STATUS_CATEGORIES` — a third copy of vocabularies the database enum defines.

## What changed

**`derive.py` (new, generic).** Reads a model's fields off the model:

- A **foreign key names its target table**, which decides the picker — `users` → member, `projects` → project, `initiatives` → initiative. One mapping serving every dataset, rather than an override list per model. A reference to a table with no picker is filterable by a stored definition and offered as no control, which is the right default without anyone listing it.
- A **SQL type** says whether a column orders (long-form text and references do not) and whether it can be compared at all (JSON and binary cannot).
- A **SQL enum carries its own values**, which now ride to the client on `FieldDescription.options`.

**`tasks.py`** drops to what no table can say: the five fields that are a subquery, and the two columns that are the recurrence feature's own state. The tag filter moved to the generic side as well, since `TAG_LINKS` already says every tool binds to tags the same way.

**`spec.py`** loses the four parallel lists. `FieldType` and "does this control take several values" are derived from the control kind; presentation order is the `ControlKind` declaration order; `Dataset.hidden` — a list of names validated against the fields — became an `offer` flag on the field itself.

**Frontend** takes option values from the wire. `ControlKind.priority` and `ControlKind.status_category` collapse into `select`, so one control renders every closed vocabulary; only the labels stay ours, keyed by field.

## Behaviour

The derived offered set is **identical** to the shipped one — same fifteen fields, same operators, same multi-select flags — verified by diffing the endpoint payload before and after. Two deliberate differences:

- `priority` and `status_category` report `kind: "select"` and carry their values.
- Sorting admits a few more scalar columns (`completed_at`, `is_archived`, and other non-reference scalars). A widening; nothing that was orderable stopped being so.

One bug found on the way: SQLModel wraps a plain `str` field in `AutoString`, a `TypeDecorator` rather than a `String` subclass, so the first version of the deriver silently dropped every string column including `title`. Decorated types are now unwrapped, with a test.

## Net

515 insertions, 456 deletions — but the shape matters more than the count. `derive.py` serves every future dataset, so the next tool's fields cost a model reference and a line for anything genuinely internal, instead of the ~150 lines this one did.

## Testing

- `pytest app/services/fields/registry_test.py` — 43 pass (the four that asserted the deleted hand lists now assert the derivation rules instead; new tests cover FK-derived controls, enum-derived options, and the decorated-string regression)
- `pytest app/api/v1/tenant_endpoints/tasks_test.py` — 45 pass
- `ruff check` / `ruff format` / `ty check app` clean
- `tsc --noEmit` clean; `vitest` widgets + dashboards — 396 pass