### PR TITLE
A funnel measures against its widest stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bursts of change stop stuttering** — a batch is worked out once rather than per item: a third of a second of unresponsive page becomes under a millisecond.
 
 ### Fixed
+- **A funnel's bars stay inside their tile** — a funnel measured every stage against the first one rather than the largest, so a set of stages that does not narrow drew the bigger ones past the edge of the panel. Dashboard tiles also clip what they hold, so no visual can spill across the one beside it.
 - **A dashboard tile nobody has pointed anywhere stops reporting a failure** — a widget placed but not yet given anything to show asked the server for a statement it does not have, and drew that refusal as data it could not load.
 - **An empty heatmap says it is empty** — a daily-activity tile with nothing to show yet reported that it had no date column to place values on, sending its author to fix a query that was never wrong.
 

--- a/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/WidgetTile.tsx
@@ -139,7 +139,17 @@ export function WidgetTile({
   if (chromeless) {
     // No label here: the canvas's own <section> already names this region, and
     // a second label on a plain div would only add noise for a screen reader.
-    return <div className={cn("h-full w-full text-card-foreground", className)}>{body}</div>;
+    //
+    // Clipped, like the framed one below it. A tile is a fixed box on a grid
+    // and what it holds is drawn by a renderer that cannot know how much room
+    // it has — so the box is the last word on where its contents end. Each
+    // renderer still fits itself first; this is what makes "it did not" a
+    // clipped edge rather than a chart lying across the tile beside it.
+    return (
+      <div className={cn("h-full w-full overflow-hidden text-card-foreground", className)}>
+        {body}
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/components/initiativeTools/dashboards/scene/FunnelNode.test.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/FunnelNode.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * A funnel's bars stay inside the panel.
+ *
+ * A funnel narrows by convention, not by construction: a statement grouping by
+ * status returns its rows in whatever order it likes, and "stage one" is then
+ * not the widest. Scaling every bar against the first stage drew the larger
+ * ones past the end of the tile — so what the bars are measured against, and
+ * that none of them exceeds the box, is what these pin.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FunnelNode } from "./FunnelNode";
+
+const funnel = (values: number[]) => ({
+  kind: "funnel" as const,
+  stages: values.map((value, index) => ({ label: `s${index}`, value })),
+});
+
+/** The drawn width of each bar, in order. */
+const widths = (container: HTMLElement): string[] =>
+  Array.from(container.querySelectorAll<HTMLElement>("[style*='width']")).map(
+    (bar) => bar.style.width
+  );
+
+describe("a funnel that does not narrow", () => {
+  it("measures against its widest stage, not its first", () => {
+    // Ordered by a status enum rather than by size: the biggest is third.
+    const { container } = render(<FunnelNode node={funnel([257, 254, 273, 262])} />);
+    const drawn = widths(container);
+    expect(drawn[2]).toBe("100%");
+    // And everything else is a share of it rather than of the first stage.
+    expect(drawn[0]).toBe(`${(257 / 273) * 100}%`);
+  });
+
+  it("draws no bar past the end of the panel", () => {
+    const { container } = render(<FunnelNode node={funnel([10, 400, 25])} />);
+    for (const width of widths(container)) {
+      expect(Number.parseFloat(width)).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("still shows the smallest stage as something", () => {
+    const { container } = render(<FunnelNode node={funnel([1000, 1])} />);
+    expect(Number.parseFloat(widths(container)[1])).toBeGreaterThan(0);
+  });
+
+  it("draws a full bar where every stage is nothing", () => {
+    const { container } = render(<FunnelNode node={funnel([0, 0])} />);
+    expect(widths(container)).toEqual(["100%", "100%"]);
+  });
+
+  it("names every stage", () => {
+    render(<FunnelNode node={funnel([3, 2])} />);
+    expect(screen.getByText("s0")).toBeInTheDocument();
+    expect(screen.getByText("s1")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/initiativeTools/dashboards/scene/FunnelNode.tsx
+++ b/frontend/src/components/initiativeTools/dashboards/scene/FunnelNode.tsx
@@ -17,12 +17,20 @@ type Node = Extract<SceneNode, { kind: "funnel" }>;
  * own tone still gets it; that is how a widget marks one step as the problem.
  */
 export function FunnelNode({ node }: { node: Node }) {
-  const top = node.stages[0]?.value ?? 0;
+  // Measured against the largest stage rather than the first. A funnel usually
+  // narrows, and for one that does these are the same number — but nothing
+  // makes the data narrow. A statement grouping by status returns its rows in
+  // whatever order it likes, so "the first" is not "the widest", and scaling
+  // against it drew every larger stage past the end of the panel.
+  const top = node.stages.reduce((widest, stage) => Math.max(widest, stage.value), 0);
 
   return (
     <div className="flex h-full w-full flex-col justify-center gap-1.5 p-1">
       {node.stages.map((stage, index) => {
-        const width = top > 0 ? Math.max(0.04, stage.value / top) : 1;
+        // Floored so the smallest stage is still a mark, capped because a bar
+        // is drawn inside a box — the same bounds every other proportional
+        // fill on a dashboard is held to.
+        const width = top > 0 ? Math.min(1, Math.max(0.04, stage.value / top)) : 1;
         const previous = node.stages[index - 1]?.value;
         const conversion = previous && previous > 0 ? stage.value / previous : undefined;
 


### PR DESCRIPTION
## The problem

A funnel's bars ran past the end of the tile — seen on a *Quest pipeline* widget
counting tasks by status category.

```tsx
const top = node.stages[0]?.value ?? 0;
const width = top > 0 ? Math.max(0.04, stage.value / top) : 1;
```

Every stage is measured against **the first** one, which is the widest only for
data that narrows — and nothing makes it narrow. The statement behind that widget
is `… GROUP BY s.category` with no `ORDER BY`, so its rows arrive in whatever
order the plan gives them, and the funnel widget only sorts when the author asks
it to (`config.order === "descending"`). Any stage larger than whichever came
first computed a width above 100% and was drawn outside the panel.

## The fix

Measure against the largest stage. For a funnel that does narrow these are the
same number, so nothing changes for well-behaved data; it stops being wrong the
moment the data does not narrow.

The width is also capped, which is what every other proportional fill on a
dashboard already does — `ProgressNode`, `TimelineNode` and `BoardNode` all clamp
to `[0, 1]` and the funnel was the only one that did not.

**And a tile clips what it holds.** The framed tile already did; the chromeless
one the canvas uses did not, so anything a renderer drew outside its box landed
on the tile beside it. A tile is a fixed box on a grid: each renderer still fits
itself first, and this is what makes "it did not" a clipped edge rather than a
chart lying across its neighbour.

## Testing

```
cd frontend && pnpm vitest run src/components/initiativeTools/dashboards src/lib/widgets   # 402 passed
tsc --noEmit                                                                                # clean
```

New `FunnelNode.test.tsx`: stages that do not narrow measure against the widest,
no bar exceeds 100%, the smallest stage is still visible, all-zero stages draw
full bars, and every stage is named.