### PR TITLE
Ask for nothing where nothing was pointed at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bursts of change stop stuttering** — a batch is worked out once rather than per item: a third of a second of unresponsive page becomes under a millisecond.
 
 ### Fixed
+- **A dashboard tile nobody has pointed anywhere stops reporting a failure** — a widget placed but not yet given anything to show asked the server for a statement it does not have, and drew that refusal as data it could not load.
 - **An empty heatmap says it is empty** — a daily-activity tile with nothing to show yet reported that it had no date column to place values on, sending its author to fix a query that was never wrong.
 
 - **The unread dot reaches the initiative and the tool** — it lit the community and stopped there, because almost nothing recorded where it happened: a mention, a reply, a comment or an assignment named its community and nothing inside it. They carry the initiative and the tool now, so the dot runs all the way down the sidebar and finding what happened is following a trail. On the rail it also moves onto the community's picture, where a presence dot sits, rather than hanging off the corner of the square behind it.

--- a/frontend/src/hooks/useWidgetData.test.tsx
+++ b/frontend/src/hooks/useWidgetData.test.tsx
@@ -145,6 +145,18 @@ describe("a widget already on a dashboard", () => {
     ).toBe(false);
   });
 
+  it("asks for nothing where nobody has pointed it anywhere", () => {
+    // A placed widget with no statement has none for the server to look up,
+    // and the tile already draws this as unconfigured rather than as a
+    // failure. Asking would be a request that can only come back empty
+    // handed — and one that reads as a broken tile if anything downstream
+    // treats a refusal as an error.
+    renderHook(() => useWidgetData({ source: "query" }, 7, 11, "w1"));
+    const asked = useWidgetQuery.mock.calls.at(-1);
+    expect(asked?.slice(0, 2)).toEqual([null, null]);
+    expect(Boolean((asked?.[2] as { enabled?: boolean } | undefined)?.enabled)).toBe(false);
+  });
+
   it("sends the statement while it is still being written", () => {
     // No dashboard and no widget: the config dialog's preview, which has
     // nothing stored yet for the server to look up.

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -124,7 +124,12 @@ export function useWidgetData(
   // question somebody published, and there is no way to ask another of them.
   // A widget that is not placed yet — the config dialog's preview — has no
   // stored statement to look up, so it sends the one being written.
-  const placed = typeof dashboardId === "number" && Boolean(widgetId);
+  // A widget nobody has pointed anywhere yet has no statement for the server to
+  // look up, and asking for one is a request that can only come back empty
+  // handed. The binding here is the effective one — the definition with the
+  // instance config over it, which is what the server reads too — so this asks
+  // the same question the lookup would.
+  const placed = typeof dashboardId === "number" && Boolean(widgetId) && Boolean(binding.sql);
   const widgetQuery = useWidgetQuery(
     source === "query" && placed ? (dashboardId ?? null) : null,
     source === "query" && placed ? (widgetId ?? null) : null,


### PR DESCRIPTION
## The problem

A widget placed on a dashboard but not yet pointed at anything drew **"This
widget's data could not be loaded. Try again."** — a failure, where the truth is
that nobody has finished setting it up.

It arrived with #1505. A placed widget is now read by naming it, so the server
looks up the statement stored on it — and a widget with no statement has none to
look up, so the lookup refuses and the tile drew the refusal as a broken fetch.

## The fix

Don't ask. The binding this reads is the effective one — the definition with the
instance config over it, which is exactly what the server's lookup reads — so
asking whether there is a statement here gives the same answer the lookup would,
and a widget without one falls back to the unconfigured state the canvas already
draws for it.

## Testing

```
cd frontend && pnpm vitest run src/hooks/useWidgetData.test.tsx \
  src/components/initiativeTools/dashboards      # 94 passed
tsc --noEmit                                     # clean
```

New test: a placed widget with no `sql` asks for nothing, beside the existing two
— a placed widget with one is read by naming it, and an unplaced one still sends
the statement being written.