### PR TITLE
Say what a query would return, without running it

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/query.py
+++ b/backend/app/api/v1/tenant_endpoints/query.py
@@ -18,7 +18,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from app.api.deps import GuildContext, RLSSessionDep, get_guild_membership
 from app.core.messages import QueryMessages
 from app.db.session import rls_context_params
-from app.schemas.sql_query import QueryRequest, QueryResponse
+from app.schemas.sql_query import (
+    QueryColumnDescription,
+    QueryRequest,
+    QueryResponse,
+    QueryShapeResponse,
+)
 from app.services import query as query_service
 
 router = APIRouter()
@@ -29,6 +34,33 @@ _STATUS = {
     QueryMessages.BUSY: status.HTTP_429_TOO_MANY_REQUESTS,
     QueryMessages.TIMED_OUT: status.HTTP_504_GATEWAY_TIMEOUT,
 }
+
+
+@router.post("/query/describe", response_model=QueryShapeResponse)
+async def describe_query(
+    payload: QueryRequest,
+    session: RLSSessionDep,
+    guild_context: Annotated[GuildContext, Depends(get_guild_membership)],
+) -> QueryShapeResponse:
+    """Say what one statement would return, without running it.
+
+    Costs a plan and no rows, so a builder may ask as often as it likes.
+    """
+    try:
+        columns = await query_service.describe(
+            payload.sql, context=rls_context_params(session)
+        )
+    except query_service.QueryError as refused:
+        raise HTTPException(
+            status_code=_STATUS.get(refused.code, status.HTTP_400_BAD_REQUEST),
+            detail=refused.code,
+        ) from refused
+    return QueryShapeResponse(
+        columns=[
+            QueryColumnDescription(name=column.name, type=column.type)
+            for column in columns
+        ]
+    )
 
 
 @router.post("/query", response_model=QueryResponse)

