### PR TITLE
Open every picker on something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Direct messages could not set up a device on a deployed server.** Opening *My Messages* failed with *this device could not be set up*, on every install, while working perfectly in development. The encryption the messages run on is WebAssembly, and a browser only compiles WebAssembly a page's security policy makes room for — the worker that ratchets messages was served without that room, so the browser refused to compile it before it had done anything. It is now served the same narrow policy the dashboard widget sandbox already had: its own script, WebAssembly, and nothing else. The app-wide policy is unchanged, and still forbids WebAssembly everywhere else.
 
+- **Every picker now opens on something.** Choosing a template for a new document, attaching a document to a project, linking one from a queue item, and dropping a `#` reference, a `[[ ]]` link or a mention into what you are writing all sat on *No templates available* or an empty menu until you had typed the first letters of a name — so a community full of templates looked like one with none. Each now opens on what was most recently worked on, narrowed exactly the way typing narrows it, so the list it offers can never hold something searching would refuse to find. Typing still searches as it always did.
+
 ## [0.66.1] - 2026-09-07
 
 ### Fixed

--- a/frontend/src/components/comments/MentionPopover.tsx
+++ b/frontend/src/components/comments/MentionPopover.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import type { SearchSuggestion, UserSummary } from "@/api/generated/initiativeAPI.schemas";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useInitiative } from "@/hooks/useInitiatives";
-import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildPickerSuggestions } from "@/hooks/useSearch";
 import { useInitiativeMemberSearch } from "@/hooks/useUsers";
 import { getInitials } from "@/lib/initials";
 import type { ActiveMention } from "@/lib/mentions";
