### PR TITLE
Delete what the sharing gate stopped using

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -54,6 +54,7 @@ from app.services.tenant import initiatives as initiatives_service
 from app.services.tenant import ownership as ownership_service
 from app.services.tenant import documents as documents_service
 from app.services import permissions as permissions_service
+from app.services import reachability
 from app.services.tenant import my_tools as my_tools_service
 from app.services.tenant import search as search_service
 from app.services import rls as rls_service
@@ -192,6 +193,7 @@ async def _get_project_or_404(
     session: SessionDep,
     guild_id: int | None = None,
     *,
+    user_id: int,
     populate_existing: bool = False,
 ) -> Project:
     statement = (
@@ -232,6 +234,15 @@ async def _get_project_or_404(
     result = await session.exec(statement)
     project = result.one_or_none()
     if not project:
+        if guild_id is not None:
+            raise await reachability.missing_or_denied(
+                "projects",
+                project_id,
+                user_id,
+                guild_id,
+                not_found=ProjectMessages.NOT_FOUND,
+                denied=ProjectMessages.NO_ACCESS,
+            )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=ProjectMessages.NOT_FOUND
         )
@@ -1230,7 +1241,10 @@ async def create_project(
     template_project: Project | None = None
     if project_in.template_id is not None:
         template_project = await _get_project_or_404(
-            project_in.template_id, session, guild_context.guild_id
+            project_in.template_id,
+            session,
+            guild_context.guild_id,
+            user_id=current_user.id,
         )
         if not template_project.is_template:
             raise HTTPException(
@@ -1360,7 +1374,9 @@ async def create_project(
 
     await session.commit()
 
-    project = await _get_project_or_404(project.id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project.id, session, guild_context.guild_id, user_id=current_user.id
+    )
     if project.initiative_id and project.initiative:
         # Notify every member the project is shared with, derived from the grants:
         # all members, members of a granted role, or a directly granted user.
@@ -1404,7 +1420,9 @@ async def archive_project(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> ProjectRead:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1416,7 +1434,9 @@ async def archive_project(
         project.archived_at = datetime.now(timezone.utc)
         session.add(project)
         await session.commit()
-    updated = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    updated = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _attach_task_summaries(session, [updated])
     await _broadcast_project(updated, "updated")
     return await _project_read_for_user(
@@ -1439,7 +1459,7 @@ async def duplicate_project(
     guild_context: GuildContextDep,
 ) -> ProjectRead:
     source_project = await _get_project_or_404(
-        project_id, session, guild_context.guild_id
+        project_id, session, guild_context.guild_id, user_id=current_user.id
     )
     await _require_project_membership(
         source_project,
@@ -1541,7 +1561,7 @@ async def duplicate_project(
     await session.commit()
 
     new_project = await _get_project_or_404(
-        new_project.id, session, guild_context.guild_id
+        new_project.id, session, guild_context.guild_id, user_id=current_user.id
     )
     if new_project.initiative_id and new_project.initiative:
         notify_ids = [
@@ -1575,7 +1595,9 @@ async def unarchive_project(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> ProjectRead:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1587,7 +1609,9 @@ async def unarchive_project(
         project.archived_at = None
         session.add(project)
         await session.commit()
-    updated = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    updated = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _attach_task_summaries(session, [updated])
     await _broadcast_project(updated, "updated")
     return await _project_read_for_user(
@@ -1661,7 +1685,9 @@ async def record_project_view(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> RecentViewWrite:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1690,7 +1716,9 @@ async def clear_project_view(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> None:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1712,7 +1740,9 @@ async def favorite_project(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> ProjectFavoriteStatus:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1732,7 +1762,9 @@ async def unfavorite_project(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> ProjectFavoriteStatus:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1754,7 +1786,9 @@ async def project_activity_feed(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=20),
 ) -> ProjectActivityResponse:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1800,7 +1834,9 @@ async def read_project(
     guild_context: GuildContextDep,
     include_deleted: IncludeDeletedDep = False,
 ) -> ProjectRead:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1841,7 +1877,9 @@ async def search_project_members(
     rehydrating stored ids into names/avatars) rather than searching; it
     narrows the same assignable set, so an id outside it returns nothing.
     """
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(project, current_user, session, access="read")
 
     # Candidate pool = the initiative's members. User-level grants are validated
@@ -1918,7 +1956,9 @@ async def update_project(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> ProjectRead:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -1958,7 +1998,9 @@ async def update_project(
 
     session.add(project)
     await session.commit()
-    project = await _get_project_or_404(project.id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project.id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _attach_task_summaries(session, [project])
     await _broadcast_project(project, "updated")
     return await _project_read_for_user(
@@ -1976,7 +2018,9 @@ async def attach_project_document(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> ProjectRead:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -2006,7 +2050,7 @@ async def attach_project_document(
         user_id=current_user.id,
     )
     updated_project = await _get_project_or_404(
-        project_id, session, guild_context.guild_id
+        project_id, session, guild_context.guild_id, user_id=current_user.id
     )
     await _attach_task_summaries(session, [updated_project])
     await _broadcast_project(updated_project, "updated")
@@ -2025,7 +2069,9 @@ async def detach_project_document(
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_context: GuildContextDep,
 ) -> ProjectRead:
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -2054,7 +2100,7 @@ async def detach_project_document(
         project_id=project.id,
     )
     updated_project = await _get_project_or_404(
-        project_id, session, guild_context.guild_id
+        project_id, session, guild_context.guild_id, user_id=current_user.id
     )
     await _attach_task_summaries(session, [updated_project])
     await _broadcast_project(updated_project, "updated")
@@ -2147,7 +2193,9 @@ async def delete_project(
     from app.services.platform import guilds as guilds_service
     from app.services.tenant.soft_delete import soft_delete_entity
 
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     await _require_project_membership(
         project,
         current_user,
@@ -2189,7 +2237,9 @@ async def set_project_grants(
     await resource_access.set_resource_grants(
         session, Tool.project, project_id, current_user, guild_context, grants
     )
-    project = await _get_project_or_404(project_id, session, guild_context.guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_context.guild_id, user_id=current_user.id
+    )
     return await _project_read_for_user(session, current_user, project)
 
 
@@ -2209,7 +2259,9 @@ async def count_project_export_rows(
     standalone backups; the initiative/guild aggregate export passes
     ``access="read"``, its deliberate relaxation), then return the task count
     as the size proxy for inline-vs-job selection."""
-    project = await _get_project_or_404(project_id, session, guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_id, user_id=current_user.id
+    )
     await _require_project_membership(project, current_user, session, access=access)
     return (
         await session.exec(
@@ -2232,7 +2284,9 @@ async def build_project_export_for_user(
     keys (name / handle) so the file imports cleanly on another instance.
     The initiative/guild aggregate export passes ``access="read"`` — its
     deliberate relaxation; standalone exports keep write."""
-    project = await _get_project_or_404(project_id, session, guild_id)
+    project = await _get_project_or_404(
+        project_id, session, guild_id, user_id=current_user.id
+    )
     await _require_project_membership(project, current_user, session, access=access)
     return await project_export_service.build_project_export(
         session,

--- a/backend/app/core/role_context.py
+++ b/backend/app/core/role_context.py
@@ -87,16 +87,6 @@ def set_override_sharing_initiatives(initiative_ids: Optional[FrozenSet[int]]) -
     )
 
 
-def override_sharing_initiatives() -> FrozenSet[int]:
-    """Every initiative this request holds "Full access" in.
-
-    The set behind :func:`request_overrides_sharing`, for a caller that has to
-    ask about many rows at once rather than one — a statement narrowing a list
-    cannot call a per-id predicate.
-    """
-    return _override_initiatives.get()
-
-
 def request_overrides_sharing(initiative_id: Optional[int]) -> bool:
     """Whether the request holds "Full access" in ``initiative_id`` — the
     initiative-scoped sibling of ``is_request_guild_admin``. Reads the per-request

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -62,14 +62,9 @@ class DacPath:
     membership one, or None where no tool governs the table. Both gates come
     from the same declaration and the same join, so a child table asks its
     parent about its role and its sharing once rather than twice.
-
-    ``self_governed`` marks a table that IS the governed resource. Its INSERT
-    asks gate 3 for the tool's *create* right and asks gate 4 nothing at all,
-    because a resource has no sharing until it exists (see ``app.db.guild_ddl``).
     """
 
     predicate: DacBuilder
-    self_governed: bool = False
 
 
 def _resource_call(tool: str, resource_id: str, initiative: str, write: bool) -> str:
@@ -158,7 +153,7 @@ def _dac_self(tool: Tool | None = None) -> DacPath:
             creating=command == "INSERT" and tool is None,
         )
 
-    return DacPath(predicate=build, self_governed=True)
+    return DacPath(predicate=build)
 
 
 def _dac_via(

--- a/backend/app/models/tenant/document.py
+++ b/backend/app/models/tenant/document.py
@@ -225,12 +225,6 @@ class ProjectDocument(SQLModel, table=True):
     document: Optional[Document] = Relationship(back_populates="project_links")
 
 
-class DocumentPermissionLevel(str, Enum):
-    owner = "owner"
-    write = "write"
-    read = "read"
-
-
 class DocumentLink(CreatedByMixin, table=True):
     """Tracks wikilinks between documents for backlinks queries."""
 

--- a/backend/app/models/tenant/project.py
+++ b/backend/app/models/tenant/project.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, timezone
-from enum import Enum
 from typing import List, Optional, TYPE_CHECKING
 
 from sqlalchemy import Column, Date, DateTime, String, Text
@@ -117,9 +116,3 @@ class Project(CommentsToggleMixin, CreatedByMixin, SoftDeleteMixin, table=True):
             "viewonly": True,
         }
     )
-
-
-class ProjectPermissionLevel(str, Enum):
-    owner = "owner"
-    write = "write"
-    read = "read"

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -17,9 +17,8 @@ Postgres, with the sync initiative-scope check beside its SQL counterpart in
 """
 
 from dataclasses import dataclass
-from enum import Enum
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
 
 from fastapi import HTTPException, status
 from sqlalchemy import ColumnElement, and_, or_, true
@@ -35,14 +34,8 @@ from app.services.membership import NO_SCOPE_COLUMN, initiative_scope_ok
 from app.core.tools import Tool
 
 from app.models.platform.guild import GuildMembership, GuildRole
-from app.models.tenant.project import (
-    Project,
-    ProjectPermissionLevel,
-)
-from app.models.tenant.document import (
-    Document,
-    DocumentPermissionLevel,
-)
+from app.models.tenant.project import Project
+from app.models.tenant.document import Document
 from app.models.tenant.initiative import InitiativeMember, InitiativeRoleModel
 from app.models.platform.user import User
 from app.core.messages import (
@@ -57,54 +50,6 @@ from app.core.messages import (
 )
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 
-
-# ---------------------------------------------------------------------------
-# Generic helpers (work with both project and document permission enums)
-# ---------------------------------------------------------------------------
-
-# Permission-level enum the generic helpers operate on. Bound to Enum so each
-# caller's concrete level type (ProjectPermissionLevel, DocumentPermissionLevel,
-# QueuePermissionLevel) flows through to the return type.
-PermLevel = TypeVar("PermLevel", bound=Enum)
-
-
-def effective_permission_level(
-    user_level: PermLevel | None,
-    role_level: PermLevel | None,
-    level_order: dict[PermLevel, int],
-) -> PermLevel | None:
-    """Return the higher of two permission levels (MAX behaviour).
-
-    Args:
-        user_level: The user-specific permission level (may be None).
-        role_level: The role-based permission level (may be None).
-        level_order: Mapping from permission level enum to numeric rank.
-
-    Returns:
-        The higher of the two levels, or None if both are None.
-    """
-    if user_level is None:
-        return role_level
-    if role_level is None:
-        return user_level
-    if level_order.get(role_level, 0) > level_order.get(user_level, 0):
-        return role_level
-    return user_level
-
-
-# ── Convenience constants ────────────────────────────────────────
-
-PROJECT_LEVEL_ORDER: dict[ProjectPermissionLevel, int] = {
-    ProjectPermissionLevel.read: 0,
-    ProjectPermissionLevel.write: 1,
-    ProjectPermissionLevel.owner: 2,
-}
-
-DOCUMENT_LEVEL_ORDER: dict[DocumentPermissionLevel, int] = {
-    DocumentPermissionLevel.read: 0,
-    DocumentPermissionLevel.write: 1,
-    DocumentPermissionLevel.owner: 2,
-}
 
 # Where a level string sits on the shared read < write < owner ladder.
 _LEVEL_RANK = {"read": 0, "write": 1, "owner": 2}

--- a/backend/app/services/permissions_test.py
+++ b/backend/app/services/permissions_test.py
@@ -27,17 +27,14 @@ from app.models.platform.user import UserRole
 from app.models.tenant.document import Document
 from app.models.tenant.initiative import InitiativeMember
 from app.models.tenant.project import Project
-from app.models.tenant.project import ProjectPermissionLevel as PL
 from app.models.tenant.queue import Queue
 from app.models.tenant.resource_grant import ResourceGrant
 from app.services.permissions import (
     DAC_RESOURCES,
-    PROJECT_LEVEL_ORDER,
     audience_user_ids,
     compute_permission,
     dac_scope_clause,
     effective_level,
-    effective_permission_level,
     has_project_write_access,
     require_access,
 )
@@ -176,31 +173,6 @@ async def _remove_from_initiative(session, initiative, user) -> None:
         )
     )
     await session.commit()
-
-
-# ── effective_permission_level (pure helper) ─────────────────────────────────
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    ("user_level", "role_level", "expected"),
-    [
-        (None, None, None),
-        (PL.read, None, PL.read),
-        (None, PL.write, PL.write),
-        (PL.read, PL.owner, PL.owner),
-        (PL.owner, PL.read, PL.owner),
-    ],
-)
-def test_effective_permission_level_takes_the_higher_of_the_two(
-    user_level, role_level, expected
-):
-    """The user's own grant and their role's grant combine by taking the higher,
-    in either order."""
-    assert (
-        effective_permission_level(user_level, role_level, PROJECT_LEVEL_ORDER)
-        == expected
-    )
 
 
 # ── Every tool resolves sharing through the same engine ──────────────────────


### PR DESCRIPTION
## What this is

An audit for what the four-gate work left behind, and the deletions that follow. Nothing here changes behaviour except the last item.

I scanned every module the work touched for symbols defined and never referenced outside their own definition. Five things came back.

## Dead

**`DacPath.self_governed`** — set on every `_dac_self()` and read by nobody. It stopped being read when the "is this INSERT creating the resource?" decision moved *into* `_dac_self` to fix reactions (#1454); its docstring still explained a rule that now lives elsewhere, which is the worst kind of dead code — it reads as load-bearing.

**`effective_permission_level`** plus **`PROJECT_LEVEL_ORDER`** and **`DOCUMENT_LEVEL_ORDER`** — a generic "take the higher of two levels" helper with no caller but its own test. The live ladder is `_LEVEL_RANK`, on level *strings*, which is what `resource_grants` stores.

**`ProjectPermissionLevel`** and **`DocumentPermissionLevel`** — the enums those maps were keyed on. Defined in the models, referenced nowhere else in `app/`, absent from `app/schemas` and from the generated frontend types. Leftovers from the per-resource `*_permissions` tables that `resource_grants` / `ResourceAccessLevel` replaced.

**`role_context.override_sharing_initiatives()`** — the set-shaped getter behind the "Full access" override. Its docstring said it existed "for a caller that has to ask about many rows at once"; that caller was the notice board's `mark_read`, which stopped narrowing its own read when the policy took the job (#1423).

The test that covered `effective_permission_level` goes with it — it was the only thing keeping the cluster alive.

## One behaviour fix

`test_set_project_access_all_members` was the last of the 403-vs-404 residue reachable from here. `_get_project_or_404` now names its reader and answers through `missing_or_denied`, so a project in the caller's own initiative that sharing refuses is *denied* rather than reported missing.

`user_id` is **required**, not optional — the lesson from #1456, where an optional one meant no caller passed it and the branch could not run. Making it required had `ty` enumerate all 23 call sites, every one of which had `current_user` in scope.

## Testing

```
cd backend
pytest -n 8 app/db app/core app/services/permissions_test.py \
            app/api/v1/tenant_endpoints/{projects,tasks,documents}_test.py
# 908 passed, then 183 passed
ruff check app && ruff format app && ty check   # clean
```