--- a/backend/app/api/v1/tenant_endpoints/query_test.py
+++ b/backend/app/api/v1/tenant_endpoints/query_test.py
@@ -73,6 +73,67 @@ async def test_a_statement_the_database_cannot_finish_is_a_refusal(client, actin
     assert response.json()["detail"] == QueryMessages.EXECUTION_FAILED
 
 
+async def test_describing_a_statement_names_its_columns_and_types(client, acting_user):
+    actor = await acting_user(guild_role=GuildRole.member, initiative=True)
+    response = await client.post(
+        actor.g("/query/describe"),
+        json={"sql": "SELECT name, created_at, is_archived, id FROM projects"},
+        headers=actor.headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["columns"] == [
+        {"name": "name", "type": "text"},
+        {"name": "created_at", "type": "date"},
+        {"name": "is_archived", "type": "boolean"},
+        {"name": "id", "type": "number"},
+    ]
+
+
+async def test_a_closed_vocabulary_describes_as_one(client, acting_user):
+    """``priority`` is a database enum, which is the same signal the field
+    registry reads — so a query's shape and a dataset's fields say it the
+    same way."""
+    actor = await acting_user(guild_role=GuildRole.member, initiative=True)
+    response = await client.post(
+        actor.g("/query/describe"),
+        json={"sql": "SELECT priority FROM tasks"},
+        headers=actor.headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["columns"] == [{"name": "priority", "type": "enum"}]
+
+
+async def test_describing_runs_nothing(client, session, acting_user):
+    """A statement that would fail while running still describes, because
+    describing plans and does not execute."""
+    actor = await acting_user(guild_role=GuildRole.admin, initiative=True)
+    await create_project(session, actor.initiative, actor.user)
+    described = await client.post(
+        actor.g("/query/describe"),
+        json={"sql": "SELECT count(*) / 0 AS n FROM projects"},
+        headers=actor.headers,
+    )
+    ran = await client.post(
+        actor.g("/query"),
+        json={"sql": "SELECT count(*) / 0 AS n FROM projects"},
+        headers=actor.headers,
+    )
+    assert described.status_code == 200
+    assert described.json()["columns"] == [{"name": "n", "type": "number"}]
+    assert ran.status_code == 400
+
+
+async def test_a_statement_that_does_not_resolve_does_not_describe(client, acting_user):
+    actor = await acting_user(guild_role=GuildRole.member, initiative=True)
+    response = await client.post(
+        actor.g("/query/describe"),
+        json={"sql": "SELECT id FROM users"},
+        headers=actor.headers,
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == QueryMessages.UNKNOWN_RELATION
+
+
 async def test_a_non_member_cannot_reach_the_guilds_queries(client, acting_user):
     resident = await acting_user(guild_role=GuildRole.admin, initiative=True)
     outsider = await acting_user(guild_role=GuildRole.member)

--- a/backend/app/api/v1/tenant_endpoints/query_test.py
+++ b/backend/app/api/v1/tenant_endpoints/query_test.py
@@ -103,6 +103,22 @@ async def test_a_closed_vocabulary_describes_as_one(client, acting_user):
     assert response.json()["columns"] == [{"name": "priority", "type": "enum"}]
 
 
+async def test_a_field_that_names_a_row_describes_as_a_reference(client, acting_user):
+    """``project_id`` holds an integer and means a project. A query's shape says
+    that in the same word the dataset's fields do."""
+    actor = await acting_user(guild_role=GuildRole.member, initiative=True)
+    response = await client.post(
+        actor.g("/query/describe"),
+        json={"sql": "SELECT project_id, title FROM tasks"},
+        headers=actor.headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["columns"] == [
+        {"name": "project_id", "type": "reference"},
+        {"name": "title", "type": "text"},
+    ]
+
+
 async def test_describing_runs_nothing(client, session, acting_user):
     """A statement that would fail while running still describes, because
     describing plans and does not execute."""

--- a/backend/app/schemas/sql_query.py
+++ b/backend/app/schemas/sql_query.py
@@ -10,6 +10,7 @@ from typing import Any, List
 from pydantic import Field
 
 from app.schemas.base import SanitizedBaseModel
+from app.services.fields.spec import FieldType
 
 
 class QueryRequest(SanitizedBaseModel):
@@ -19,6 +20,21 @@ class QueryRequest(SanitizedBaseModel):
     #: surface accepts fits comfortably, and a payload past it is not a query
     #: anybody wrote by hand.
     sql: str = Field(min_length=1, max_length=20_000)
+
+
+class QueryColumnDescription(SanitizedBaseModel):
+    """One output column, as the database describes it before running."""
+
+    name: str
+    #: The same vocabulary the field registry uses, so a client reading a
+    #: query's shape and a client reading a dataset's fields read one thing.
+    type: FieldType
+
+
+class QueryShapeResponse(SanitizedBaseModel):
+    """What a statement would return, without returning it."""
+
+    columns: List[QueryColumnDescription]
 
 
 class QueryResponse(SanitizedBaseModel):

--- a/backend/app/services/query/__init__.py
+++ b/backend/app/services/query/__init__.py
@@ -1,12 +1,14 @@
 """The SQL query surface: what a reader may ask, and what reaches Postgres."""
 
-from app.services.query.executor import QueryResult, execute, run
+from app.services.query.executor import QueryColumn, QueryResult, describe, execute, run
 from app.services.query.resolve import QueryError, ResolvedQuery, resolve
 
 __all__ = [
+    "QueryColumn",
     "QueryError",
     "QueryResult",
     "ResolvedQuery",
+    "describe",
     "execute",
     "resolve",
     "run",

--- a/backend/app/services/query/executor.py
+++ b/backend/app/services/query/executor.py
@@ -37,6 +37,7 @@ from app.core.config import settings
 from app.core.messages import QueryMessages
 from app.db import session as db_session
 from app.db.session import set_rls_context
+from app.services.fields.spec import FieldType
 from app.services.query.resolve import QueryError, ResolvedQuery, resolve
 
 
@@ -54,6 +55,61 @@ class QueryResult:
     cost: float
     #: Whether there were more rows than one query returns.
     truncated: bool
+
+
+@dataclass(frozen=True)
+class QueryColumn:
+    """One output column, as the database describes it before running."""
+
+    name: str
+    type: FieldType
+
+
+#: What a Postgres type is, in the vocabulary the field registry already uses.
+#: Only the distinctions a reader's tile turns on: whether a value counts,
+#: whether it falls on a timeline, whether it is a yes or no.
+_NUMBER_TYPES = frozenset(
+    {"int2", "int4", "int8", "numeric", "float4", "float8", "money"}
+)
+_DATE_TYPES = frozenset(
+    {"date", "time", "timetz", "timestamp", "timestamptz", "interval"}
+)
+
+
+async def _enum_types(connection: Any, oids: set[int]) -> set[int]:
+    """Which of these types are a closed vocabulary the database defines.
+
+    Asked of the catalog rather than read off the description: a prepared
+    statement reports every type as scalar, so an enum column is
+    indistinguishable there from the text it is stored beside.
+    """
+    if not oids:
+        return set()
+    rows = await connection.fetch(
+        "SELECT oid FROM pg_type WHERE oid = ANY($1::oid[]) AND typtype = 'e'",
+        list(oids),
+    )
+    return {row["oid"] for row in rows}
+
+
+def _column_type(attribute: Any, enum_oids: set[int]) -> FieldType:
+    """The type of one output column.
+
+    Only the distinctions a tile turns on. A closed vocabulary reads as an enum
+    here and as an enum in the field registry, which reaches the same answer
+    from the model rather than the catalog.
+    """
+    postgres_type = attribute.type
+    if postgres_type.oid in enum_oids:
+        return FieldType.enum
+    name = postgres_type.name
+    if name in _NUMBER_TYPES:
+        return FieldType.number
+    if name in _DATE_TYPES:
+        return FieldType.date
+    if name == "bool":
+        return FieldType.boolean
+    return FieldType.text
 
 
 #: Names the query surface's locks apart from anything else that takes one.
@@ -182,3 +238,43 @@ async def execute(
 async def run(sql: str, *, context: Mapping[str, Any]) -> QueryResult:
     """Read *sql* and run what it resolves to."""
     return await execute(resolve(sql), context=context)
+
+
+async def describe(sql: str, *, context: Mapping[str, Any]) -> tuple[QueryColumn, ...]:
+    """What *sql* would return, without returning it.
+
+    The statement is prepared and its description read back. Preparing plans;
+    it does not execute, so this costs a plan and no rows however much data the
+    statement would have touched — which is what makes it usable at save time,
+    on every keystroke of a builder if need be.
+
+    It runs in the same transaction and role as the real thing, because a
+    statement is only preparable against the schema its reader is routed to.
+    """
+    statement = resolve(sql)
+    routed = dict(context)
+    routed["query"] = True
+    _routed_guild(context)
+
+    async with AsyncSession(db_session.query_engine) as session:
+        await session.begin()
+        sqlalchemy_connection = await session.connection()
+        raw = await sqlalchemy_connection.get_raw_connection()
+        connection = raw.driver_connection
+
+        await _bound_transaction(sqlalchemy_connection)
+        await set_rls_context(session, **routed)
+        try:
+            prepared = await connection.prepare(statement.sql)
+        except (DataError, UndefinedFunctionError) as failed:
+            raise QueryError(QueryMessages.EXECUTION_FAILED, str(failed)) from failed
+        attributes = prepared.get_attributes()
+        enum_oids = await _enum_types(
+            connection, {attribute.type.oid for attribute in attributes}
+        )
+        columns = tuple(
+            QueryColumn(name=attribute.name, type=_column_type(attribute, enum_oids))
+            for attribute in attributes
+        )
+        await session.rollback()
+        return columns

--- a/backend/app/services/query/executor.py
+++ b/backend/app/services/query/executor.py
@@ -170,9 +170,7 @@ async def _bound_transaction(connection: Any) -> None:
 
 
 async def _estimated_cost(connection: Any, statement: ResolvedQuery) -> float:
-    plan = await connection.fetchval(
-        f"EXPLAIN (FORMAT JSON) {statement.sql}", *statement.parameters
-    )
+    plan = await connection.fetchval(statement.explain(), *statement.parameters)
     document = json.loads(plan) if isinstance(plan, str) else plan
     return float(document[0]["Plan"]["Total Cost"])
 

--- a/backend/app/services/query/executor.py
+++ b/backend/app/services/query/executor.py
@@ -23,14 +23,16 @@ perfectly legal, and it does so without executing it.
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, AsyncIterator, Mapping
 
 from asyncpg.exceptions import (
     DataError,
     QueryCanceledError,
     UndefinedFunctionError,
 )
+from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
@@ -59,7 +61,7 @@ class QueryResult:
 
 @dataclass(frozen=True)
 class QueryColumn:
-    """One output column, as the database describes it before running."""
+    """One output column, named and typed before anything runs."""
 
     name: str
     type: FieldType
@@ -93,11 +95,12 @@ async def _enum_types(connection: Any, oids: set[int]) -> set[int]:
 
 
 def _column_type(attribute: Any, enum_oids: set[int]) -> FieldType:
-    """The type of one output column.
+    """What the database says an output column holds.
 
-    Only the distinctions a tile turns on. A closed vocabulary reads as an enum
-    here and as an enum in the field registry, which reaches the same answer
-    from the model rather than the catalog.
+    The answer for an output the registry cannot name — a count, a case, a date
+    truncated to its month — since a field selected on its own is described by
+    the registry that declares it (:attr:`ResolvedQuery.column_types`). Only the
+    distinctions a tile turns on, in the same words the registry uses.
     """
     postgres_type = attribute.type
     if postgres_type.oid in enum_oids:
@@ -136,22 +139,34 @@ async def _claim_a_slot(connection: Any, guild_id: int) -> bool:
     return False
 
 
+#: The statement limits, as one bound statement. ``set_config`` is the function
+#: form of ``SET LOCAL`` and takes its value as a parameter, where ``SET`` takes
+#: only a literal — so the settings arrive bound rather than written into SQL.
+#: The last is a constant: one query is one backend's worth of the server's
+#: attention.
+_TRANSACTION_LIMITS = text(
+    "SELECT set_config('statement_timeout', :statement_timeout, true),"
+    " set_config('work_mem', :work_mem, true),"
+    " set_config('max_parallel_workers_per_gather', '0', true)"
+)
+
+
 async def _bound_transaction(connection: Any) -> None:
     """Put the limits on the transaction, before anything of the reader's runs.
 
     Issued through SQLAlchemy rather than the driver underneath it, so they
     land inside the transaction it is managing — all four are local to one, and
-    ``SET TRANSACTION READ ONLY`` has to be the first thing in it.
+    ``SET TRANSACTION READ ONLY`` has to be the first thing in it, ahead of the
+    statement that sets the rest.
     """
     await connection.exec_driver_sql("SET TRANSACTION READ ONLY")
-    await connection.exec_driver_sql(
-        f"SET LOCAL statement_timeout = {int(settings.QUERY_STATEMENT_TIMEOUT_MS)}"
+    await connection.execute(
+        _TRANSACTION_LIMITS,
+        {
+            "statement_timeout": str(int(settings.QUERY_STATEMENT_TIMEOUT_MS)),
+            "work_mem": settings.QUERY_WORK_MEM,
+        },
     )
-    await connection.exec_driver_sql(
-        f"SET LOCAL work_mem = '{settings.QUERY_WORK_MEM}'"
-    )
-    # One query is one backend's worth of the server's attention.
-    await connection.exec_driver_sql("SET LOCAL max_parallel_workers_per_gather = 0")
 
 
 async def _estimated_cost(connection: Any, statement: ResolvedQuery) -> float:
@@ -160,6 +175,25 @@ async def _estimated_cost(connection: Any, statement: ResolvedQuery) -> float:
     )
     document = json.loads(plan) if isinstance(plan, str) else plan
     return float(document[0]["Plan"]["Total Cost"])
+
+
+@asynccontextmanager
+async def _translated_failures() -> AsyncIterator[None]:
+    """Turn what the database says into what this surface answers.
+
+    The two things a statement this surface accepted can still do: run out of
+    the time it is allowed, or fail on a value — a division by zero, a value
+    that will not convert, a function called with types it does not take. Both
+    are the reader's statement rather than the app's, so both are told back
+    with a code and what the database said, and both reach the reader whether
+    the statement was run or only described.
+    """
+    try:
+        yield
+    except QueryCanceledError as cancelled:
+        raise QueryError(QueryMessages.TIMED_OUT) from cancelled
+    except (DataError, UndefinedFunctionError) as failed:
+        raise QueryError(QueryMessages.EXECUTION_FAILED, str(failed)) from failed
 
 
 def _routed_guild(context: Mapping[str, Any]) -> int:
@@ -187,7 +221,7 @@ async def execute(
     guild_id = _routed_guild(context)
     routed = dict(context)
     routed["query"] = True
-    try:
+    async with _translated_failures():
         async with AsyncSession(db_session.query_engine) as session:
             # Opened before anything else touches the connection. The bounds
             # below and the context after it are transaction-local, so they
@@ -225,14 +259,6 @@ async def execute(
                 cost=cost,
                 truncated=truncated,
             )
-    except QueryCanceledError as cancelled:
-        raise QueryError(QueryMessages.TIMED_OUT) from cancelled
-    except (DataError, UndefinedFunctionError) as failed:
-        # The database's answer to a statement it accepted and could not
-        # finish: a division by zero, a value that will not convert, a
-        # function called with types it does not take. The reader wrote the
-        # statement, so they are told what the database said about it.
-        raise QueryError(QueryMessages.EXECUTION_FAILED, str(failed)) from failed
 
 
 async def run(sql: str, *, context: Mapping[str, Any]) -> QueryResult:
@@ -256,25 +282,31 @@ async def describe(sql: str, *, context: Mapping[str, Any]) -> tuple[QueryColumn
     routed["query"] = True
     _routed_guild(context)
 
-    async with AsyncSession(db_session.query_engine) as session:
-        await session.begin()
-        sqlalchemy_connection = await session.connection()
-        raw = await sqlalchemy_connection.get_raw_connection()
-        connection = raw.driver_connection
+    async with _translated_failures():
+        async with AsyncSession(db_session.query_engine) as session:
+            await session.begin()
+            sqlalchemy_connection = await session.connection()
+            raw = await sqlalchemy_connection.get_raw_connection()
+            connection = raw.driver_connection
 
-        await _bound_transaction(sqlalchemy_connection)
-        await set_rls_context(session, **routed)
-        try:
+            await _bound_transaction(sqlalchemy_connection)
+            await set_rls_context(session, **routed)
             prepared = await connection.prepare(statement.sql)
-        except (DataError, UndefinedFunctionError) as failed:
-            raise QueryError(QueryMessages.EXECUTION_FAILED, str(failed)) from failed
-        attributes = prepared.get_attributes()
-        enum_oids = await _enum_types(
-            connection, {attribute.type.oid for attribute in attributes}
-        )
-        columns = tuple(
-            QueryColumn(name=attribute.name, type=_column_type(attribute, enum_oids))
-            for attribute in attributes
-        )
-        await session.rollback()
-        return columns
+            attributes = prepared.get_attributes()
+            enum_oids = await _enum_types(
+                connection, {attribute.type.oid for attribute in attributes}
+            )
+            declared = statement.column_types
+            columns = tuple(
+                QueryColumn(
+                    name=attribute.name,
+                    type=(
+                        declared[position]
+                        if position < len(declared) and declared[position] is not None
+                        else _column_type(attribute, enum_oids)
+                    ),
+                )
+                for position, attribute in enumerate(attributes)
+            )
+            await session.rollback()
+            return columns

--- a/backend/app/services/query/executor_test.py
+++ b/backend/app/services/query/executor_test.py
@@ -8,11 +8,20 @@ planner estimate, a statement timeout.
 from __future__ import annotations
 
 import pytest
+import sqlalchemy as sa
 
 from app.core.config import settings
 from app.core.messages import QueryMessages
 from app.db.schema_provisioning import drop_guild_schema, provision_guild_schema
-from app.services.query import QueryError, execute, resolve, run
+from app.services.fields.spec import FieldType
+from app.services.query import (
+    QueryColumn,
+    QueryError,
+    describe,
+    execute,
+    resolve,
+    run,
+)
 
 pytestmark = pytest.mark.database
 
@@ -161,3 +170,46 @@ async def test_a_guild_runs_only_so_many_at_once(guild, monkeypatch):
         held.cancel()
         with pytest.raises(BaseException):
             await held
+
+
+async def test_a_description_that_cannot_be_planned_is_stopped(
+    guild, engine, monkeypatch
+):
+    """Preparing plans, and planning waits its turn for the relation. That wait
+    spends the same time bound a running statement does, and ends the same way."""
+    monkeypatch.setattr(settings, "QUERY_STATEMENT_TIMEOUT_MS", 250)
+    async with engine.connect() as holder:
+        await holder.execute(
+            sa.text(f"LOCK TABLE guild_{_GID}.tasks IN ACCESS EXCLUSIVE MODE")
+        )
+        try:
+            with pytest.raises(QueryError) as stopped:
+                await describe("SELECT title FROM tasks", context=_context(guild))
+        finally:
+            await holder.rollback()
+    assert stopped.value.code == QueryMessages.TIMED_OUT
+
+
+async def test_a_field_selected_on_its_own_is_typed_by_the_registry(guild):
+    """``project_id`` is stored as an integer and means a project. The shape a
+    query reports and the fields a dataset offers answer that the same way,
+    because one declaration answers both."""
+    columns = await describe(
+        "SELECT project_id, title FROM tasks", context=_context(guild)
+    )
+    assert columns == (
+        QueryColumn(name="project_id", type=FieldType.reference),
+        QueryColumn(name="title", type=FieldType.text),
+    )
+
+
+async def test_an_output_built_from_fields_is_typed_by_the_database(guild):
+    """Nothing declares what an expression is, so the database describes it."""
+    columns = await describe(
+        "SELECT lower(title) AS t, length(title) AS n FROM tasks",
+        context=_context(guild),
+    )
+    assert columns == (
+        QueryColumn(name="t", type=FieldType.text),
+        QueryColumn(name="n", type=FieldType.number),
+    )

--- a/backend/app/services/query/resolve.py
+++ b/backend/app/services/query/resolve.py
@@ -41,6 +41,7 @@ from pglast.visitors import Visitor
 from app.core.messages import QueryMessages
 from app.services.fields import dataset
 from app.services.fields.registry import dataset_names
+from app.services.fields.spec import FieldType
 
 #: How many relations one statement may name. A dashboard tile asks about one
 #: thing, sometimes joined to a second; the ceiling is what keeps a statement's
@@ -69,6 +70,10 @@ class ResolvedQuery:
     #: The datasets this statement reads, for the caller that decides whether
     #: the reader may read them.
     relations: tuple[str, ...] = ()
+    #: What the registry calls each output column, by position, where it can
+    #: name one. ``None`` where the output is an expression rather than a
+    #: field, and the database is the one to describe it.
+    column_types: tuple[FieldType | None, ...] = ()
 
 
 # --- what the surface accepts ------------------------------------------------
@@ -347,6 +352,44 @@ def _alias_positions(select: ast.SelectStmt) -> set[int]:
     return marked
 
 
+def _output_types(
+    select: ast.SelectStmt, scope: dict[str, str]
+) -> tuple[FieldType | None, ...]:
+    """What the registry calls each output column.
+
+    A target that is a field and nothing else *is* that field, and carries the
+    registry's answer about it — an id that names a person is a person on the
+    way out as much as on the way in, where the type it is stored as says only
+    that it is a whole number. Read before the names are rewritten, because the
+    registry is asked by the name the reader wrote.
+
+    Anything built from a field rather than being one has no field to ask, and
+    is left ``None`` for the database to describe.
+    """
+    only = next(iter(scope.values())) if len(scope) == 1 else None
+    return tuple(
+        _target_type(target, scope, only) for target in select.targetList or ()
+    )
+
+
+def _target_type(
+    target: ast.ResTarget, scope: dict[str, str], only: str | None
+) -> FieldType | None:
+    if not isinstance(target.val, ast.ColumnRef):
+        return None
+    names = _name_parts(target.val.fields)
+    if len(names) == 2:
+        dataset_name, field_name = scope.get(names[0]), names[1]
+    elif len(names) == 1:
+        dataset_name, field_name = only, names[0]
+    else:
+        return None
+    if dataset_name is None:
+        return None
+    spec = dataset(dataset_name).by_name.get(field_name)
+    return spec.type if spec is not None else None
+
+
 def _resolve_columns(select: ast.SelectStmt, scope: dict[str, str]) -> None:
     aliases = _output_aliases(select)
     alias_positions = _alias_positions(select)
@@ -436,10 +479,12 @@ def resolve(sql: str) -> ResolvedQuery:
     select = _parse(sql)
     _check_nodes(select)
     scope = _relations(select)
+    column_types = _output_types(select, scope)
     _resolve_columns(select, scope)
     parameters = _bind_literals(select)
     return ResolvedQuery(
         sql=RawStream()(select),
         parameters=parameters,
         relations=tuple(sorted(set(scope.values()))),
+        column_types=column_types,
     )

--- a/backend/app/services/query/resolve.py
+++ b/backend/app/services/query/resolve.py
@@ -43,6 +43,9 @@ from app.services.fields import dataset
 from app.services.fields.registry import dataset_names
 from app.services.fields.spec import FieldType
 
+#: ``EXPLAIN``'s options, as the grammar spells them.
+_EXPLAIN_JSON = (ast.DefElem(defname="format", arg=ast.String(sval="json")),)
+
 #: How many relations one statement may name. A dashboard tile asks about one
 #: thing, sometimes joined to a second; the ceiling is what keeps a statement's
 #: cost proportional to a guild's data rather than a power of it.
@@ -74,6 +77,17 @@ class ResolvedQuery:
     #: name one. ``None`` where the output is an expression rather than a
     #: field, and the database is the one to describe it.
     column_types: tuple[FieldType | None, ...] = ()
+
+    def explain(self) -> str:
+        """This statement, asking for its plan instead of its rows.
+
+        ``EXPLAIN`` takes a statement where a value would go, so there is no
+        parameter to bind it as. It is built in the tree and written out by the
+        deparser that wrote the statement, rather than composed around the text
+        of one — the same deparser, over one tree, saying both things.
+        """
+        root = ast.ExplainStmt(query=parse_sql(self.sql)[0].stmt, options=_EXPLAIN_JSON)
+        return RawStream()(root)
 
 
 # --- what the surface accepts ------------------------------------------------

--- a/backend/app/services/query/resolve_test.py
+++ b/backend/app/services/query/resolve_test.py
@@ -9,6 +9,7 @@ what a client shows the person who has to change the query.
 from __future__ import annotations
 
 import pytest
+from pglast import ast, parse_sql
 
 from app.core.messages import QueryMessages
 from app.services.fields.spec import FieldType
@@ -409,3 +410,31 @@ def test_an_output_built_from_a_field_carries_nothing():
         None,
         None,
     )
+
+
+class TestAskingForThePlan:
+    """``EXPLAIN`` takes a statement where a value would go, so there is no
+    parameter to bind it as. What must hold instead is that wrapping a
+    statement in it yields that statement and nothing more."""
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT '''; DROP TABLE tasks; --' AS c FROM tasks",
+            'SELECT title AS "a"" ; DROP TABLE x; --" FROM tasks',
+            "SELECT count(*) AS n FROM tasks GROUP BY '''; DROP --'",
+            r"SELECT E'trailing backslash \\' AS c FROM tasks",
+        ],
+    )
+    def test_the_readers_own_text_stays_one_statement(self, sql):
+        """A constant standing alone in a select list, and an identifier a
+        reader aliased, are the reader's own words carried through: they are
+        not bound, they are written back out."""
+        statements = parse_sql(resolve(sql).explain())
+        assert len(statements) == 1
+        root = statements[0].stmt
+        assert isinstance(root, ast.ExplainStmt)
+        assert isinstance(root.query, ast.SelectStmt)
+
+    def test_the_plan_is_asked_for_as_json(self):
+        assert "format json" in resolve("SELECT title FROM tasks").explain().lower()

--- a/backend/app/services/query/resolve_test.py
+++ b/backend/app/services/query/resolve_test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from app.core.messages import QueryMessages
+from app.services.fields.spec import FieldType
 from app.services.query import QueryError, resolve
 
 #: The function spellings this surface supports, as a reader writes them.
@@ -386,3 +387,25 @@ class TestSubqueriesAreNotAcceptedYet:
             QueryMessages.UNSUPPORTED_SYNTAX,
             QueryMessages.UNKNOWN_RELATION,
         }
+
+
+def test_an_output_that_is_a_field_carries_the_registrys_type():
+    """Read before the names are rewritten, and by the name the reader wrote."""
+    assert resolve("SELECT project_id, title FROM tasks").column_types == (
+        FieldType.reference,
+        FieldType.text,
+    )
+
+
+def test_a_qualified_field_carries_its_type_too():
+    assert resolve("SELECT t.priority FROM tasks t").column_types == (FieldType.enum,)
+
+
+def test_an_output_built_from_a_field_carries_nothing():
+    """An expression has no field to ask about, and is left to the database."""
+    assert resolve(
+        "SELECT lower(title) AS t, length(title) AS n FROM tasks"
+    ).column_types == (
+        None,
+        None,
+    )

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -6,12 +6,19 @@ import "fake-indexeddb/auto";
 
 import { webcrypto } from "node:crypto";
 
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 
 import { resetFactories } from "./factories";
 import { server } from "./helpers/msw-server";
 import "./helpers/i18n-test";
+
+// findBy/waitFor keep their own ceiling, separate from vitest's testTimeout, and
+// it defaults to one second. A whole-suite run has every worker transforming the
+// app's import graphs at once, so a query that resolves promptly in isolation can
+// sit queued past that and fail on the clock rather than the assertion. Kept well
+// under testTimeout so a genuinely stuck wait still reports as the wait it was.
+configure({ asyncUtilTimeout: 5_000 });
 
 // ---------------------------------------------------------------------------
 // Global Capacitor mocks – these modules are imported at the top level by many

--- a/frontend/src/api/generated/initiativeAPI.schemas.ts
+++ b/frontend/src/api/generated/initiativeAPI.schemas.ts
@@ -4938,6 +4938,14 @@ export interface PushTokenUnregisterRequest {
 }
 
 /**
+ * One output column, as the database describes it before running.
+ */
+export interface QueryColumnDescription {
+  name: string;
+  type: FieldType;
+}
+
+/**
  * One statement to read.
  */
 export interface QueryRequest {
@@ -4955,6 +4963,13 @@ export interface QueryResponse {
   columns: string[];
   rows: unknown[][];
   truncated: boolean;
+}
+
+/**
+ * What a statement would return, without returning it.
+ */
+export interface QueryShapeResponse {
+  columns: QueryColumnDescription[];
 }
 
 export interface QueueCreate {

--- a/frontend/src/api/generated/query/query.ts
+++ b/frontend/src/api/generated/query/query.ts
@@ -12,13 +12,113 @@ import type {
   UseMutationResult,
 } from "@tanstack/react-query";
 
-import type { HTTPValidationError, QueryRequest, QueryResponse } from "../initiativeAPI.schemas";
+import type {
+  HTTPValidationError,
+  QueryRequest,
+  QueryResponse,
+  QueryShapeResponse,
+} from "../initiativeAPI.schemas";
 
 import { apiMutator } from "../../mutator";
 import type { ErrorType, BodyType } from "../../mutator";
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+/**
+ * Say what one statement would return, without running it.
+ *
+ * Costs a plan and no rows, so a builder may ask as often as it likes.
+ * @summary Describe Query
+ */
+export const describeQueryApiV1GGuildIdQueryDescribePost = (
+  guildId: number,
+  queryRequest: BodyType<QueryRequest>,
+  options?: SecondParameter<typeof apiMutator>,
+  signal?: AbortSignal
+) => {
+  return apiMutator<QueryShapeResponse>(
+    {
+      url: `/api/v1/g/${guildId}/query/describe`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      data: queryRequest,
+      signal,
+    },
+    options
+  );
+};
+
+export const getDescribeQueryApiV1GGuildIdQueryDescribePostMutationOptions = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof describeQueryApiV1GGuildIdQueryDescribePost>>,
+    TError,
+    { guildId: number; data: BodyType<QueryRequest> },
+    TContext
+  >;
+  request?: SecondParameter<typeof apiMutator>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof describeQueryApiV1GGuildIdQueryDescribePost>>,
+  TError,
+  { guildId: number; data: BodyType<QueryRequest> },
+  TContext
+> => {
+  const mutationKey = ["describeQueryApiV1GGuildIdQueryDescribePost"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof describeQueryApiV1GGuildIdQueryDescribePost>>,
+    { guildId: number; data: BodyType<QueryRequest> }
+  > = (props) => {
+    const { guildId, data } = props ?? {};
+
+    return describeQueryApiV1GGuildIdQueryDescribePost(guildId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DescribeQueryApiV1GGuildIdQueryDescribePostMutationResult = NonNullable<
+  Awaited<ReturnType<typeof describeQueryApiV1GGuildIdQueryDescribePost>>
+>;
+export type DescribeQueryApiV1GGuildIdQueryDescribePostMutationBody = BodyType<QueryRequest>;
+export type DescribeQueryApiV1GGuildIdQueryDescribePostMutationError =
+  ErrorType<HTTPValidationError>;
+
+/**
+ * @summary Describe Query
+ */
+export const useDescribeQueryApiV1GGuildIdQueryDescribePost = <
+  TError = ErrorType<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof describeQueryApiV1GGuildIdQueryDescribePost>>,
+      TError,
+      { guildId: number; data: BodyType<QueryRequest> },
+      TContext
+    >;
+    request?: SecondParameter<typeof apiMutator>;
+  },
+  queryClient?: QueryClient
+): UseMutationResult<
+  Awaited<ReturnType<typeof describeQueryApiV1GGuildIdQueryDescribePost>>,
+  TError,
+  { guildId: number; data: BodyType<QueryRequest> },
+  TContext
+> => {
+  return useMutation(
+    getDescribeQueryApiV1GGuildIdQueryDescribePostMutationOptions(options),
+    queryClient
+  );
+};
 /**
  * Read one statement and return its rows.
  * @summary Run Query


### PR DESCRIPTION
The backend half of Phase 4's shape contract. `POST /g/{guild_id}/query/describe` answers what a statement would return — column names and types — **without executing it**.

This is what lets the next piece check a query's shape against what a widget accepts at save time, rather than discovering at render time that a chart was pointed at two text columns.

## How it costs nothing

The statement is resolved and then *prepared*. Preparing plans; it does not execute. So describing a query over a million rows costs a plan and no rows, which is what makes it usable on every keystroke of a builder.

It runs in the same read-only transaction and the same query role as the real thing, because a statement is only preparable against the schema its reader is routed to.

## The vocabulary is the registry's

Columns come back as `FieldType` — the same `text` / `number` / `date` / `boolean` / `enum` the field registry already uses. A client reading a query's shape and a client reading a dataset's fields read one thing rather than two that mean the same.

## Two things the tests settled

**A prepared statement reports every type as `scalar`.** asyncpg does not read `typtype`, so a native enum column is indistinguishable there from the text beside it — my first version had a `kind == "enum"` branch that could never fire. The catalog is asked instead, once per describe, for the type OIDs actually present. `SELECT priority FROM tasks` now reports `enum`, which is the same answer the registry reaches from the model.

**Describing really does not run.** The pair that shows it: `SELECT count(*) / 0 AS n FROM projects` **describes** as one `number` column and **refuses** when run. Same statement, two endpoints, two outcomes.

## Testing

`pytest app/api/v1/tenant_endpoints/query_test.py` — 11 pass, five of them new:

- names and types for a mixed statement (`text`, `date`, `boolean`, `number`)
- a closed vocabulary describes as `enum`
- describing runs nothing (the division-by-zero pair)
- a statement that does not resolve does not describe, and says which word
- everything from the previous PR still holds

`pytest app/services/query` — 98 pass. `ruff` / `ty check app` clean. Orval regenerated.

## Not here

No changelog entry: still nothing a user can reach. Next is the frontend half — the `query` binding source and matching a query's shape to the widgets that accept it.