### PR TITLE
Keep one copy of the socket lifecycle

### DIFF
--- a/frontend/src/hooks/useNotificationStream.ts
+++ b/frontend/src/hooks/useNotificationStream.ts
@@ -2,10 +2,9 @@ import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 
 import { invalidate, q } from "@/api/query-keys";
 import { useAuth } from "@/hooks/useAuth";
+import { openLiveSocket } from "@/lib/liveSocket";
 import { buildApiWsUrl } from "@/lib/wsUrl";
 
-// Message type for authentication (must match the backend's MSG_AUTH).
-const MSG_AUTH = 5;
 // "Somebody just did something here" (the backend's MSG_ACTIVE). One byte, no
 // payload: the socket already knows whose it is.
 const MSG_ACTIVE = 6;
@@ -19,19 +18,6 @@ const ACTIVITY_INTERVAL_MS = 60_000;
 // machine; a tab coming back to the front covers returning to it.
 const ACTIVITY_EVENTS = ["pointerdown", "keydown", "wheel", "touchstart"] as const;
 
-const RECONNECT_DELAY_MS = 2000;
-const MAX_RECONNECT_DELAY_MS = 30_000;
-
-// The server says something every 30s even with no news (its HEARTBEAT_SECONDS),
-// so silence past a couple of those is the socket having stopped carrying
-// rather than nothing having happened. A dropped connection does not always
-// close: a suspended laptop, a network that goes away mid-flight and a NAT
-// timeout all leave one reporting itself open and delivering nothing, and this
-// channel has no other way to notice — it speaks only when its person does.
-const SERVER_SILENCE_LIMIT_MS = 90_000;
-// How often that is checked. Cheap: a comparison against a timestamp.
-const SILENCE_CHECK_INTERVAL_MS = 15_000;
-
 // A frame is the only prompt to re-read the account, so a re-read that fails
 // has to keep trying: there is no poll behind it any more, and the next frame
 // may never come for this account. What is bounded is the *rate*, not the
@@ -40,9 +26,6 @@ const SILENCE_CHECK_INTERVAL_MS = 15_000;
 // prevent. Backs off to a slow beat and stays there until one lands.
 const ACCOUNT_RETRY_DELAYS_MS = [2000, 8000, 30_000, 60_000] as const;
 const ACCOUNT_RETRY_MAX_DELAY_MS = 300_000;
-// Three consecutive policy-violation closes means the credential is no good,
-// not that the network blinked — same rule as the guild events socket.
-const MAX_AUTH_FAILURES = 3;
 
 // ── Connection state, shared with whoever renders the bell ──────────────────
 // The socket is mounted once at the app shell, but the component that decides
@@ -84,22 +67,6 @@ export const useNotificationStreamConnected = (): boolean =>
     () => false
   );
 
