### PR TITLE
Ask the room question of somebody not in the room

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/posts_realtime_test.py
+++ b/backend/app/api/v1/tenant_endpoints/posts_realtime_test.py
@@ -54,14 +54,15 @@ class _Room:
     rows, and neither is allowed to be the only one that works.
     """
 
-    def __init__(self, guild_id: int, initiative_id: int) -> None:
+    def __init__(self, guild_id: int, initiative_id: int, user_id: int = 1) -> None:
         self._guild_id = guild_id
         self._initiative_id = initiative_id
+        self._user_id = user_id
         self.socket = FakeWebSocket()
 
     async def __aenter__(self) -> "_Room":
         await manager.connect(
-            self._guild_id, [self._initiative_id], self.socket, user_id=1
+            self._guild_id, [self._initiative_id], self.socket, user_id=self._user_id
         )
         await room_sink.process_room_sweep()
         return self
@@ -248,12 +249,20 @@ async def test_answering_a_poll_tells_the_room_the_tallies_moved(
 async def test_a_notice_never_reaches_another_initiatives_room(
     client: AsyncClient, acting_user, session
 ):
-    """The room key is (guild, initiative): a board next door hears nothing."""
+    """The room key is (guild, initiative): a board next door hears nothing.
+
+    Watched by somebody who is in neither initiative, deliberately. A socket is
+    also put into the rooms of every initiative its own user belongs to, as the
+    roster moves under it (``room_sink._open_new_rooms``) — so an author
+    watching their own other board is told about their own notice, correctly,
+    and is the wrong person to ask this question of.
+    """
     a = await acting_user(guild_role=GuildRole.admin, initiative=True)
     await _posts_enabled(session, a.initiative)
     elsewhere = await create_initiative(session, a.guild, a.user)
+    outsider = await acting_user(guild_role=GuildRole.member, guild=a.guild)
 
-    async with _Room(a.guild.id, elsewhere.id) as room:
+    async with _Room(a.guild.id, elsewhere.id, user_id=outsider.user.id) as room:
         response = await client.post(
             a.g("/posts/"),
             headers=a.headers,


### PR DESCRIPTION
## Not a leak

`test_a_notice_never_reaches_another_initiatives_room` has been failing on dev since the rooms began fanning out from the change log. I flagged it in #1491 as a cross-initiative leak assertion worth looking at rather than assuming flake. Having looked: **it is not a leak**, and I was wrong to imply it might be.

A socket is put into the rooms of every initiative *its own user belongs to* as the roster moves under it — that is what `room_sink._open_new_rooms` is for, and its docstring says so:

> Put anybody newly in an initiative into its room, without a reconnect. Rooms are resolved once, when a socket connects, so a tab that was already open when its person joined an initiative hears nothing from it.

The test watched the other board **as the author**, who is a member of both initiatives. So being joined to their own other room, and told about their own notice, is correct behaviour — and they are the wrong person to ask this question of.

## Confirmed the other way round

```
socket for a user in NEITHER initiative, after the post is created:
  heard: []
```

The join is `watching & members`, so a socket is only ever added to a room its user is a member of. Gate 2 holds.

## The change

The test watches as somebody in neither initiative, which is the question it means to ask. `_Room` takes the user id rather than hardcoding `1`.

Test-only. Nothing in `app/` changes.

## Testing

`pytest app/api/v1/tenant_endpoints/posts_realtime_test.py` — 7 passed (was 6 passed, 1 failed).