### PR TITLE
Give the read floor the two tables it was skipped for

### DIFF
--- a/backend/alembic/versions/20260909_0245_notification_settings_are_private.py
+++ b/backend/alembic/versions/20260909_0245_notification_settings_are_private.py
@@ -58,6 +58,13 @@ def _base_roles() -> tuple[str, ...]:
     return (f"{settings.PLATFORM_ROLE_PREFIX}platform_base", "app_guild_base")
 
 
+#: The read half of ``app_guild_base``, which the query role and ``guild_<id>_ro``
+#: inherit. It takes no default privileges, so the table is granted and policed
+#: for it here rather than arriving with the schema (0239); it reads the same one
+#: row and writes nothing. ``guild_base_ro_parity_test`` is what asks for this.
+_READ_FLOOR = "app_guild_base_ro"
+
+
 #: Old column -> the categories it gated. ``email_mentions`` gated five
 #: notification types that are now three categories, so it seeds all three:
 #: somebody who switched it off wanted all of it off.
@@ -217,6 +224,14 @@ def upgrade() -> None:
                 f"CREATE POLICY {name} ON public.user_notification_prefs "
                 f'AS PERMISSIVE FOR {command} TO "{base}" {clause}'
             )
+    op.execute(
+        f'GRANT SELECT ON TABLE public.user_notification_prefs TO "{_READ_FLOOR}"'
+    )
+    op.execute(
+        f"CREATE POLICY user_notification_prefs_self_select_{_READ_FLOOR} "
+        "ON public.user_notification_prefs AS PERMISSIVE FOR SELECT "
+        f'TO "{_READ_FLOOR}" USING (user_id = {_USER_ID})'
+    )
     # The system engine seeds a new account's row and reads it while delivering.
     op.execute(
         "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_notification_prefs "
@@ -365,6 +380,10 @@ def downgrade() -> None:
                 f"DROP POLICY IF EXISTS user_notification_prefs_self_{command}_{base} "
                 "ON public.user_notification_prefs"
             )
+    op.execute(
+        f"DROP POLICY IF EXISTS user_notification_prefs_self_select_{_READ_FLOOR} "
+        "ON public.user_notification_prefs"
+    )
     op.execute("ALTER TABLE public.user_notification_prefs NO FORCE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE public.user_notification_prefs DISABLE ROW LEVEL SECURITY")
     op.drop_table("user_notification_prefs")

--- a/backend/app/db/guild_base_ro_parity_test.py
+++ b/backend/app/db/guild_base_ro_parity_test.py
@@ -14,6 +14,19 @@ pytestmark = pytest.mark.database
 WRITABLE_FLOOR = "app_guild_base"
 READ_FLOOR = "app_guild_base_ro"
 
+
+@pytest.fixture(autouse=True)
+async def _materialize_lazy_shared_tables():
+    """``storage_backfill_state`` is created lazily at runtime, not by a
+    migration, so whether it is in the catalog here depends on whether a
+    storage test happened to run first in this worker. Created up front, the
+    way ``security_invariants_test`` does it, so the floors are compared over
+    the same set of tables every run."""
+    from app.services.storage_backfill import _ensure_table
+
+    await _ensure_table()
+
+
 _TABLES = """
 SELECT c.oid::regclass::text AS name,
        has_table_privilege(:writable, c.oid, 'SELECT') AS writable_reads,

--- a/backend/app/services/storage_backfill.py
+++ b/backend/app/services/storage_backfill.py
@@ -35,6 +35,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.config import settings
 from app.db.backfill_uploads_to_s3 import BackfillSummary, backfill_uploads_to_s3
 from app.db import session as db_session
 from app.db.session import AdminSessionLocal
@@ -79,6 +80,12 @@ if _ADMIN_GRANT is None:
         "SELECT/INSERT/UPDATE"
     )
 
+
+def _platform_floor() -> str:
+    """The platform ladder's floor, which carries the platform prefix."""
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
 _table_lock = asyncio.Lock()
 _table_ready = False
 
@@ -120,6 +127,18 @@ async def _ensure_table() -> None:
             )
             await conn.execute(
                 text(f"GRANT {_ADMIN_GRANT} ON storage_backfill_state TO app_admin")
+            )
+            # The schema's default privileges hand every new relation in
+            # ``public`` full DML to the two request-path floors, and this
+            # table is the system engine's alone. A migration adding an
+            # admin-only shared table says the same thing on its own line
+            # (0132, 0133, 0134); this one is created at runtime, so it says
+            # it here.
+            await conn.execute(
+                text(
+                    "REVOKE ALL ON storage_backfill_state "
+                    f'FROM app_guild_base, "{_platform_floor()}"'
+                )
             )
         _table_ready = True
 


### PR DESCRIPTION
`guild_base_ro_parity_test` holds `app_guild_base_ro` to the read half of `app_guild_base` — every table the writable floor can read, and no other. Two tables reached one floor and not the other.

## `user_notification_prefs`

Migration `0245` (#1494) grants the two writable bases `SELECT, INSERT, UPDATE` and gives each an own-row policy. The read floor takes no schema default privileges (`0239`), so it was granted nothing and the parity check fails:

```
AssertionError: app_guild_base_ro cannot read: ['user_notification_prefs']
```

It now gets `SELECT` and the same own-row `SELECT` policy the other bases have — the read half of what they hold, reading the one row and writing nothing. `0245` is unreleased (`RELEASED_MIGRATION` is `20260907_0235`), so it is corrected in place.

## `storage_backfill_state`

Not migrated at all: `app.services.storage_backfill._ensure_table` creates it at runtime, and the schema's default privileges then hand both request-path floors full DML on a table only the system engine uses. The create path already revokes-then-grants for `app_admin`; it now says the same for the two floors, which is the line a migration adding an admin-only shared table already writes (`0132`, `0133`, `0134`).

## Why only one of the two showed up

That table exists in a worker only if a storage test ran there first, so the parity check compared a different set of tables per xdist worker — `storage_backfill_state` appeared in some runs and not others. It materializes the table up front now, the way `security_invariants_test` already does for the same reason.

## Testing

Dropped this checkout's own test database so `0245` re-ran from scratch, then:

- `app/db` — 803 passed, 105 skipped
- `guild_base_ro_parity_test` + `storage_backfill_test` — 12 passed
- `security_invariants_test`, `system_grants_test`, `tenancy_test` — 32 passed

`ruff check`, `ruff format`, and `ty check` pass.

## Not in scope

`app/db/bootstrap.py`'s default-privileges block names `platform_base` unprefixed and returns early when it is absent, so under a test run the suite's own prefixed floor never receives the `public` default privileges a deployment gives it. Nothing in CI exercises them. Worth its own look.