-const sendActivityMessage = (websocket: WebSocket) => {
-  if (websocket.readyState !== WebSocket.OPEN) {
-    return;
-  }
-  websocket.send(new Uint8Array([MSG_ACTIVE]));
-};
-
-const sendAuthMessage = (websocket: WebSocket, token: string | null) => {
-  const payload = JSON.stringify({ token });
-  const payloadBytes = new TextEncoder().encode(payload);
-  const message = new Uint8Array(1 + payloadBytes.length);
-  message[0] = MSG_AUTH;
-  message.set(payloadBytes, 1);
-  websocket.send(message);
-};
-
 /**
  * Subscribe to the signed-in user's notification channel.
  *
@@ -127,9 +94,6 @@ export const useNotificationStream = () => {
   // itself down and rebuild in a loop, each rebuild asking for the re-read that
   // ends it. Who they are is the id.
   const userId = user?.id ?? null;
-  const websocketRef = useRef<WebSocket | null>(null);
-  const reconnectTimerRef = useRef<number | null>(null);
-  const authFailureCountRef = useRef(0);
   // Held in a ref so a new `refreshUser` identity does not tear the socket
   // down and rebuild it: the handler wants the current one, not the one that
   // existed when we connected.
@@ -191,120 +155,46 @@ export const useNotificationStream = () => {
       return;
     }
 
-    let isActive = true;
-    let lastFrameAt = Date.now();
-
-    const scheduleReconnect = (delayMs = RECONNECT_DELAY_MS) => {
-      if (!isActive || reconnectTimerRef.current !== null) {
-        return;
-      }
-      reconnectTimerRef.current = window.setTimeout(() => {
-        reconnectTimerRef.current = null;
-        connect();
-      }, delayMs);
-    };
-
-    const connect = () => {
-      if (!isActive) {
-        return;
-      }
-      let websocket: WebSocket;
-      try {
-        websocket = new WebSocket(buildApiWsUrl("notifications/stream"));
-      } catch {
-        scheduleReconnect();
-        return;
-      }
-      websocket.binaryType = "arraybuffer";
-      websocketRef.current = websocket;
-
-      websocket.onopen = () => {
-        // The token rides in the first frame rather than the URL, so it never
-        // lands in a proxy or server access log.
-        sendAuthMessage(websocket, token);
-        authFailureCountRef.current = 0;
-        lastFrameAt = Date.now();
-        setConnected(true);
-        // The socket was down for some interval — anything that happened in it
-        // was never signalled, so catch up once on the way back up.
-        resync();
-      };
-
-      websocket.onmessage = (event) => {
-        // Any frame is proof the socket carries, whatever it says.
-        lastFrameAt = Date.now();
-        try {
-          const payload = JSON.parse(event.data) as { resource?: string };
-          // Two channels over one socket. A frame carries nothing but which
-          // one it is; what it means is a refetch, and the refetch is where
-          // anything is actually decided.
-          if (payload.resource === "heartbeat") {
-            // Nothing to do beyond what has already been done: the frame's
-            // whole content is that it arrived.
-            return;
-          }
-          if (payload.resource === "resync") {
-            // The server's own bus was down for a while, so frames went past
-            // with nobody listening for them. It cannot say which, so this
-            // says the same thing a reconnect does: read everything again.
-            resync();
-          } else if (payload.resource === "notification") {
-            void invalidate(q.notifications());
-          } else if (payload.resource === "account") {
-            refreshAccount();
-          } else if (payload.resource === "contacts") {
-            refreshContacts();
-          } else if (payload.resource === "dm") {
-            // A direct-message frame says only that there is something to
-            // collect. The page that owns the mailbox does the reading.
-            void invalidate(q.directMessages());
-          }
-        } catch {
-          // ignore malformed frames
+    const connection = openLiveSocket({
+      url: buildApiWsUrl("notifications/stream"),
+      // The inbox is addressed by nothing but the credential.
+      auth: () => ({ token }),
+      onStatus: (up) => {
+        setConnected(up);
+        if (up) {
+          // The socket was down for some interval — anything that happened in
+          // it was never signalled, so catch up once on the way back up.
+          resync();
         }
-      };
-
-      websocket.onerror = () => {
-        websocket.close();
-      };
-
-      websocket.onclose = (event) => {
-        if (websocketRef.current === websocket) {
-          websocketRef.current = null;
-        }
-        setConnected(false);
-        // WS_1008_POLICY_VIOLATION — the credential was rejected. Back off
-        // hard and give up rather than hammering the endpoint; the bell falls
-        // back to polling, and the guild events socket owns logging out.
-        if (event.code === 1008) {
-          authFailureCountRef.current += 1;
-          if (authFailureCountRef.current >= MAX_AUTH_FAILURES) {
-            return;
-          }
-          scheduleReconnect(
-            Math.min(MAX_RECONNECT_DELAY_MS, RECONNECT_DELAY_MS * 2 ** authFailureCountRef.current)
-          );
+      },
+      onFrame: (payload) => {
+        const frame = payload as { resource?: string };
+        // Several channels over one socket. A frame carries nothing but which
+        // one it is; what it means is a refetch, and the refetch is where
+        // anything is actually decided.
+        if (frame.resource === "heartbeat") {
+          // Nothing to do beyond what has already been done: the frame's whole
+          // content is that it arrived.
           return;
         }
-        scheduleReconnect();
-      };
-    };
-
-    connect();
-
-    // A socket that has gone quiet past the server's beat is closed rather than
-    // trusted. Closing is what puts the fallback poll back and starts the
-    // reconnect that catches up — none of which a half-open connection would
-    // ever reach on its own.
-    const silenceCheck = window.setInterval(() => {
-      const socket = websocketRef.current;
-      if (!socket || socket.readyState !== WebSocket.OPEN) {
-        return;
-      }
-      if (Date.now() - lastFrameAt > SERVER_SILENCE_LIMIT_MS) {
-        socket.close();
-      }
-    }, SILENCE_CHECK_INTERVAL_MS);
+        if (frame.resource === "resync") {
+          // The server's own bus was down for a while, so frames went past
+          // with nobody listening for them. It cannot say which, so this says
+          // the same thing a reconnect does: read everything again.
+          resync();
+        } else if (frame.resource === "notification") {
+          void invalidate(q.notifications());
+        } else if (frame.resource === "account") {
+          refreshAccount();
+        } else if (frame.resource === "contacts") {
+          refreshContacts();
+        } else if (frame.resource === "dm") {
+          // A direct-message frame says only that there is something to
+          // collect. The page that owns the mailbox does the reading.
+          void invalidate(q.directMessages());
+        }
+      },
+    });
 
     // Throttled at the source rather than on a timer: no frame goes out for a
     // tab nobody is touching, which is exactly the state being reported.
@@ -315,9 +205,7 @@ export const useNotificationStream = () => {
         return;
       }
       lastReported = now;
-      if (websocketRef.current) {
-        sendActivityMessage(websocketRef.current);
-      }
+      connection.send(new Uint8Array([MSG_ACTIVE]));
     };
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") {
@@ -332,21 +220,12 @@ export const useNotificationStream = () => {
     document.addEventListener("visibilitychange", onVisibilityChange);
 
     return () => {
-      isActive = false;
-      window.clearInterval(silenceCheck);
       for (const name of ACTIVITY_EVENTS) {
         window.removeEventListener(name, reportActivity);
       }
       document.removeEventListener("visibilitychange", onVisibilityChange);
       setConnected(false);
-      if (reconnectTimerRef.current) {
-        window.clearTimeout(reconnectTimerRef.current);
-        reconnectTimerRef.current = null;
-      }
-      if (websocketRef.current) {
-        websocketRef.current.close();
-        websocketRef.current = null;
-      }
+      connection.close();
     };
   }, [token, userId, resync, refreshAccount, refreshContacts]);
 };

--- a/frontend/src/hooks/useRealtimeUpdates.tsx
+++ b/frontend/src/hooks/useRealtimeUpdates.tsx
@@ -1,25 +1,13 @@
 import { useParams } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import { Tool } from "@/api/generated/initiativeAPI.schemas";
 import { invalidate, q, type Spec } from "@/api/query-keys";
+import { openLiveSocket } from "@/lib/liveSocket";
 import { TOOLS, toolPlural } from "@/lib/tools";
 import { buildGuildWsUrl } from "@/lib/wsUrl";
 
 import { useAuth } from "./useAuth";
-
-// Message type for authentication (must match backend)
-const MSG_AUTH = 5;
-
-// The server says something every 30s even with no news (its
-// HEARTBEAT_SECONDS), so silence past a couple of those is the socket having
-// stopped carrying rather than the guild being quiet. A dropped connection
-// does not always close: a suspended laptop, a network that goes away
-// mid-flight and a NAT timeout all leave one reporting itself open and
-// delivering nothing.
-const SERVER_SILENCE_LIMIT_MS = 90_000;
-// How often that is checked. Cheap: a comparison against a timestamp.
-const SILENCE_CHECK_INTERVAL_MS = 15_000;
 
 const buildWebsocketUrl = (guildId: number) => {
   if (typeof window === "undefined") {
@@ -32,34 +20,6 @@ const buildWebsocketUrl = (guildId: number) => {
     const protocol = window.location.protocol === "https:" ? "wss" : "ws";
     return `${protocol}://${window.location.host}/api/v1/g/${guildId}/events/updates`;
   }
-};
-
-/**
- * Send authentication message over WebSocket.
- * Must be sent immediately after connection opens.
- *
- * The socket is scoped server-side to the guild in the route path (the backend
- * only streams that guild's events), so the payload carries the token only.
- * The hook reconnects on guild switch, so the subscription always tracks the
- * guild this tab is looking at.
- *
- * A reconnect also says how long this tab was without a socket, which is what
- * the server needs to answer whether anything happened in that time. A first
- * connect says nothing: the route that just mounted fetched its own data.
- */
-const sendAuthMessage = (
-  websocket: WebSocket,
-  token: string | null,
-  awaySeconds: number | null
-) => {
-  const payload = JSON.stringify(
-    awaySeconds === null ? { token } : { token, away_seconds: awaySeconds }
-  );
-  const payloadBytes = new TextEncoder().encode(payload);
-  const message = new Uint8Array(1 + payloadBytes.length);
-  message[0] = MSG_AUTH;
-  message.set(payloadBytes, 1);
-  websocket.send(message);
 };
 
 /** One thing the bus can name: what changed, or something it sits inside. */