@@ -119,7 +119,9 @@ export const MentionPopover = ({
   const types = active.canCreate
     ? linkableToolTypes(initiative)
     : (active.types ?? MENTIONABLE_TYPES);
-  const suggestions = useGuildSearchSuggest(active.query, {
+  // A bare trigger names nothing yet, so the list opens on what was most
+  // recently worked on instead of on nothing at all.
+  const suggestions = useGuildPickerSuggestions(active.query, {
     types,
     initiative_id: initiativeId,
     // A mention points at work, not at the blueprint work is started from.
@@ -135,7 +137,7 @@ export const MentionPopover = ({
   const wanted = active.canCreate ? types : active.types;
   const rows: Row[] = useMemo(() => {
     if (active.user) return (members.data?.items ?? []).map(memberRow);
-    const found = (suggestions.data ?? [])
+    const found = suggestions.items
       .filter((suggestion) => !wanted || wanted.includes(suggestion.entity_type))
       .map(suggestionRow);
     if (!active.canCreate || !active.query.trim()) return found;
@@ -144,7 +146,7 @@ export const MentionPopover = ({
     const named = active.query.trim().toLowerCase();
     if (found.some((row) => row.label.toLowerCase() === named)) return found;
     return [...found, createRow(active.query.trim(), t)];
-  }, [active.user, active.canCreate, active.query, wanted, members.data, suggestions.data, t]);
+  }, [active.user, active.canCreate, active.query, wanted, members.data, suggestions.items, t]);
 
   const isLoading = inInitiative && (active.user ? members.isLoading : suggestions.isLoading);
 

--- a/frontend/src/components/documents/CreateDocumentDialog.test.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * The template picker on the new-document dialog.
+ *
+ * It is backed by the guild lookup, which matches words — and before anything
+ * is typed there are none, so the picker opened on "No templates available" in
+ * a community with plenty of them. What it opens on now is the recent list,
+ * asked for blueprints, which is the only way it can say that templates exist
+ * at all.
+ */
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { renderPage } from "@/__tests__/helpers/render";
+import { CreateDocumentDialog } from "@/components/documents/CreateDocumentDialog";
+
+const page = () => () => <CreateDocumentDialog open onOpenChange={() => {}} initiativeId={7} />;
+
+describe("CreateDocumentDialog", () => {
+  it("offers templates before anything is typed", async () => {
+    const asked: URL[] = [];
+    server.use(
+      guildHttp.get("/search/recent", ({ request }) => {
+        asked.push(new URL(request.url));
+        return HttpResponse.json([
+          {
+            entity_type: "document",
+            entity_id: 12,
+            title: "Session prep",
+            initiative_id: 7,
+            tool: "document",
+            tool_id: 12,
+          },
+        ]);
+      })
+    );
+
+    renderPage(page());
+
+    await userEvent.click(await screen.findByRole("combobox", { name: /start from template/i }));
+    expect(await screen.findByText("Session prep")).toBeInTheDocument();
+
+    // Narrowed the same way typing would narrow it, so the list it opens on
+    // can hold nothing its own search would refuse to find.
+    await waitFor(() => expect(asked.length).toBeGreaterThan(0));
+    expect(asked[0].searchParams.get("template")).toBe("true");
+    expect(asked[0].searchParams.getAll("types")).toEqual(["document"]);
+  });
+});

--- a/frontend/src/components/documents/CreateDocumentDialog.test.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.test.tsx
@@ -12,9 +12,11 @@ import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
+import { buildSearchSuggestion } from "@/__tests__/factories";
 import { guildHttp } from "@/__tests__/helpers/guildHttp";
 import { server } from "@/__tests__/helpers/msw-server";
 import { renderPage } from "@/__tests__/helpers/render";
+import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { CreateDocumentDialog } from "@/components/documents/CreateDocumentDialog";
 
 const page = () => () => <CreateDocumentDialog open onOpenChange={() => {}} initiativeId={7} />;
@@ -26,14 +28,12 @@ describe("CreateDocumentDialog", () => {
       guildHttp.get("/search/recent", ({ request }) => {
         asked.push(new URL(request.url));
         return HttpResponse.json([
-          {
+          buildSearchSuggestion({
             entity_type: "document",
-            entity_id: 12,
+            tool: Tool.document,
             title: "Session prep",
             initiative_id: 7,
-            tool: "document",
-            tool_id: 12,
-          },
+          }),
         ]);
       })
     );

--- a/frontend/src/components/documents/CreateDocumentDialog.tsx
+++ b/frontend/src/components/documents/CreateDocumentDialog.tsx
@@ -45,7 +45,7 @@ import { Tabs, TabsBar, TabsContent, TabsTrigger } from "@/components/ui/tabs";
 import { useAppConfig } from "@/hooks/useAppConfig";
 import { useCreateDocument, useUploadDocument } from "@/hooks/useDocuments";
 import { useInitiative } from "@/hooks/useInitiatives";
-import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildPickerSuggestions } from "@/hooks/useSearch";
 import { toast } from "@/lib/chesterToast";
 import { formatBytes, getFileTypeLabel } from "@/lib/fileUtils";
 import { matchSmartLinkProvider, SUPPORTED_PROVIDER_BADGES } from "@/lib/smartLinkProviders";
@@ -113,8 +113,9 @@ export const CreateDocumentDialog = ({
   const lockedInitiative = lockedInitiativeFromList ?? initiativeQuery.data ?? null;
 
   // Template picker — the shared lookup, asked for blueprints, only while the
-  // dialog is open.
-  const templateDocumentsQuery = useGuildSearchSuggest(templateSearch, {
+  // dialog is open. It opens on the templates most recently worked on, which is
+  // the only way it can say that this community has any.
+  const templates = useGuildPickerSuggestions(templateSearch, {
     types: [SearchEntityType.document],
     template: true,
     enabled: open && !isTemplateDocument,
@@ -122,11 +123,11 @@ export const CreateDocumentDialog = ({
 
   const templateItems = useMemo(
     () =>
-      (templateDocumentsQuery.data ?? []).map((doc) => ({
+      templates.items.map((doc) => ({
         value: String(doc.entity_id),
         label: doc.title,
       })),
-    [templateDocumentsQuery.data]
+    [templates.items]
   );
 
   const clearTemplate = useCallback(() => {
@@ -328,7 +329,7 @@ export const CreateDocumentDialog = ({
                   );
                 }}
                 onSearchChange={setTemplateSearch}
-                loading={templateDocumentsQuery.isFetching}
+                loading={templates.isFetching}
                 disabled={isTemplateDocument}
                 placeholder={t("create.selectTemplate")}
                 searchPlaceholder={t("create.searchTemplates")}

--- a/frontend/src/components/initiativeTools/queues/useQueueItemForm.ts
+++ b/frontend/src/components/initiativeTools/queues/useQueueItemForm.ts
@@ -6,7 +6,7 @@ import {
   ENTITY_PICKER_PAGE_SIZE,
   type LinkedEntity,
 } from "@/components/initiativeTools/queues/LinkedEntityPicker";
-import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildPickerSuggestions } from "@/hooks/useSearch";
 
 const DEFAULT_COLOR = "#6366F1";
 
@@ -91,8 +91,9 @@ export const useQueueItemForm = ({ open, initiativeId, item }: UseQueueItemFormA
 
   // Both pickers ask the one lookup the whole app searches through, narrowed
   // to this initiative and to live work — a queue item links to something
-  // being done, not to a blueprint or something already put away.
-  const docsQuery = useGuildSearchSuggest(docSearch, {
+  // being done, not to a blueprint or something already put away. Each opens on
+  // what was most recently worked on, so neither starts as an empty box.
+  const docsPicker = useGuildPickerSuggestions(docSearch, {
     types: [SearchEntityType.document],
     initiative_id: initiativeId,
     template: false,
@@ -100,19 +101,19 @@ export const useQueueItemForm = ({ open, initiativeId, item }: UseQueueItemFormA
     enabled: open && docPickerOpen,
   });
   const docResults = useMemo(
-    () => (docsQuery.data ?? []).map((doc) => ({ id: doc.entity_id, title: doc.title })),
-    [docsQuery.data]
+    () => docsPicker.items.map((doc) => ({ id: doc.entity_id, title: doc.title })),
+    [docsPicker.items]
   );
 
-  const tasksQuery = useGuildSearchSuggest(taskSearch, {
+  const tasksPicker = useGuildPickerSuggestions(taskSearch, {
     types: [SearchEntityType.task],
     initiative_id: initiativeId,
     limit: ENTITY_PICKER_PAGE_SIZE,
     enabled: open && taskPickerOpen,
   });
   const taskResults = useMemo(
-    () => (tasksQuery.data ?? []).map((task) => ({ id: task.entity_id, title: task.title })),
-    [tasksQuery.data]
+    () => tasksPicker.items.map((task) => ({ id: task.entity_id, title: task.title })),
+    [tasksPicker.items]
   );
 
   return {
@@ -143,8 +144,8 @@ export const useQueueItemForm = ({ open, initiativeId, item }: UseQueueItemFormA
     // Picker option lists
     selectedUser,
     docResults,
-    docsLoading: docsQuery.isFetching,
+    docsLoading: docsPicker.isFetching,
     taskResults,
-    tasksLoading: tasksQuery.isFetching,
+    tasksLoading: tasksPicker.isFetching,
   };
 };

--- a/frontend/src/components/projects/ProjectDocumentsSection.tsx
+++ b/frontend/src/components/projects/ProjectDocumentsSection.tsx
@@ -32,7 +32,7 @@ import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useDocumentsList } from "@/hooks/useDocuments";
 import { useAttachProjectDocument, useDetachProjectDocument } from "@/hooks/useProjects";
 import { useRelativeTime } from "@/hooks/useRelativeTime";
-import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildPickerSuggestions } from "@/hooks/useSearch";
 import { toast } from "@/lib/chesterToast";
 import { MAX_DOCUMENT_IDS } from "@/lib/documentUtils";
 import { getItem, setItem } from "@/lib/storage";
@@ -87,9 +87,11 @@ export const ProjectDocumentsSection = ({
     { enabled: attachedDocumentIds.length > 0 }
   );
 
-  // Attach picker — the shared lookup, only while the dialog is open. A
-  // template is not a document to attach to a project.
-  const docSearchQuery = useGuildSearchSuggest(docSearch, {
+  // Attach picker — the shared lookup, only while the dialog is open. It opens
+  // on this initiative's most recent documents, so there is something to attach
+  // before anything is typed. A template is not a document to attach to a
+  // project.
+  const docPicker = useGuildPickerSuggestions(docSearch, {
     types: [SearchEntityType.document],
     initiative_id: initiativeId,
     template: false,
@@ -123,10 +125,10 @@ export const ProjectDocumentsSection = ({
   // no notion of which of them this project already holds.
   const comboboxItems = useMemo(() => {
     const attached = new Set(attachedDocumentIds);
-    return (docSearchQuery.data ?? [])
+    return docPicker.items
       .filter((doc) => !attached.has(doc.entity_id))
       .map((doc) => ({ value: String(doc.entity_id), label: doc.title }));
-  }, [docSearchQuery.data, attachedDocumentIds]);
+  }, [docPicker.items, attachedDocumentIds]);
 
   return (
     <Collapsible
@@ -200,7 +202,7 @@ export const ProjectDocumentsSection = ({
                           );
                         }}
                         onSearchChange={setDocSearch}
-                        loading={docSearchQuery.isFetching}
+                        loading={docPicker.isFetching}
                         placeholder={t("documents.chooseDocument")}
                         emptyMessage={t("documents.noMatchesFound")}
                         buttonClassName="justify-between"

--- a/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/entity-mentions-plugin.tsx
@@ -15,7 +15,7 @@ import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui
 import { $createEntityMentionNode } from "@/components/ui/editor/nodes/entity-mention-node";
 import { useActiveGuildId } from "@/hooks/useActiveGuildId";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildPickerSuggestions } from "@/hooks/useSearch";
 import { entityRefTypeFor } from "@/lib/entityResolver";
 import { guildPath } from "@/lib/guildUrl";
 import { activeMention, ENTITY_TRIGGER, MENTIONABLE_TYPES } from "@/lib/mentions";
@@ -80,8 +80,9 @@ export function EntityMentionsPlugin({
   const debouncedQuery = useDebouncedValue(active?.query ?? "", 200);
 
   // The one lookup every picker in the app goes through, narrowed to this
-  // initiative's live work.
-  const { data, isFetching, isPlaceholderData } = useGuildSearchSuggest(debouncedQuery, {
+  // initiative's live work. A bare `#` names nothing yet, so it opens on what
+  // was most recently worked on rather than on a menu with nothing in it.
+  const { items, isFetching, stale } = useGuildPickerSuggestions(debouncedQuery, {
     types: active?.types ?? MENTIONABLE_TYPES,
     initiative_id: initiativeId ?? undefined,
     template: false,
@@ -96,16 +97,13 @@ export function EntityMentionsPlugin({
   const wanted = active?.types;
   const shown = useMemo(
     () =>
-      (data ?? [])
+      items
         .filter((suggestion) => !wanted || wanted.includes(suggestion.entity_type))
         .map((suggestion) => new EntityOption(suggestion)),
-    [data, wanted]
+    [items, wanted]
   );
-  // What is on screen is the previous query's answer while the next is in
-  // flight. It stays visible so the menu does not blink shut, but it is not an
-  // answer to what has been typed now — so nothing here is offered to the
-  // keyboard, and Enter cannot land on a thing the reader has stopped naming.
-  const stale = isPlaceholderData;
+  // Nothing held over from a query the reader has moved on from is offered to
+  // the keyboard, so Enter cannot land on a thing they have stopped naming.
   const options = useMemo(() => (stale ? [] : shown), [stale, shown]);
 
   const onSelectOption = useCallback(

--- a/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.tsx
+++ b/frontend/src/components/ui/editor/plugins/smart-chip-insert-dialog.tsx
@@ -18,7 +18,7 @@ import {
 import { $createSmartChipNode } from "@/components/ui/editor/nodes/smart-chip-node";
 import { SMART_CHIP_MENU } from "@/components/ui/editor/plugins/smart-chip-menu";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import { useGuildRecentSuggestions, useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildPickerSuggestions } from "@/hooks/useSearch";
 import { hitIcon } from "@/lib/searchResults";
 import { CHIP_ENTITY_TYPES, chipEntityType, chipKindsFor } from "@/lib/smartChips";
 import { cn } from "@/lib/utils";
@@ -72,32 +72,18 @@ export function SmartChipInsertDialog({
   // that belongs to none has nothing to offer and should say so.
   const hasInitiative = (initiativeId ?? 0) > 0;
 
-  const searched = debounced.trim().length > 0;
-  const narrowing = {
+  const {
+    items: shown,
+    searched,
+    stale,
+    isFetching,
+  } = useGuildPickerSuggestions(debounced, {
     types,
     initiative_id: initiativeId ?? undefined,
     template: false,
     limit: LIMIT,
-  };
-
-  // Two questions, and a picker asks whichever one it is being used for. Before
-  // anything is typed it is "what could I point at", which the lookup cannot
-  // answer — it matches words, and there are none yet.
-  const suggestions = useGuildRecentSuggestions({
-    ...narrowing,
-    enabled: hasInitiative && !searched,
+    enabled: hasInitiative,
   });
-  const matches = useGuildSearchSuggest(debounced, {
-    ...narrowing,
-    enabled: hasInitiative && searched,
-  });
-
-  const active = searched ? matches : suggestions;
-  // What came back is the previous query's answer, held so the list does not
-  // empty between keystrokes. It is not an answer to what is typed NOW, so it
-  // is shown but cannot be chosen.
-  const stale = searched && matches.isPlaceholderData;
-  const shown = active.data ?? [];
 
   const insert = (kind: SmartChipKind, suggestion: SearchSuggestion) => {
     activeEditor.update(() => {
@@ -154,14 +140,14 @@ export function SmartChipInsertDialog({
 
   const emptyMessage = !hasInitiative
     ? t("smartChips.noInitiative")
-    : active.isFetching
+    : isFetching
       ? t("smartChips.searching")
       : searched
         ? t("smartChips.noMatches", { query: debounced })
         : t("smartChips.nothingYet");
   // The initiative is only worth explaining where there is one; a document
   // outside every initiative has already been told the whole story.
-  const showScopeHint = hasInitiative && searched && !active.isFetching;
+  const showScopeHint = hasInitiative && searched && !isFetching;
 
   return (
     <div className="space-y-2">

--- a/frontend/src/components/ui/editor/plugins/wikilinks-plugin.tsx
+++ b/frontend/src/components/ui/editor/plugins/wikilinks-plugin.tsx
@@ -19,7 +19,7 @@ import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
 import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
 import { $createEntityMentionNode } from "@/components/ui/editor/nodes/entity-mention-node";
 import { useInitiative } from "@/hooks/useInitiatives";
-import { useGuildSearchSuggest } from "@/hooks/useSearch";
+import { useGuildPickerSuggestions } from "@/hooks/useSearch";
 import { linkableToolTypes } from "@/lib/references";
 
 // Regex to match [[ followed by any characters (for partial wikilinks)
@@ -120,15 +120,15 @@ function useWikilinkSearch(
   // between the two triggers.
   const { data: initiative } = useInitiative(initiativeId);
   const linkable = useMemo(() => linkableToolTypes(initiative), [initiative]);
-  const { data, isFetching } = useGuildSearchSuggest(queryString ?? "", {
+  // A bare `[[ ]]` names nothing yet, so the menu opens on this initiative's
+  // most recent linkable things rather than waiting for a first letter.
+  const { items: results, isFetching: isLoading } = useGuildPickerSuggestions(queryString ?? "", {
     types: linkable,
     initiative_id: initiativeId ?? undefined,
     template: false,
     limit: SUGGESTION_LIST_LENGTH_LIMIT,
-    enabled: Boolean(queryString) && initiativeId !== null,
+    enabled: queryString !== null && initiativeId !== null,
   });
-  const results = useMemo(() => data ?? [], [data]);
-  const isLoading = isFetching;
 
   const options = useMemo(() => {
     const docOptions = results.map(

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -49,6 +49,9 @@ export type SuggestFilters = Omit<SuggestGuildApiV1GGuildIdSearchSuggestGetParam
  * they narrow to: `types` for what kind of thing, `initiative_id` for where,
  * and `template` for whether it is a blueprint. A picker built on this gets
  * ranking, prefix matching and every access gate without asking for them.
+ *
+ * It answers only the half of a picker's job that starts with typed words;
+ * `useGuildPickerSuggestions` is what a picker asks, and calls this in turn.
  */
 export const useGuildSearchSuggest = (
   query: string,
@@ -78,12 +81,10 @@ export const useGuildSearchSuggest = (
  * the lookup is — so a picker's suggestions and its search are the same set of
  * things, and picking from the list can never offer what typing could not find.
  *
- * A picker that opens on an empty list teaches nothing: it cannot say what kind
- * of thing belongs here, or whether there is anything to point at at all.
+ * Not exported: a picker asks `useGuildPickerSuggestions`, which switches to
+ * this on its own. Asking for recents directly is asking half a question.
  */
-export const useGuildRecentSuggestions = (
-  options?: QueryOpts<SearchSuggestion[]> & SuggestFilters
-) => {
+const useGuildRecentSuggestions = (options?: QueryOpts<SearchSuggestion[]> & SuggestFilters) => {
   const guildId = useActiveGuildId();
   const { limit, types, initiative_id, template, ...queryOptions } = options ?? {};
   const params = {
@@ -97,4 +98,58 @@ export const useGuildRecentSuggestions = (
     queryFn: () => recentGuildApiV1GGuildIdSearchRecentGet(guildId, params),
     ...queryOptions,
   });
+};
+
+// One stable empty answer, so a picker's own memos do not recompute on every
+// render while a lookup is in flight.
+const NOTHING: SearchSuggestion[] = [];
+
+/** What a picker has to show, and what it is currently able to say about it. */
+export interface PickerSuggestions {
+  /** The rows to offer. */
+  items: SearchSuggestion[];
+  /** Whether these answer typed words, or are what was there to begin with. */
+  searched: boolean;
+  /**
+   * True while what is on screen answers a query the reader has moved on from.
+   * Shown, so the list does not blink shut between keystrokes — but not
+   * offered to the keyboard, since it is not an answer to what is typed now.
+   */
+  stale: boolean;
+  /** No answer yet. `isFetching` also covers refetching a list already shown. */
+  isLoading: boolean;
+  isFetching: boolean;
+}
+
+/**
+ * Everything a picker shows, whichever of its two questions it is asking.
+ *
+ * A picker asks one question before anything is typed — "what could I point
+ * at" — and another once something is: "which of them did I mean". The lookup
+ * only answers the second, because it matches words and there are none yet, so
+ * a picker built on it alone opens empty and teaches nothing: not what kind of
+ * thing belongs here, not whether there is anything to point at at all.
+ *
+ * Both questions take the same narrowing and run under the same gates, so the
+ * list a picker opens on can never hold something typing would refuse to find.
+ */
+export const useGuildPickerSuggestions = (
+  query: string,
+  options?: QueryOpts<SearchSuggestion[]> & SuggestFilters
+): PickerSuggestions => {
+  const { enabled = true, ...narrowing } = options ?? {};
+  const searched = query.trim().length > 0;
+  // Both are called every render and only one is switched on: a switched-off
+  // query keeps the answer it was last given, which belongs to the other
+  // question.
+  const recents = useGuildRecentSuggestions({ ...narrowing, enabled: enabled && !searched });
+  const matches = useGuildSearchSuggest(query, { ...narrowing, enabled: enabled && searched });
+  const active = searched ? matches : recents;
+  return {
+    items: active.data ?? NOTHING,
+    searched,
+    stale: searched && matches.isPlaceholderData,
+    isLoading: active.isLoading,
+    isFetching: active.isFetching,
+  };
 };


### PR DESCRIPTION
## Problem

The guild lookup (`/search/suggest`) matches words, and returns `[]` when there are none. Six pickers were built on it alone, so each opened on an empty list:

- **Create document → Start from template** — `No templates available`, in a community with plenty. This is the one that got reported.
- **Project → attach a document**
- **Queue item → linked document / linked task**
- `#` references, `[[ ]]` links, and the comment mention popover — no menu rows until a first letter arrived.

`/search/recent` already answers the other half of the question ("what could I point at"), and `useGuildRecentSuggestions` already existed for it — but only the smart-chip dialog used it, switching between the two hooks by hand.

## Changes

- `useGuildPickerSuggestions(query, filters)` in `useSearch.ts` — one hook holding that switch: recents while nothing is typed, matches once something is. Both halves take the same narrowing and run under the same gates, so a picker cannot open on something its own search would refuse to find.
- All seven picker sites now ask it, including the smart-chip dialog, whose hand-rolled version is deleted.
- `useGuildRecentSuggestions` is no longer exported — asking for recents alone is asking half a question.
- `CommandCenter` is unchanged: it already has its own browse state (recently visited + your open tasks), which is a different list from "what could I point at here".

No backend change — `/search/recent` already takes the same `types` / `initiative_id` / `template` narrowing as `/search/suggest`.

## Testing

- `pnpm typecheck`, `pnpm lint` (3 warnings, all pre-existing in untouched files), `pnpm biome format`
- `pnpm test:run` — 2882 passed. `MyTasksPage.test.tsx > waits for the saved sort…` fails, but it fails identically on unmodified `dev` (verified by stashing) and passes when run alone; it is a suite-ordering artifact, not this change.
- New: `CreateDocumentDialog.test.tsx` — the template picker offers a template before anything is typed, and asks for `template=true&types=document`. Confirmed it fails against the old code.