### PR TITLE
Tell a guild-level row apart from no row at all

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/calendars_test.py
+++ b/backend/app/api/v1/tenant_endpoints/calendars_test.py
@@ -100,11 +100,16 @@ async def test_create_calendar(client: AsyncClient, acting_user, session):
 
 @pytest.mark.integration
 async def test_create_calendar_requires_feature_enabled(
-    client: AsyncClient, acting_user
+    client: AsyncClient, acting_user, session
 ):
     """calendars_enabled is the initiative's tool gate — off means 403 even
     for a guild admin."""
     a = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    # The factory switches every tool on, so a test about one being OFF
+    # turns it off.
+    a.initiative.calendars_enabled = False
+    session.add(a.initiative)
+    await session.commit()
 
     response = await client.post(
         a.g("/calendars/"),

--- a/backend/app/api/v1/tenant_endpoints/dashboards_test.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards_test.py
@@ -112,7 +112,11 @@ async def test_create_requires_feature_enabled(
     client: AsyncClient, acting_user, session
 ):
     a = await acting_user(guild_role=GuildRole.admin, initiative=True)
-    # dashboards_enabled defaults to False.
+    # The factory switches every tool on, so a test about one being OFF
+    # turns it off.
+    a.initiative.dashboards_enabled = False
+    session.add(a.initiative)
+    await session.commit()
 
     response = await client.post(
         a.g("/dashboards/"),

--- a/backend/app/api/v1/tenant_endpoints/posts_test.py
+++ b/backend/app/api/v1/tenant_endpoints/posts_test.py
@@ -79,7 +79,11 @@ async def test_create_requires_feature_enabled(
     client: AsyncClient, acting_user, session
 ):
     a = await acting_user(guild_role=GuildRole.admin, initiative=True)
-    # posts_enabled defaults to False.
+    # The factory switches every tool on, so a test about one being OFF
+    # turns it off.
+    a.initiative.posts_enabled = False
+    session.add(a.initiative)
+    await session.commit()
 
     response = await client.post(
         a.g("/posts/"),

--- a/backend/app/services/reachability.py
+++ b/backend/app/services/reachability.py
@@ -66,8 +66,12 @@ def _comment_initiative() -> ColumnElement[Optional[int]]:
     return sa_func.coalesce(*lookups)
 
 
-def _initiative_query(model: Any, row_id: int) -> Select[tuple[Optional[int]]]:
-    """A select yielding ``row_id``'s initiative, or nothing if it is not there.
+def _initiative_query(model: Any, row_id: int) -> Select[tuple[int, Optional[int]]]:
+    """A select yielding ``row_id`` and its initiative, or no row at all.
+
+    The id rides along so the two cases stay apart: a row that exists and
+    belongs to no initiative (a guild calendar) answers ``None`` for the
+    second column, which a single-column select could not tell from no row.
 
     Most tables carry ``initiative_id``. A task does not — it belongs to a
     project — and a comment names one of several parents, so each is read
@@ -77,14 +81,16 @@ def _initiative_query(model: Any, row_id: int) -> Select[tuple[Optional[int]]]:
 
     live = getattr(model, "deleted_at", None)
     if model is Comment:
-        statement = select(_comment_initiative()).where(Comment.id == row_id)
+        statement = select(Comment.id, _comment_initiative()).where(
+            Comment.id == row_id
+        )
     elif hasattr(model, "initiative_id"):
-        statement = select(model.initiative_id).where(model.id == row_id)
+        statement = select(model.id, model.initiative_id).where(model.id == row_id)
     else:
         from app.models.tenant.project import Project
 
         statement = (
-            select(Project.initiative_id)
+            select(model.id, Project.initiative_id)
             .join(model, model.project_id == Project.id)
             .where(model.id == row_id)
         )
@@ -142,7 +148,7 @@ async def reader_is_in_the_initiative(
         found = (await probe.exec(_initiative_query(model, row_id))).first()
         if found is None:
             return False
-        initiative_id = found[0] if isinstance(found, tuple) else found
+        initiative_id = found[1]
         if initiative_id is None:
             return True
         member = (

--- a/backend/app/services/tenant/calendars.py
+++ b/backend/app/services/tenant/calendars.py
@@ -133,9 +133,15 @@ async def get_calendar_for_export(
     )
     calendar = (await session.exec(stmt)).one_or_none()
     if calendar is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=CalendarMessages.NOT_FOUND,
+        from app.services import reachability
+
+        raise await reachability.missing_or_denied(
+            "calendars",
+            calendar_id,
+            int(current_user.id or 0),
+            guild_id,
+            not_found=CalendarMessages.NOT_FOUND,
+            denied=CalendarMessages.PERMISSION_REQUIRED,
         )
     if calendar.initiative is not None and not calendar.initiative.calendars_enabled:
         raise HTTPException(


### PR DESCRIPTION
## Problem

The last eight failures on `dev`, in two groups. Both are mine.

## 1. A guild-level row read as no row (5)

`reachability`'s probe selected a single column — the row's initiative — and `.first()` returns `None` both when there is no row **and** when the row's `initiative_id` is NULL. A guild calendar is exactly the second case, so it was answered as missing rather than denied.

It selects the id alongside now, so the two stay apart: no row is `None`, a guild-level row is `(id, None)`.

That one change fixed:

- `calendars_test::test_a_guild_calendar_is_hidden_when_it_is_not_shared`
- `initiative_share_override_test::test_full_access_pm_reaches_restricted_content`
- `projects_test::test_set_project_access_all_members`
- `exports_test::test_bulk_project_selection_exports_backup_zip`

The fifth, `exports_test::test_calendar_export_applies_calendar_sharing`, needed the wiring as well: `get_calendar_for_export` is the export adapter's own fetch-and-authorize seam and raised its own unconditional 404. It answers through `missing_or_denied` like the rest.

## 2. Three tests that meant "this tool is off" (3)

`test_create_calendar_requires_feature_enabled`, and the same test for dashboards and posts, asserted 403 and got 201. They relied on the tool being off *by default* — and the test factory now switches every tool on, so the thing they were testing had quietly stopped being true. Each turns its own tool off explicitly now, which is what the exports inventory test already does.

This is the second time that factory change has surfaced a test resting on a default rather than saying what it meant. Both were caught by the assertion, not by the setup, which is the argument for the tests being explicit.

## Testing

```
cd backend
pytest -n 4 app/api/v1/tenant_endpoints/{exports,calendars}_test.py          # 76 passed
pytest -n 4 app/api/v1/tenant_endpoints/{calendars,initiative_share_override,projects}_test.py  # 83 passed
pytest -n 4 …/{calendars,dashboards,posts}_test.py::…requires_feature_enabled # 3 passed
ruff check app && ruff format app && ty check                                # clean
```

All eight named in the last `dev` run pass. Leaving the full sweep to CI.
