### PR TITLE
Name a test's role and its fields the way the code does

### DIFF
--- a/backend/app/api/v1/platform_endpoints/field_catalog_test.py
+++ b/backend/app/api/v1/platform_endpoints/field_catalog_test.py
@@ -11,6 +11,7 @@ import pytest
 
 from app.api.v1.platform_endpoints.field_catalog import read_query_vocabulary
 from app.models.platform.guild import GuildRole
+from app.services.fields import dataset
 from app.services.fields.registry import dataset_names
 from app.services.query.resolve import QueryError, resolve
 
@@ -18,8 +19,13 @@ from app.services.query.resolve import QueryError, resolve
 @pytest.mark.unit
 class TestTheVocabularyIsTheValidatorsOwn:
     def test_every_dataset_offered_can_be_read(self):
-        for dataset in read_query_vocabulary().datasets:
-            resolve(f"SELECT id FROM {dataset}")
+        """Named with a field it actually declares, not with ``id``: a join
+        table is keyed by the two things it relates and has no id of its own."""
+        for name in read_query_vocabulary().datasets:
+            field = next(
+                spec.name for spec in dataset(name).fields if spec.column is not None
+            )
+            resolve(f"SELECT {field} FROM {name}")
 
     def test_every_function_offered_is_one_the_validator_accepts(self):
         """Called with an argument each takes, so a refusal here is the name

--- a/backend/app/db/guild_scoped_members_test.py
+++ b/backend/app/db/guild_scoped_members_test.py
@@ -19,6 +19,7 @@ them at all.
 import pytest
 from sqlalchemy import text
 
+from app.db.schema_provisioning import guild_query_role_name
 from app.testing import create_guild, create_guild_membership, create_user
 
 pytestmark = pytest.mark.database
@@ -28,8 +29,14 @@ _IDS = "SELECT id FROM public.current_guild_members ORDER BY id"
 
 
 async def _as_query_role(conn, guild_id: int):
-    """Become the role a query runs as. Everything below reads through it."""
-    await conn.execute(text(f'SET LOCAL ROLE "guild_{int(guild_id)}_q"'))
+    """Become the role a query runs as. Everything below reads through it.
+
+    Named through the provisioner's own helper rather than spelled out: every
+    test run gets its own prefixed roles, and roles are cluster-global — so a
+    hand-written ``guild_1_q`` finds whatever another database left lying
+    around, or nothing at all.
+    """
+    await conn.execute(text(f'SET LOCAL ROLE "{guild_query_role_name(guild_id)}"'))
 
 
 async def _routed(conn, guild_id: int | None, *, pam: bool = False):


### PR DESCRIPTION
## dev is red, and both causes are mine

Backend CI failed on `43d31077b` (the #1490 merge). Three tests failed; two are mine and this fixes them. The third — `posts_realtime_test::test_a_notice_never_reaches_another_initiatives_room` — is **not** from my branches and is flagged below.

### `guild_scoped_members_test` — the role name

I wrote `SET LOCAL ROLE "guild_<id>_q"` by hand. Every test run gets its own prefixed roles (`test_<checkout>_<worker>_guild_1_q`), and **roles are cluster-global** — so locally it found the *dev database's* `guild_1_q` and passed for entirely the wrong reason, while CI has no such role and could not set it at all:

```
asyncpg.exceptions.InvalidParameterValueError: role "guild_1_q" does not exist
```

It asks `guild_query_role_name(guild_id)` now, which is what the provisioner uses. Verified under `-n 2`, which is where the per-worker prefixes actually differ.

The behaviour those tests describe was never in doubt — I checked the view directly against dev with real roles (guild 1 → 11 members, a grantee into guild 1 → 11, routed nowhere → 0). It was the test that was wrong, not the view.

### `field_catalog_test` — `SELECT id FROM <dataset>`

The drift test I added in #1486 reads one column from every dataset the vocabulary offers, and it used `id`. #1490 added `task_assignees`, which is keyed by the two things it relates and has no id of its own:

```
QueryError: QUERY_UNKNOWN_FIELD: task_assignees.id
```

It now names a field the dataset actually declares, so a dataset added later cannot break it for this reason again.

## Not mine, and worth a look

`posts_realtime_test::test_a_notice_never_reaches_another_initiatives_room` fails with the room receiving 2 events it asserts it should not:

```
assert [{'action': 'created', 'parents': [], 'resource': {'id': 1, 'type': 'posts'}}, ...] == []
```

That file comes from the realtime work (`Fan the rooms out from the change log`, `Update comments and notices live`), not from anything I touched. It is a cross-initiative leak assertion, so it is worth someone looking at rather than assuming flake — I have not touched it here.

## Testing

- `pytest app/db/guild_scoped_members_test.py app/api/v1/platform_endpoints/field_catalog_test.py` — 18 passed
- `pytest -n 2 app/db/guild_scoped_members_test.py` — 9 passed (the arrangement that exposed the bug)