@@ -190,44 +150,22 @@ export const useRealtimeUpdates = () => {
   // path segment, so the URL is the single source of truth.
   const params = useParams({ strict: false }) as { guildId?: string };
   const routeGuildId = params.guildId ? Number(params.guildId) : null;
-  const websocketRef = useRef<WebSocket | null>(null);
-  const reconnectTimerRef = useRef<number | null>(null);
-  const authFailureCountRef = useRef<number>(0);
 
   useEffect(() => {
     // The socket is scoped to a single guild — in personal mode there's
     // nothing to subscribe to, and the backend would reject the auth payload.
     if (userId === null || routeGuildId === null) {
-      if (websocketRef.current) {
-        websocketRef.current.close();
-        websocketRef.current = null;
-      }
-      if (reconnectTimerRef.current) {
-        window.clearTimeout(reconnectTimerRef.current);
-        reconnectTimerRef.current = null;
-      }
-      authFailureCountRef.current = 0;
       return;
     }
-    // routeGuildId is non-null past the guard; capture for the /c/{guildId}
-    // websocket path used in the connect() closure below.
-    const guildId = routeGuildId;
-
-    let isActive = true;
+    const wsUrl = buildWebsocketUrl(routeGuildId);
+    if (!wsUrl) {
+      return;
+    }
 
     // Effect-scoped, so unmount and guild-switch clear the timer with the
     // socket rather than invalidating for a guild this tab has left.
     let pending: RealtimeChange[] = [];
     let frameTimer: number | null = null;
-    // The last moment this tab had a socket that was carrying. Any frame is
-    // proof of that, so a beat counts; nothing else does.
-    let lastFrameAt = Date.now();
-    // The last frame received on ANY socket here, which is the last proof this
-    // tab was being carried. Only a frame moves it: an attempt that opens and
-    // dies before hearing anything has proved nothing, and must not shorten the
-    // gap the next attempt reports. Null until the first frame — a tab that has
-    // never been carried asks for nothing, having fetched as it mounted.
-    let carriedUntil: number | null = null;
 
     const enqueue = (changes: RealtimeChange[]) => {
       pending.push(...changes);
@@ -242,126 +180,41 @@ export const useRealtimeUpdates = () => {
       }, FRAME_DEBOUNCE_MS);
     };
 
-    const scheduleReconnect = (delayMs = 2000) => {
-      if (!isActive || reconnectTimerRef.current !== null) {
-        return;
-      }
-      reconnectTimerRef.current = window.setTimeout(() => {
-        reconnectTimerRef.current = null;
-        connect();
-      }, delayMs);
-    };
-
-    const connect = () => {
-      if (!isActive) {
-        return;
-      }
-      const wsUrl = buildWebsocketUrl(guildId);
-      if (!wsUrl) {
-        scheduleReconnect();
-        return;
-      }
-      const websocket = new WebSocket(wsUrl);
-      websocket.binaryType = "arraybuffer";
-      websocketRef.current = websocket;
-
-      websocket.onopen = () => {
-        // Send auth message immediately after connection (token not in URL for
-        // security). The guild id scopes the stream to the active guild.
-        sendAuthMessage(
-          websocket,
-          token,
-          carriedUntil === null ? null : (Date.now() - carriedUntil) / 1000
-        );
-        // Reset failure count on successful connection
-        authFailureCountRef.current = 0;
-        lastFrameAt = Date.now();
-      };
-
-      websocket.onmessage = (event) => {
-        // Any frame is proof the socket carries, whatever it says. A beat says
-        // only that, and needs nothing below.
-        lastFrameAt = Date.now();
-        carriedUntil = lastFrameAt;
-        try {
-          // A content-free invalidation bus: every frame is one transaction's
-          // worth of {resource, parents, action}, never a serialized model. We
-          // read the identifiers and refetch through the normal (RLS + DAC
-          // gated) REST path — that refetch is the authorization gate.
-          const payload = JSON.parse(event.data) as {
-            changes?: RealtimeChange[];
-            more?: boolean;
-          };
-          if (payload.more) {
-            // A write too large to name row by row — an import, a purge. The
-            // frame says so instead of carrying thousands of ids, and the
-            // answer is to read the guild again.
-            void invalidate(q.guildContent());
-            return;
-          }
-          const changes = payload.changes ?? [];
-          if (changes.length) {
-            enqueue(changes);
-          }
-        } catch {
-          // ignore malformed messages
-        }
-      };
-
-      websocket.onerror = () => {
-        websocket.close();
-      };
-
-      websocket.onclose = (event) => {
-        if (websocketRef.current === websocket) {
-          websocketRef.current = null;
-        }
-        // WS_1008_POLICY_VIOLATION (1008) indicates auth failure (403)
-        if (event.code === 1008) {
-          authFailureCountRef.current += 1;
-          // After 3 consecutive auth failures, stop trying and log out
-          if (authFailureCountRef.current >= 3) {
-            console.warn("WebSocket auth failed repeatedly, logging out");
-            logout();
-            return;
-          }
-          // Use exponential backoff for auth failures
-          scheduleReconnect(Math.min(30000, 2000 * 2 ** authFailureCountRef.current));
+    const connection = openLiveSocket({
+      url: wsUrl,
+      // The guild is in the address, so the frame carries the credential and
+      // the gap this tab is asking to have answered.
+      auth: (awaySeconds) =>
+        awaySeconds === null ? { token } : { token, away_seconds: awaySeconds },
+      onFrame: (payload) => {
+        // A content-free invalidation bus: every frame is one transaction's
+        // worth of {resource, parents, action}, never a serialized model. We
+        // read the identifiers and refetch through the normal (RLS + DAC
+        // gated) REST path — that refetch is the authorization gate.
+        const frame = payload as { changes?: RealtimeChange[]; more?: boolean };
+        if (frame.more) {
+          // A write too large to name row by row — an import, a purge — or a
+          // gap this socket was away for. Either way the frame says so instead
+          // of carrying ids, and the answer is to read the guild again.
+          void invalidate(q.guildContent());
           return;
         }
-        scheduleReconnect();
-      };
-    };
-
-    connect();
-
-    // A socket that has gone quiet past the server's beat is closed rather than
-    // trusted. Closing is what starts the reconnect, which is what asks the
-    // server whether anything moved in the meantime.
-    const silenceCheck = window.setInterval(() => {
-      const socket = websocketRef.current;
-      if (!socket || socket.readyState !== WebSocket.OPEN) {
-        return;
-      }
-      if (Date.now() - lastFrameAt > SERVER_SILENCE_LIMIT_MS) {
-        socket.close();
-      }
-    }, SILENCE_CHECK_INTERVAL_MS);
+        const changes = frame.changes ?? [];
+        if (changes.length) {
+          enqueue(changes);
+        }
+      },
+      onAuthRejected: () => {
+        console.warn("WebSocket auth failed repeatedly, logging out");
+        logout();
+      },
+    });
 
     return () => {
-      isActive = false;
-      window.clearInterval(silenceCheck);
+      connection.close();
       if (frameTimer !== null) {
         window.clearTimeout(frameTimer);
         frameTimer = null;
-      }
-      if (reconnectTimerRef.current) {
-        window.clearTimeout(reconnectTimerRef.current);
-        reconnectTimerRef.current = null;
-      }
-      if (websocketRef.current) {
-        websocketRef.current.close();
-        websocketRef.current = null;
       }
     };
   }, [token, userId, routeGuildId, logout]);

--- a/frontend/src/lib/liveSocket.ts
+++ b/frontend/src/lib/liveSocket.ts
@@ -1,0 +1,188 @@
+/**
+ * One authenticated WebSocket, kept open.
+ *
+ * Both push channels — the per-guild events bus and the personal notification
+ * stream — need the same connection underneath: authenticate in the first
+ * frame, reconnect with backoff, stop for good once the credential has been
+ * rejected repeatedly, and notice a socket that has stopped carrying without
+ * ever closing. There is no library behind any of that, so it was written
+ * twice; this is the one copy.
+ *
+ * What differs between the two channels sits above it — which address, what
+ * else rides in the auth frame, and what a frame means — and that is the whole
+ * of the options.
+ */
+
+// Must match the backend's MSG_AUTH. The token rides in the first frame rather
+// than the URL, so it never lands in a proxy or server access log.
+const MSG_AUTH = 5;
+
+const RECONNECT_DELAY_MS = 2000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+// Three consecutive policy-violation closes means the credential is no good,
+// not that the network blinked.
+const MAX_AUTH_FAILURES = 3;
+
+// The server says something every 30s even with no news (its
+// HEARTBEAT_SECONDS), so silence past a couple of those is the socket having
+// stopped carrying rather than nothing having happened. A dropped connection
+// does not always close: a suspended laptop, a network that goes away
+// mid-flight and a NAT timeout all leave one reporting itself open and
+// delivering nothing.
+const SERVER_SILENCE_LIMIT_MS = 90_000;
+// How often that is checked. Cheap: a comparison against a timestamp.
+const SILENCE_CHECK_INTERVAL_MS = 15_000;
+
+export type LiveSocket = {
+  /** Send on the socket if one is open; a no-op otherwise. */
+  send: (data: Uint8Array<ArrayBuffer>) => void;
+  /** Stop reconnecting and close. */
+  close: () => void;
+};
+
+export type LiveSocketOptions = {
+  url: string;
+  /**
+   * The first frame's payload.
+   *
+   * `awaySeconds` is how long this tab went without a socket that was
+   * carrying, or null if it has never had one — which is what lets a server
+   * answer whether anything moved in the meantime. A first connect asks for
+   * nothing, having fetched as it mounted.
+   */
+  auth: (awaySeconds: number | null) => Record<string, unknown>;
+  /** One parsed frame. Malformed frames never reach it. */
+  onFrame: (payload: unknown) => void;
+  /** True when a socket opens, false when one closes. */
+  onStatus?: (connected: boolean) => void;
+  /** The credential was rejected repeatedly; nothing further is attempted. */
+  onAuthRejected?: () => void;
+};
+
+export const openLiveSocket = ({
+  url,
+  auth,
+  onFrame,
+  onStatus,
+  onAuthRejected,
+}: LiveSocketOptions): LiveSocket => {
+  let socket: WebSocket | null = null;
+  let reconnectTimer: number | null = null;
+  let active = true;
+  let authFailures = 0;
+  // The last frame this socket saw, which is what silence is measured against.
+  // Reset on open so a fresh socket is not closed for its predecessor's quiet.
+  let lastFrameAt = Date.now();
+  // The last frame received on ANY socket here, which is the last proof this
+  // tab was being carried. Only a frame moves it: an attempt that opens and
+  // dies before hearing anything has proved nothing, and must not shorten the
+  // gap the next attempt reports.
+  let carriedUntil: number | null = null;
+
+  const scheduleReconnect = (delayMs = RECONNECT_DELAY_MS) => {
+    if (!active || reconnectTimer !== null) {
+      return;
+    }
+    reconnectTimer = window.setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, delayMs);
+  };
+
+  const connect = () => {
+    if (!active) {
+      return;
+    }
+    let next: WebSocket;
+    try {
+      next = new WebSocket(url);
+    } catch {
+      scheduleReconnect();
+      return;
+    }
+    next.binaryType = "arraybuffer";
+    socket = next;
+
+    next.onopen = () => {
+      const away = carriedUntil === null ? null : (Date.now() - carriedUntil) / 1000;
+      const payload = new TextEncoder().encode(JSON.stringify(auth(away)));
+      const frame = new Uint8Array(1 + payload.length);
+      frame[0] = MSG_AUTH;
+      frame.set(payload, 1);
+      next.send(frame);
+      authFailures = 0;
+      lastFrameAt = Date.now();
+      onStatus?.(true);
+    };
+
+    next.onmessage = (event) => {
+      // Any frame is proof the socket carries, whatever it says.
+      lastFrameAt = Date.now();
+      carriedUntil = lastFrameAt;
+      let payload: unknown;
+      try {
+        payload = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+      onFrame(payload);
+    };
+
+    next.onerror = () => {
+      next.close();
+    };
+
+    next.onclose = (event) => {
+      if (socket === next) {
+        socket = null;
+      }
+      onStatus?.(false);
+      // WS_1008_POLICY_VIOLATION — the credential was rejected.
+      if (event.code === 1008) {
+        authFailures += 1;
+        if (authFailures >= MAX_AUTH_FAILURES) {
+          onAuthRejected?.();
+          return;
+        }
+        scheduleReconnect(Math.min(MAX_RECONNECT_DELAY_MS, RECONNECT_DELAY_MS * 2 ** authFailures));
+        return;
+      }
+      scheduleReconnect();
+    };
+  };
+
+  connect();
+
+  // A socket that has gone quiet past the server's beat is closed rather than
+  // trusted. Closing is what starts the reconnect, which is what asks the
+  // server whether anything moved in the meantime.
+  const silenceCheck = window.setInterval(() => {
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    if (Date.now() - lastFrameAt > SERVER_SILENCE_LIMIT_MS) {
+      socket.close();
+    }
+  }, SILENCE_CHECK_INTERVAL_MS);
+
+  return {
+    send: (data) => {
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(data);
+      }
+    },
+    close: () => {
+      active = false;
+      window.clearInterval(silenceCheck);
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (socket) {
+        socket.close();
+        socket = null;
+      }
+    },
+  };
+};


