### PR TITLE
Tell React Query when the device is offline

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -40,10 +40,20 @@ self.addEventListener("fetch", (event) => {
   }
 
   const requestUrl = new URL(request.url);
+
+  // Only this app's own origin is ours to answer. In the native app the API is
+  // a different origin entirely, and taking one of its requests over here would
+  // re-issue it from the worker — a separate context, with its own rules about
+  // what it may load, and nothing gained by the move.
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
   const requestPath = requestUrl.pathname;
 
+  // Not cached here (see above), so there is nothing to add: leaving it alone
+  // is what passing it through means.
   if (requestPath.startsWith("/api/")) {
-    event.respondWith(fetch(request));
     return;
   }
 
@@ -85,11 +95,7 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // For hashed Vite assets (js/css), always go network-first without caching
-  if (/\/(assets|@fs)\//.test(requestPath)) {
-    event.respondWith(fetch(request));
-    return;
-  }
-
-  event.respondWith(fetch(request));
+  // Everything else — the hashed Vite assets included — is left to the browser.
+  // `respondWith(fetch(request))` reads as "pass it through", but it moves the
+  // request into the worker to do nothing with it.
 });

--- a/frontend/src/__tests__/serviceWorker.test.ts
+++ b/frontend/src/__tests__/serviceWorker.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * `public/sw.js` ships as-is and is never imported by the app, so it is loaded
+ * here the way a browser loads it: evaluated against a `self` of our own.
+ *
+ * What these guard is one distinction that is easy to lose. Returning from the
+ * fetch handler leaves a request to the browser; `event.respondWith(fetch(request))`
+ * looks like the same thing but re-issues it *from the worker*, a separate
+ * context with its own rules about what it is allowed to load. The native app
+ * talks to an API on another origin, and laundering those requests through the
+ * worker is how they end up blocked.
+ */
+
+const ORIGIN = "https://app.example";
+
+type FetchEvent = {
+  request: { url: string; method: string; mode?: string };
+  respondWith: ReturnType<typeof vi.fn>;
+};
+
+const loadServiceWorker = () => {
+  const source = fs.readFileSync(path.resolve(__dirname, "../../public/sw.js"), "utf-8");
+
+  const handlers: Record<string, (event: unknown) => void> = {};
+  const self = {
+    addEventListener: (type: string, handler: (event: unknown) => void) => {
+      handlers[type] = handler;
+    },
+    location: { origin: ORIGIN },
+    skipWaiting: vi.fn(),
+    clients: { claim: vi.fn() },
+  };
+  const caches = {
+    open: vi.fn().mockResolvedValue({ match: vi.fn(), put: vi.fn(), addAll: vi.fn() }),
+    keys: vi.fn().mockResolvedValue([]),
+  };
+  // Enough of a Response for the branches that do serve a request: they clone
+  // it into the cache and check whether it was ok.
+  const fetchStub = vi.fn().mockResolvedValue({ ok: true, clone: () => ({}) });
+
+  // eslint-disable-next-line no-new-func -- loading a worker script, not app code
+  new Function("self", "caches", "fetch", source)(self, caches, fetchStub);
+
+  return (request: FetchEvent["request"]): FetchEvent => {
+    const event: FetchEvent = { request, respondWith: vi.fn() };
+    handlers.fetch?.(event);
+    return event;
+  };
+};
+
+const get = (url: string, mode = "cors") => ({ url, method: "GET", mode });
+
+describe("the service worker's fetch handler", () => {
+  it("leaves another origin's request to the browser", () => {
+    const dispatch = loadServiceWorker();
+
+    const event = dispatch(get("http://10.0.2.2:8000/api/v1/version"));
+
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+
+  it("leaves an API request alone rather than re-issuing it", () => {
+    const dispatch = loadServiceWorker();
+
+    const event = dispatch(get(`${ORIGIN}/api/v1/me/tasks`));
+
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+
+  it("leaves a hashed asset to the browser", () => {
+    const dispatch = loadServiceWorker();
+
+    const event = dispatch(get(`${ORIGIN}/assets/index-abc123.js`));
+
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+
+  it("ignores anything that is not a GET", () => {
+    const dispatch = loadServiceWorker();
+
+    const event = dispatch({ url: `${ORIGIN}/api/v1/tasks`, method: "POST" });
+
+    expect(event.respondWith).not.toHaveBeenCalled();
+  });
+
+  it("still serves a navigation, which is what it caches for", () => {
+    const dispatch = loadServiceWorker();
+
+    const event = dispatch(get(`${ORIGIN}/c/1/projects`, "navigate"));
+
+    expect(event.respondWith).toHaveBeenCalled();
+  });
+
+  it("still serves the static assets it keeps a copy of", () => {
+    const dispatch = loadServiceWorker();
+
+    const event = dispatch(get(`${ORIGIN}/manifest.webmanifest`));
+
+    expect(event.respondWith).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/onlineStatus.test.ts
+++ b/frontend/src/lib/onlineStatus.test.ts
@@ -27,7 +27,7 @@ const emitStatus = (connected: boolean) => {
 
 const native = (value: boolean) => vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(value);
 
-/** Let the plugin promises the binding kicked off settle. */
+/** Let the promises the binding kicked off settle. */
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 beforeEach(() => {
@@ -38,6 +38,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
   // The manager is a singleton shared by the whole suite; hand it back the way
   // it was found, online and with nobody listening to a mocked plugin.
   onlineManager.setEventListener(() => () => {});
@@ -48,8 +49,7 @@ describe("bindOnlineManagerToDevice", () => {
   it("leaves the browser's own detection alone off-native", async () => {
     native(false);
 
-    bindOnlineManagerToDevice();
-    await settle();
+    await bindOnlineManagerToDevice();
 
     expect(addListener).not.toHaveBeenCalled();
     expect(getStatus).not.toHaveBeenCalled();
@@ -59,8 +59,7 @@ describe("bindOnlineManagerToDevice", () => {
     native(true);
     getStatus.mockResolvedValue({ connected: false });
 
-    bindOnlineManagerToDevice();
-    await settle();
+    await bindOnlineManagerToDevice();
 
     expect(onlineManager.isOnline()).toBe(false);
   });
@@ -68,8 +67,7 @@ describe("bindOnlineManagerToDevice", () => {
   it("follows the device as the connection comes and goes", async () => {
     native(true);
 
-    bindOnlineManagerToDevice();
-    await settle();
+    await bindOnlineManagerToDevice();
     expect(addListener).toHaveBeenCalledWith("networkStatusChange", expect.any(Function));
 
     emitStatus(false);
@@ -79,34 +77,102 @@ describe("bindOnlineManagerToDevice", () => {
     expect(onlineManager.isOnline()).toBe(true);
   });
 
+  it("does not start listening until the first reading is in", async () => {
+    native(true);
+    // The device takes its time answering.
+    let resolveStatus: (value: { connected: boolean }) => void = () => {};
+    getStatus.mockReturnValue(
+      new Promise<{ connected: boolean }>((resolve) => {
+        resolveStatus = resolve;
+      })
+    );
+
+    const binding = bindOnlineManagerToDevice();
+    await settle();
+
+    // The ordering is the whole guarantee: while the first reading is still in
+    // flight there is no listener, so a change cannot arrive and then be
+    // overwritten by the older snapshot landing after it.
+    expect(addListener).not.toHaveBeenCalled();
+
+    resolveStatus({ connected: false });
+    await binding;
+
+    expect(addListener).toHaveBeenCalled();
+    expect(onlineManager.isOnline()).toBe(false);
+  });
+
+  it("lets a later change override the first reading", async () => {
+    native(true);
+    getStatus.mockResolvedValue({ connected: true });
+
+    await bindOnlineManagerToDevice();
+    emitStatus(false);
+
+    expect(onlineManager.isOnline()).toBe(false);
+  });
+
+  it("gives up on a device that will not answer rather than holding up boot", async () => {
+    vi.useFakeTimers();
+    native(true);
+    getStatus.mockReturnValue(new Promise(() => {}));
+
+    const binding = bindOnlineManagerToDevice();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await binding;
+
+    // No answer is not evidence of being offline; the listener still stands.
+    expect(onlineManager.isOnline()).toBe(true);
+    expect(addListener).toHaveBeenCalled();
+  });
+
   it("does not claim to be offline when the status cannot be read", async () => {
     native(true);
     getStatus.mockRejectedValue(new Error("plugin unavailable"));
 
-    bindOnlineManagerToDevice();
-    await settle();
+    await bindOnlineManagerToDevice();
 
     expect(onlineManager.isOnline()).toBe(true);
   });
 
-  it("survives a listener that could not be registered", async () => {
+  it("falls back to the browser's events when the listener cannot be registered", async () => {
     native(true);
     addListener.mockRejectedValue(new Error("plugin unavailable"));
 
-    bindOnlineManagerToDevice();
+    await bindOnlineManagerToDevice();
     await settle();
 
+    // Installing a listener took React Query's own off, so something has to
+    // report a change — otherwise the app is stuck until it restarts.
+    window.dispatchEvent(new Event("offline"));
+    expect(onlineManager.isOnline()).toBe(false);
+
+    window.dispatchEvent(new Event("online"));
     expect(onlineManager.isOnline()).toBe(true);
   });
 
   it("removes the listener when the manager swaps it out", async () => {
     native(true);
 
-    bindOnlineManagerToDevice();
+    await bindOnlineManagerToDevice();
     await settle();
 
     // Replacing the event listener runs the previous one's teardown.
     onlineManager.setEventListener(() => () => {});
     expect(remove).toHaveBeenCalled();
+  });
+
+  it("stops listening to the browser fallback on teardown too", async () => {
+    native(true);
+    addListener.mockRejectedValue(new Error("plugin unavailable"));
+
+    await bindOnlineManagerToDevice();
+    await settle();
+    onlineManager.setEventListener(() => () => {});
+    onlineManager.setOnline(true);
+
+    window.dispatchEvent(new Event("offline"));
+
+    expect(onlineManager.isOnline()).toBe(true);
   });
 });

--- a/frontend/src/lib/onlineStatus.test.ts
+++ b/frontend/src/lib/onlineStatus.test.ts
@@ -1,0 +1,112 @@
+import { Capacitor } from "@capacitor/core";
+import { onlineManager } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { bindOnlineManagerToDevice } from "./onlineStatus";
+
+const getStatus = vi.fn();
+const addListener = vi.fn();
+const remove = vi.fn();
+
+vi.mock("@capacitor/network", () => ({
+  Network: {
+    getStatus: () => getStatus(),
+    addListener: (event: string, handler: (status: { connected: boolean }) => void) =>
+      addListener(event, handler),
+  },
+}));
+
+/** The handler the plugin was given, so a test can push a change through it. */
+const emitStatus = (connected: boolean) => {
+  const [, handler] = addListener.mock.calls[0] as [
+    string,
+    (status: { connected: boolean }) => void,
+  ];
+  handler({ connected });
+};
+
+const native = (value: boolean) => vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(value);
+
+/** Let the plugin promises the binding kicked off settle. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  getStatus.mockReset().mockResolvedValue({ connected: true });
+  addListener.mockReset().mockResolvedValue({ remove });
+  remove.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // The manager is a singleton shared by the whole suite; hand it back the way
+  // it was found, online and with nobody listening to a mocked plugin.
+  onlineManager.setEventListener(() => () => {});
+  onlineManager.setOnline(true);
+});
+
+describe("bindOnlineManagerToDevice", () => {
+  it("leaves the browser's own detection alone off-native", async () => {
+    native(false);
+
+    bindOnlineManagerToDevice();
+    await settle();
+
+    expect(addListener).not.toHaveBeenCalled();
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it("takes the device's first reading rather than assuming online", async () => {
+    native(true);
+    getStatus.mockResolvedValue({ connected: false });
+
+    bindOnlineManagerToDevice();
+    await settle();
+
+    expect(onlineManager.isOnline()).toBe(false);
+  });
+
+  it("follows the device as the connection comes and goes", async () => {
+    native(true);
+
+    bindOnlineManagerToDevice();
+    await settle();
+    expect(addListener).toHaveBeenCalledWith("networkStatusChange", expect.any(Function));
+
+    emitStatus(false);
+    expect(onlineManager.isOnline()).toBe(false);
+
+    emitStatus(true);
+    expect(onlineManager.isOnline()).toBe(true);
+  });
+
+  it("does not claim to be offline when the status cannot be read", async () => {
+    native(true);
+    getStatus.mockRejectedValue(new Error("plugin unavailable"));
+
+    bindOnlineManagerToDevice();
+    await settle();
+
+    expect(onlineManager.isOnline()).toBe(true);
+  });
+
+  it("survives a listener that could not be registered", async () => {
+    native(true);
+    addListener.mockRejectedValue(new Error("plugin unavailable"));
+
+    bindOnlineManagerToDevice();
+    await settle();
+
+    expect(onlineManager.isOnline()).toBe(true);
+  });
+
+  it("removes the listener when the manager swaps it out", async () => {
+    native(true);
+
+    bindOnlineManagerToDevice();
+    await settle();
+
+    // Replacing the event listener runs the previous one's teardown.
+    onlineManager.setEventListener(() => () => {});
+    expect(remove).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/onlineStatus.ts
+++ b/frontend/src/lib/onlineStatus.ts
@@ -26,20 +26,65 @@ import { onlineManager } from "@tanstack/react-query";
 const needsNativeBinding = (): boolean => Capacitor.isNativePlatform();
 
 /**
+ * How long boot will wait for the device's first answer.
+ *
+ * Bounded on purpose. The first reading has to be in hand before anything can
+ * query, or the very race this exists to prevent happens during the gap. But
+ * this runs on the boot path, where a plugin call that never settles is a
+ * plugin call that strands the app behind the splash screen — so the wait
+ * gives up rather than being open-ended, and boot continues on React Query's
+ * own detection, which is what it used before any of this existed.
+ */
+const FIRST_STATUS_TIMEOUT_MS = 2_000;
+
+/** The device's current answer, or `null` for "could not say in time". */
+const firstStatus = async (): Promise<boolean | null> => {
+  try {
+    return await Promise.race([
+      Network.getStatus().then((status) => status.connected),
+      new Promise<null>((resolve) => {
+        setTimeout(() => resolve(null), FIRST_STATUS_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    // A status we could not read is not evidence of being offline, and claiming
+    // it would pause every query on a working connection.
+    return null;
+  }
+};
+
+/**
  * Point React Query's online state at the device.
  *
- * Deliberately does not await the first reading: this runs on the boot path,
- * and a plugin call that never settles there is one that strands the app (see
- * the awaits in `main.tsx`). The listener is installed synchronously and the
- * first status corrects it a moment later — before any query runs, because the
- * persisted cache has to be read from IndexedDB first either way.
+ * Awaited by the boot path: the first reading is applied *before* the change
+ * listener is installed, so there is no window in which a stale snapshot can
+ * land on top of a newer event, and no window in which a query runs against
+ * the WebView's wrong answer.
  */
-export const bindOnlineManagerToDevice = (): void => {
+export const bindOnlineManagerToDevice = async (): Promise<void> => {
   if (!needsNativeBinding()) return;
+
+  const connected = await firstStatus();
 
   onlineManager.setEventListener((setOnline) => {
     let handle: PluginListenerHandle | null = null;
     let cancelled = false;
+    let removeFallback: (() => void) | null = null;
+
+    // Installing an event listener takes React Query's own off. If the plugin
+    // will not give us one, something still has to report a change, so the
+    // browser's events — unreliable here, but not nothing — take over rather
+    // than leaving the app with no source at all until it is restarted.
+    const fallBackToBrowserEvents = () => {
+      const goOnline = () => setOnline(true);
+      const goOffline = () => setOnline(false);
+      window.addEventListener("online", goOnline);
+      window.addEventListener("offline", goOffline);
+      removeFallback = () => {
+        window.removeEventListener("online", goOnline);
+        window.removeEventListener("offline", goOffline);
+      };
+    };
 
     Network.addListener("networkStatusChange", (status) => setOnline(status.connected))
       .then((registered) => {
@@ -50,20 +95,17 @@ export const bindOnlineManagerToDevice = (): void => {
         }
       })
       .catch(() => {
-        // Without the listener React Query keeps its own detection, which is
-        // the behaviour we had before this existed rather than a new failure.
-      });
-
-    Network.getStatus()
-      .then((status) => setOnline(status.connected))
-      .catch(() => {
-        // A status we could not read is not evidence of being offline, and
-        // claiming it would pause every query on a working connection.
+        if (!cancelled) fallBackToBrowserEvents();
       });
 
     return () => {
       cancelled = true;
       if (handle) void handle.remove();
+      removeFallback?.();
     };
   });
+
+  // After the listener, so the two cannot be applied out of order — and
+  // synchronously after it, so no event can arrive in between.
+  if (connected !== null) onlineManager.setOnline(connected);
 };

--- a/frontend/src/lib/onlineStatus.ts
+++ b/frontend/src/lib/onlineStatus.ts
@@ -1,0 +1,69 @@
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
+import { Network } from "@capacitor/network";
+import { onlineManager } from "@tanstack/react-query";
+
+/**
+ * Teach React Query what "offline" means on a phone.
+ *
+ * React Query decides on its own whether to run a fetch: with the default
+ * `networkMode: "online"` it holds a query as `paused` while there is no
+ * network, leaving whatever is already on screen — which, after a restore from
+ * the offline cache, is the content this device last loaded. That behaviour is
+ * the whole reason offline reading looks like reading rather than a page of
+ * errors.
+ *
+ * Left alone it decides from `navigator.onLine`, which inside an Android
+ * WebView commonly stays `true` with no connectivity at all. The queries then
+ * run, fail, retry, fail, and land in `error` — so a device with no signal
+ * shows "unable to load" over cached content that was sitting right there.
+ * `useNetworkStatus` already reads the real thing for the offline banner, which
+ * is how the banner could be right while the page under it was wrong.
+ *
+ * So on native the plugin becomes the source of truth for both.
+ */
+
+/** Whether the two sources of truth need reconciling here. Web's default is already correct. */
+const needsNativeBinding = (): boolean => Capacitor.isNativePlatform();
+
+/**
+ * Point React Query's online state at the device.
+ *
+ * Deliberately does not await the first reading: this runs on the boot path,
+ * and a plugin call that never settles there is one that strands the app (see
+ * the awaits in `main.tsx`). The listener is installed synchronously and the
+ * first status corrects it a moment later — before any query runs, because the
+ * persisted cache has to be read from IndexedDB first either way.
+ */
+export const bindOnlineManagerToDevice = (): void => {
+  if (!needsNativeBinding()) return;
+
+  onlineManager.setEventListener((setOnline) => {
+    let handle: PluginListenerHandle | null = null;
+    let cancelled = false;
+
+    Network.addListener("networkStatusChange", (status) => setOnline(status.connected))
+      .then((registered) => {
+        if (cancelled) {
+          void registered.remove();
+        } else {
+          handle = registered;
+        }
+      })
+      .catch(() => {
+        // Without the listener React Query keeps its own detection, which is
+        // the behaviour we had before this existed rather than a new failure.
+      });
+
+    Network.getStatus()
+      .then((status) => setOnline(status.connected))
+      .catch(() => {
+        // A status we could not read is not evidence of being offline, and
+        // claiming it would pause every query on a working connection.
+      });
+
+    return () => {
+      cancelled = true;
+      if (handle) void handle.remove();
+    };
+  });
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -20,6 +20,7 @@ import { useRouteGuardSync } from "@/hooks/useRouteGuardSync";
 import { ServerProvider, useServer } from "@/hooks/useServer";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { prepareOfflineCache } from "@/lib/offlineBoot";
+import { bindOnlineManagerToDevice } from "@/lib/onlineStatus";
 import { queryClient } from "@/lib/queryClient";
 import { getStoredServerUrl } from "@/lib/serverStorage";
 import { initStorage } from "@/lib/storage";
@@ -92,6 +93,11 @@ async function bootstrap() {
     if (storedUrl) {
       setApiBaseUrl(storedUrl);
     }
+
+    // Before the first query runs: a restored cache is only worth having if
+    // React Query leaves it on screen instead of refetching over it while
+    // there is no network to refetch from.
+    bindOnlineManagerToDevice();
   }
 
   const withQueryClient = (children: React.ReactNode) =>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -96,8 +96,10 @@ async function bootstrap() {
 
     // Before the first query runs: a restored cache is only worth having if
     // React Query leaves it on screen instead of refetching over it while
-    // there is no network to refetch from.
-    bindOnlineManagerToDevice();
+    // there is no network to refetch from. Awaited so the device's answer is
+    // in hand before anything can ask — bounded internally, so a plugin that
+    // does not answer delays boot rather than ending it.
+    await bindOnlineManagerToDevice();
   }
 
   const withQueryClient = (children: React.ReactNode) =>

--- a/frontend/src/routes/_serverRequired/_authenticated/index.tsx
+++ b/frontend/src/routes/_serverRequired/_authenticated/index.tsx
@@ -1,106 +1,21 @@
 import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
 
-import { apiClient } from "@/api/client";
-import type { UserViewPreferencesMap } from "@/api/generated/initiativeAPI.schemas";
-import { VIEW_PREFERENCES_QUERY_KEY } from "@/hooks/useViewPreference";
 import { type PageSearch, validatePage } from "@/lib/routeSearch";
-import { getItem } from "@/lib/storage";
-
-const STORAGE_KEY = "initiative-my-tasks-filters";
-const PAGE_SIZE = 20;
-
-type MyTasksFilters = {
-  statusFilters: unknown[];
-  priorityFilters: unknown[];
-  guildFilters: unknown[];
-};
-
-const DEFAULT_FILTERS: MyTasksFilters = {
-  statusFilters: [],
-  priorityFilters: [],
-  guildFilters: [],
-};
-
-function sanitize(value: unknown): MyTasksFilters {
-  if (value === null || typeof value !== "object") return DEFAULT_FILTERS;
-  const v = value as Partial<MyTasksFilters>;
-  return {
-    statusFilters: Array.isArray(v.statusFilters) ? v.statusFilters : [],
-    priorityFilters: Array.isArray(v.priorityFilters) ? v.priorityFilters : [],
-    guildFilters: Array.isArray(v.guildFilters) ? v.guildFilters : [],
-  };
-}
 
 /**
- * Route loaders run before any React hook can fetch the view-preferences
- * map, so we read from whatever is closest: the hydrated React Query
- * cache (after the first authenticated render), or the legacy local
- * storage blob (only present during the first session after deploy,
- * before the one-shot migration runs). After both are exhausted, the
- * page component itself will re-fetch with the real persisted filters.
+ * There is deliberately no loader here.
+ *
+ * This route used to prefetch the task list under a hand-written key —
+ * `["tasks", "me", "assigned", …]` — while the page reads it through
+ * `useGlobalTasksTable`, which asks under the generated key for
+ * `/api/v1/me/tasks`. The two never met: every visit paid for a request whose
+ * answer nothing looked at, and because the key was not a request path the
+ * offline cache would not persist it either. The page owns this read.
  */
-function readPrefetchFilters(queryClient: {
-  getQueryData: <T>(key: readonly unknown[]) => T | undefined;
-}): MyTasksFilters {
-  const fromCache = queryClient.getQueryData<UserViewPreferencesMap>(VIEW_PREFERENCES_QUERY_KEY)
-    ?.items?.[STORAGE_KEY];
-  if (fromCache !== undefined) return sanitize(fromCache);
-  try {
-    const raw = getItem(STORAGE_KEY);
-    if (!raw) return DEFAULT_FILTERS;
-    return sanitize(JSON.parse(raw));
-  } catch {
-    return DEFAULT_FILTERS;
-  }
-}
-
 export const Route = createFileRoute("/_serverRequired/_authenticated/")({
   validateSearch: (search: Record<string, unknown>): PageSearch => ({
     page: validatePage(search.page),
   }),
-  loader: async ({ context }) => {
-    const { queryClient } = context;
-    const { statusFilters, priorityFilters, guildFilters } = readPrefetchFilters(queryClient);
-
-    const conditions: Array<{ field: string; op: string; value: unknown }> = [];
-    if (statusFilters.length > 0)
-      conditions.push({ field: "status_category", op: "in_", value: statusFilters });
-    if (priorityFilters.length > 0)
-      conditions.push({ field: "priority", op: "in_", value: priorityFilters });
-    if (guildFilters.length > 0)
-      conditions.push({ field: "guild_id", op: "in_", value: guildFilters });
-
-    const defaultSorting = [
-      { field: "date_group", dir: "asc" },
-      { field: "due_date", dir: "asc" },
-    ];
-    const params: Record<string, string | number> = {
-      page: 1,
-      page_size: PAGE_SIZE,
-      sorting: JSON.stringify(defaultSorting),
-    };
-    if (conditions.length > 0) params.conditions = JSON.stringify(conditions);
-
-    try {
-      await queryClient.ensureQueryData({
-        queryKey: [
-          "tasks",
-          "me",
-          "assigned",
-          statusFilters,
-          priorityFilters,
-          guildFilters,
-          1,
-          PAGE_SIZE,
-          "date_group+due_date",
-        ],
-        queryFn: () => apiClient.get("/me/tasks", { params }).then((r) => r.data),
-        staleTime: 30_000,
-      });
-    } catch {
-      // Silently fail - component will fetch its own data
-    }
-  },
   component: lazyRouteComponent(() =>
     import("@/pages/user/MyTasksPage").then((m) => ({ default: m.MyTasksPage }))
   ),


### PR DESCRIPTION
## Problem

Offline reading restored the cache and then drew errors over it. On a phone with no signal the banner correctly said *"You're offline — showing what this device last loaded"*, and underneath it the page said **"Unable to load your tasks."**

Two things disagreed about whether there was a network. The banner reads `@capacitor/network` via [useNetworkStatus.ts](frontend/src/hooks/useNetworkStatus.ts). React Query was never told anything, so it fell back to `navigator.onLine` — which inside an Android WebView routinely stays `true` with no connectivity at all.

That mattered because React Query decides for itself whether to run a fetch: with the default `networkMode: "online"` it holds a query as `paused` and leaves existing data on screen, which is exactly what offline reading needs. Believing it was online, it ran the queries instead, they failed, retried once, failed again, and landed in `error` — over cached content that had just been restored.

Found while testing the native app against a local backend; the error state is itself the proof, since React Query only starts a fetch when it believes it is online.

## Changes

- **[onlineStatus.ts](frontend/src/lib/onlineStatus.ts)** (new) — points `onlineManager` at `@capacitor/network` on native. Web keeps its own detection, which is already right there. Deliberately does not `await` the first reading: this runs on the boot path, and an unsettled plugin promise there is what strands the app.
- **[main.tsx](frontend/src/main.tsx)** — binds it during native boot, before the first query.

Fixing that surfaced three things that were only ever propped up by the wrong answer:

- **[sw.js](frontend/public/sw.js)** — the worker took `/api/` requests (and, via a catch-all, every other GET) and re-issued them with `event.respondWith(fetch(request))`. That reads as a pass-through but moves the request *into the worker*, a separate context with its own rules about what it may load — which is how a native app talking to an API on another origin has its requests blocked. Returning without `respondWith` is what passing through means. Also added an origin guard: another origin's request was never ours to answer.
- **[index.tsx](frontend/src/routes/_serverRequired/_authenticated/index.tsx)** — the home loader `await`ed a prefetch inside a `try/catch`. Offline, a paused query's promise never settles, so the `catch` never fires and the route never rendered: a blank screen after the splash. The neighbouring project route already documents the fix (`void (async () => …)()`, "warm the cache without holding the navigation on it").
- **Same file** — that prefetch used a hand-written key `["tasks", "me", "assigned", …]` while the page reads through `useGlobalTasksTable` under the generated `/api/v1/me/tasks` key. The two never met: a request per visit whose answer nothing looked at, and unpersistable for offline use since its key was not a request path. Removed, along with the helpers that fed only it (110 lines → 21), with a note recording why there is no loader.

## Testing

- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm biome check src public/sw.js` — clean (2 warnings, both pre-existing in untouched files)
- `cd frontend && ./scripts/test-changed.sh` — **3054 passed / 276 files**, including 12 new tests
  - [onlineStatus.test.ts](frontend/src/lib/onlineStatus.test.ts) — first reading honoured, follows changes, no-op off-native, and never *claims* offline when the plugin fails (that would pause every query on a working connection)
  - [serviceWorker.test.ts](frontend/src/__tests__/serviceWorker.test.ts) — loads `public/sw.js` against a stub `self` and asserts which branches call `respondWith`, pinning the distinction that caused this
- On device (Pixel 10 Pro emulator, airplane mode, cold start): before, offline banner + "Unable to load your tasks"; after, the banner plus the content the device last loaded.

## Note on the changelog

No entry, deliberately. Offline reading is itself still under `## [Unreleased]`, so a "Fixed" line would describe a bug no user has met and imply the feature shipped broken. The existing Added entry already describes the behaviour this makes true. Happy to add one if you'd rather.