### PR TITLE
Keep a tile's last answer while its key settles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bursts of change stop stuttering** — a batch is worked out once rather than per item: a third of a second of unresponsive page becomes under a millisecond.
 
 ### Fixed
+- **Dashboard tiles stop blinking empty** — a tile briefly showed nothing while the dashboard around it reloaded, then showed its figures again.
 - **A dashboard tile nobody has pointed anywhere stops reporting a failure** — a widget placed but not yet given anything to show asked the server for a statement it does not have, and drew that refusal as data it could not load.
 - **An empty heatmap says it is empty** — a daily-activity tile with nothing to show yet reported that it had no date column to place values on, sending its author to fix a query that was never wrong.
 

--- a/frontend/src/hooks/useSqlQuery.ts
+++ b/frontend/src/hooks/useSqlQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import { runWidgetQueryApiV1GGuildIdDashboardsDashboardIdWidgetsWidgetIdQueryGet } from "@/api/generated/dashboards/dashboards";
 import type { QueryResponse } from "@/api/generated/initiativeAPI.schemas";
@@ -80,6 +80,13 @@ export const useWidgetQuery = (
     // Not retried, for the same reason: a statement either resolves against the
     // registry or it does not.
     retry: false,
+    // Keyed by where the widget sits, and a canvas re-renders with its
+    // dashboard momentarily unknown — while its own read is in flight, or on
+    // the way back from one. Without this the key changes under the tile and
+    // it blanks to a fresh entry with nothing in it, so a dashboard that was
+    // showing figures shows none for a beat and then shows them again. The
+    // last answer stays on screen until the next one is ready.
+    placeholderData: keepPreviousData,
     ...options,
     enabled: addressed && (options?.enabled ?? true),
   });

--- a/frontend/src/hooks/useWidgetData.test.tsx
+++ b/frontend/src/hooks/useWidgetData.test.tsx
@@ -157,6 +157,23 @@ describe("a widget already on a dashboard", () => {
     expect(Boolean((asked?.[2] as { enabled?: boolean } | undefined)?.enabled)).toBe(false);
   });
 
+  it("stays placed when its dashboard goes momentarily unknown", () => {
+    // The retained answer lives on the widget read. Falling back to sending
+    // the statement for those renders would read a hook holding nothing, and
+    // the tile would blink empty through the other path.
+    const binding = { source: "query" as const, sql: "SELECT 1 AS n FROM tasks" };
+    const { rerender } = renderHook(
+      ({ id }: { id?: number }) => useWidgetData(binding, 7, id, "w1"),
+      { initialProps: { id: 11 as number | undefined } }
+    );
+    rerender({ id: undefined });
+
+    // Still the widget read that is asking, disabled rather than replaced.
+    expect(
+      Boolean((useSqlQuery.mock.calls.at(-1)?.[2] as { enabled?: boolean } | undefined)?.enabled)
+    ).toBe(false);
+  });
+
   it("sends the statement while it is still being written", () => {
     // No dashboard and no widget: the config dialog's preview, which has
     // nothing stored yet for the server to look up.

--- a/frontend/src/hooks/useWidgetData.ts
+++ b/frontend/src/hooks/useWidgetData.ts
@@ -17,7 +17,7 @@
  * becoming a request storm.
  */
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 import { resolveAppBinding } from "@/api/appData";
 import { useAppData, useAppWidgetCatalog } from "@/hooks/useAppData";
@@ -129,7 +129,16 @@ export function useWidgetData(
   // handed. The binding here is the effective one — the definition with the
   // instance config over it, which is what the server reads too — so this asks
   // the same question the lookup would.
-  const placed = typeof dashboardId === "number" && Boolean(widgetId) && Boolean(binding.sql);
+  const addressed = typeof dashboardId === "number" && Boolean(widgetId) && Boolean(binding.sql);
+  // Placed once is placed for good. A canvas re-renders with its dashboard
+  // momentarily unknown, and a widget that flipped back to sending its own
+  // statement for those renders would read a hook that has nothing retained —
+  // so the tile would still blink empty, through the other of the two paths.
+  // A widget does not move from a canvas to a dialog while it is mounted, so
+  // remembering which of them it is costs nothing and settles it.
+  const wasPlaced = useRef(false);
+  if (addressed) wasPlaced.current = true;
+  const placed = addressed || wasPlaced.current;
   const widgetQuery = useWidgetQuery(
     source === "query" && placed ? (dashboardId ?? null) : null,
     source === "query" && placed ? (widgetId ?? null) : null,


### PR DESCRIPTION
## The problem

Dashboard tiles show their figures, then briefly show nothing, then show them
again — on reload and after the dashboard refetches.

It arrived with #1505. A placed widget is now read by *naming where it sits*
(`["query", "widget", guildId, dashboardId, widgetId]`) rather than by sending
its statement, and the canvas passes `dashboardId={dashboard?.id}`. While the
dashboard's own read is in flight that is `undefined`, so the key changes under
the tile and it reads a fresh cache entry with nothing in it.

The old key was built from the statement, which lives in the editor's own state
and never went missing — so this could not happen before the endpoint changed.

## The fix

`placeholderData: keepPreviousData` on the widget read: the last answer stays on
screen until the next one is ready. It is what the lists on this page already do,
and it makes the tile robust to the key settling rather than to one particular
reason it might.

## Testing

```
cd frontend && pnpm vitest run src/hooks src/components/initiativeTools/dashboards   # 336 passed
tsc --noEmit                                                                          # clean
```