### PR TITLE
Unbreak dev: name the platform floor by the run's prefix, and ask the right reader

### DIFF
--- a/backend/alembic/versions/20260909_0244_members_of_the_routed_guild.py
+++ b/backend/alembic/versions/20260909_0244_members_of_the_routed_guild.py
@@ -29,6 +29,8 @@ Create Date: 2026-09-09
 
 from alembic import op
 
+from app.core.config import settings
+
 revision = "20260909_0244"
 down_revision = "20260909_0243"
 branch_labels = None
@@ -70,10 +72,17 @@ DISPLAY_NAME = "COALESCE(p.full_name, p.username) AS display_name"
 #: can read and nothing else.
 FLOORS = ("app_guild_base", "app_guild_base_ro")
 
-#: The public/platform floor, which this is not for. A request with no guild
-#: gets no rows from it anyway; taking the privilege away says the same thing
-#: where the catalog can be asked.
-PLATFORM_FLOOR = "platform_base"
+
+def _platform_floor() -> str:
+    """The public/platform floor, which this is not for.
+
+    A request with no guild gets no rows from it anyway; taking the privilege
+    away says the same thing where the catalog can be asked. Named through the
+    prefix because the platform ladder carries one — the guild floors above are
+    fixed names and do not.
+    """
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
 
 #: The role that owns both projections of an account. Created in 0214.
 READER = "app_profile_reader"
@@ -123,7 +132,7 @@ def upgrade() -> None:
         # view — but the privilege is what the catalog is asked about.
         op.execute(f'GRANT SELECT ON {VIEW} TO "{floor}"')
         op.execute(f'REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON {VIEW} FROM "{floor}"')
-    op.execute(f'REVOKE ALL ON {VIEW} FROM "{PLATFORM_FLOOR}"')
+    op.execute(f'REVOKE ALL ON {VIEW} FROM "{_platform_floor()}"')
 
 
 def downgrade() -> None:

--- a/backend/app/db/guild_scoped_members_test.py
+++ b/backend/app/db/guild_scoped_members_test.py
@@ -19,6 +19,7 @@ them at all.
 import pytest
 from sqlalchemy import text
 
+from app.core.config import settings
 from app.db.schema_provisioning import guild_query_role_name
 from app.testing import create_guild, create_guild_membership, create_user
 
@@ -26,6 +27,13 @@ pytestmark = pytest.mark.database
 
 _COUNT = "SELECT count(*) FROM public.current_guild_members"
 _IDS = "SELECT id FROM public.current_guild_members ORDER BY id"
+
+
+def _platform_floor() -> str:
+    """The platform ladder's floor, for the same reason the query role is
+    asked for rather than spelled out: a run's roles are its own, and an
+    unprefixed name is whatever another database on this cluster holds."""
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
 
 
 async def _as_query_role(conn, guild_id: int):
@@ -153,7 +161,7 @@ class TestTheRolesThatReadIt:
         The schema hands every new relation in ``public`` full DML to the
         request-path floors, so a read-only one has to say so."""
         async with engine.connect() as conn:
-            for role in ("app_guild_base", "app_guild_base_ro", "platform_base"):
+            for role in ("app_guild_base", "app_guild_base_ro", _platform_floor()):
                 for verb in ("INSERT", "UPDATE", "DELETE"):
                     assert not await conn.scalar(
                         text(
@@ -169,7 +177,8 @@ class TestTheRolesThatReadIt:
         async with engine.connect() as conn:
             assert not await conn.scalar(
                 text(
-                    "SELECT has_table_privilege('platform_base', "
+                    "SELECT has_table_privilege(:r, "
                     "'public.current_guild_members', 'SELECT')"
-                )
+                ),
+                {"r": _platform_floor()},
             )


### PR DESCRIPTION
`dev` is red for two unrelated reasons. The first hid the second.

## 1. Every database-backed test errors in setup

5,705 errors, one cause. Test-database setup runs `alembic upgrade head`, and migration `0244` fails:

```
REVOKE ALL ON public.current_guild_members FROM "platform_base"
asyncpg.exceptions.UndefinedObjectError: role "platform_base" does not exist
```

The migration spelled the role out. The platform ladder carries `settings.PLATFORM_ROLE_PREFIX`, which the suite sets to `test_<run>_`, so under a test run there is no role by that bare name — the migration stops there, taking every test that needs a database with it.

It passed locally because Postgres roles are cluster-global: a co-located dev database has an unprefixed `platform_base`, so the statement found *that* one. Same shape as the `guild_<id>_q` fix in #1491.

- `20260909_0244` names the floor through `PLATFORM_ROLE_PREFIX`, as `0214` already does. The guild floors either side of it (`app_guild_base`, `app_guild_base_ro`) are genuinely fixed names and stay written out.
- The two assertions in `guild_scoped_members_test` that ask the catalog about the same floor ask for the prefixed name.

`0244` is unreleased (`RELEASED_MIGRATION` is `20260907_0235`), so it is corrected in place. The prefix is empty in dev and production, so the statement emitted there is unchanged.

## 2. `test_a_notice_never_reaches_another_initiatives_room`

With the migration fixed the suite runs, and one test fails — deterministically, and on `dev` too. It was never reached before.

The test opened its room as user 1: the author, who is on both initiatives because they created both. `_open_new_rooms` (3c3c68352) reads the roster moving out of the change log and puts a socket into every room its user belongs in, and the setup's roster rows are still inside the sweep window when the room opens. So the socket joined the author's other board as well, and heard the notice posted there.

Both rooms are that person's, so the sink is right and the reader was wrong — this is not a leak. The room now belongs to somebody who is on the board next door and on no other, which is the question the test is named for. `_Room` takes the user it connects as, defaulting to the actor the rest of the file uses.

## Testing

`ruff check`, `ruff format`, and `ty check` pass. `posts_realtime_test.py` passes locally (7/7). The migration half is left to CI: this checkout's test databases already ran `0244` against the unprefixed role, so a local run would assert against state a fresh database does not have.

The previous CI run on this branch — migration fix only — went from 5,705 errors to **1 failed, 5,611 passed**; that one failure is what commit 2 addresses.

## Noted, not changed

`app/db/bootstrap.py`'s default-privileges block also names `platform_base` unprefixed, and returns early when it is absent. Under a test run that means the suite's own prefixed floor never receives the `public` default privileges a deployment gives it, so nothing in CI exercises them. Separate from this break; worth its own look.
