### PR TITLE
Read a comment parent by name

### DIFF
--- a/backend/app/core/tools_test.py
+++ b/backend/app/core/tools_test.py
@@ -157,7 +157,7 @@ def test_every_tool_is_commentable():
     model_columns = {c.name for c in sa_inspect(Comment).persist_selectable.columns}
     assert set(COMMENT_PARENT_COLUMNS) <= model_columns
 
-    assert {col for col, *_ in _COMMENT_PARENTS} == set(COMMENT_PARENT_COLUMNS)
+    assert {p.column for p in _COMMENT_PARENTS} == set(COMMENT_PARENT_COLUMNS)
     assert set(COMMENT_TARGET_FIELDS) == set(COMMENT_PARENT_COLUMNS)
 
 


### PR DESCRIPTION
`_COMMENT_PARENTS` became a `CommentParent` record in #1473; `tools_test` still unpacked it positionally (`for col, *_ in …`), which `ty` catches and the test would fail on.

One line. `ty check app`, `ruff check app` and `pytest app/core/tools_test.py` (19 passed) all clean.