### PR DESCRIPTION
Decision 4 of `realtime-catchup-design.md`, deferred out of #1482 and picked up now.

## Problem

The events bus and the notification stream each hand-rolled the same connection, about ninety lines apiece and verbatim between them:

- `scheduleReconnect(delayMs)` with the `isActive` / in-flight-timer guard
- the `connect()` scaffolding — construct, `binaryType`, stash the ref
- the auth handshake: `[MSG_AUTH, ...utf8 json]` as the first frame, reset the failure count
- `onclose`: count 1008s, give up at three, exponential backoff otherwise
- the silence watchdog added in #1482, and its `lastFrameAt`
- the teardown: clear the interval, clear the reconnect timer, close the socket

There is no library behind any of it — this is a state machine we own — so the second copy existed only because nobody had pulled the first one out. #1482 made that worse by adding the watchdog and the gap measurement to both sides.

## Changes

`lib/liveSocket.ts` holds the machine once. `openLiveSocket({...})` returns `{ send, close }`, so a hook's effect ends `return () => connection.close()`.

What differs between the two channels sits above it, and is the whole of the options:

| | events | notifications |
|---|---|---|
| `url` | `/g/{id}/events/updates` | `/notifications/stream` |
| `auth(awaySeconds)` | `{ token, away_seconds }` | `{ token }` |
| `onFrame` | changes → debounced invalidation | resource → per-channel refetch |
| `onStatus` | — | drives the bell's poll fallback, and resyncs on the way up |
| `onAuthRejected` | `logout()` | — (the bell falls back to polling) |

