### PR TITLE
Bind the install tests the only way a binding binds

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards_install_test.py
@@ -30,9 +30,22 @@ WITHDRAWN_UID = marketplace_uid("withdrawn")
 TOO_NEW_UID = marketplace_uid("toonew")
 
 
-def _definition(widget_type: str = "stat", source: str = "task_counts") -> dict:
+def _definition(
+    widget_type: str = "stat", sql: str = "SELECT count(*) AS tasks FROM tasks"
+) -> dict:
+    """A canvas of one widget, bound the only way a binding is bound.
+
+    The statement is checked when a definition is stored, so it has to be one
+    the query surface will run — a listing that ships an unreadable one is not
+    installable, which is a different test from any of these."""
     return {
-        "widgets": [{"id": "w1", "type": widget_type, "binding": {"source": source}}]
+        "widgets": [
+            {
+                "id": "w1",
+                "type": widget_type,
+                "binding": {"source": "query", "sql": sql},
+            }
+        ]
     }
 
 
@@ -94,7 +107,7 @@ class TestInstall:
                 "name": "Sprint health",
                 "initiative_id": a.initiative.id,
                 "listing_uid": INSTALL_UID,
-                "definition": _definition(widget_type="table", source="tasks"),
+                "definition": _definition(widget_type="table"),
             },
         )
 
@@ -244,7 +257,7 @@ class TestUpgrade:
             uid=INSTALL_UID,
             public_id="tests.install",
             version="2.0.0",
-            definition=_definition(widget_type="table", source="tasks"),
+            definition=_definition(widget_type="table"),
         )
 
         # Untouched until someone here asks for it.
@@ -268,7 +281,7 @@ class TestUpgrade:
             uid=INSTALL_UID,
             public_id="tests.install",
             version="2.0.0",
-            definition=_definition(widget_type="table", source="tasks"),
+            definition=_definition(widget_type="table"),
         )
 
         response = await client.post(
@@ -294,7 +307,7 @@ class TestUpgrade:
             uid=INSTALL_UID,
             public_id="tests.install",
             version="2.0.0",
-            definition=_definition(widget_type="table", source="tasks"),
+            definition=_definition(widget_type="table"),
         )
 
         b = await acting_user(


### PR DESCRIPTION
## The problem

`dev` is red. The dashboards cutover (#1475) left `dashboards_install_test.py` behind: its fixture still named `task_counts` and `tasks` as binding sources, which the normalizer no longer accepts.

So `POST /dashboards/` returned 422, and `test_upgrading_an_authored_dashboard_is_refused` then read an id out of a response that did not have one.

I missed this in the cutover, and the failing run landed after the PR was merged.

## The fix

There is one binding source now, so the fixture takes the *statement* rather than the source:

```python
def _definition(widget_type="stat", sql="SELECT count(*) AS tasks FROM tasks") -> dict
```

The four callers that passed `source="tasks"` only ever wanted a `table` widget, so they just ask for that.

## Scope

Test-only. Nothing in `app/` changes.

I checked the rest of the tree for the same staleness — the only other place naming a legacy source is `app/db/dashboard_cutover_test.py`, which does it deliberately: those are the shapes the cutover generator has to read.

## Testing

- `pytest app/api/v1/tenant_endpoints/dashboards_install_test.py::TestUpgrade` — 6 passed (the class CI flagged)
- `pytest app/api/v1/tenant_endpoints/dashboards_install_test.py` — 16 passed, 1 failed + 2 errors that are a cross-test session artifact: each passes on its own, and none of them touches this fixture.
- `ruff check` / `ruff format` — clean