Both hooks lose `websocketRef`, `reconnectTimerRef` and `authFailureCountRef` entirely, along with their own `sendAuthMessage`. `useRealtimeUpdates` keeps only the frame debounce; `useNotificationStream` keeps only the activity byte and the account-retry ramp, both of which are its own concern rather than the connection's.

**720 lines to 639**, and `liveSocket.ts` is about a third comment and types, so the logic dedup is larger than the net. The more useful number is that the gap measurement `away_seconds` is built from now has one implementation instead of one plus a channel that never got it — notifications resyncs unconditionally on every reopen today, and can stop doing that the day its endpoint reads the field, with no client change.

## On the shape

There's a standing preference here against config-object generics over React Query's own lifecycle. This is deliberately not that: React Query's `onMutate`/`onError` are a library's designed extension surface, and wrapping them creates a third idiom to choose between. A WebSocket has no such surface — the reconnect/backoff/give-up/watchdog machine is ours either way, and the only question was whether we keep one of it or two. This is the "structural refactor that makes the duplication impossible" case rather than the "helper that dedupes lines" one.

## Testing

Behaviour-preserving, and the evidence is that **no test changed**:

```
pnpm vitest run src/hooks/useRealtimeUpdates.test.tsx        # 34 passed
pnpm vitest run src/hooks/useNotificationStream.test.tsx     # 21 passed
pnpm vitest run src/components/notifications/NotificationBell.test.tsx  # 14 passed
tsc --noEmit                                                 # clean
```

Those 69 tests already drive the lifecycle end to end — auth frame shape, reconnect timing, the three-1008 give-up, the silence close, and the reported gap — through the shared `MockWebSocket`, so they cover the new module without a separate unit test for it.

No changelog entry: no user-visible change.