### PR TITLE
Say how a dashboard tile is pointed at something

### DIFF
--- a/docs/en/guides/dashboards.md
+++ b/docs/en/guides/dashboards.md
@@ -28,6 +28,19 @@ So two people can open the same dashboard and correctly see different numbers, a
 
 The access rules you set on projects and documents follow straight through into the reporting — which means a dashboard is never the accidental side door to something somebody wasn't supposed to see.
 
+## Published figures
+
+There is one case where that's wrong, and it's the case dashboards get built for: the number everybody in the room is supposed to be looking at. A total that's smaller for half the meeting isn't a total, it's an argument.
+
+So under **Settings → Published figures** you can name a project the dashboard should show the same way to everyone who can open it. Name it once, and the tiles stop answering per person for those rows.
+
+Four things hold:
+
+- You can only publish what you can open yourself. It hands on your reach, never more.
+- Whoever owns the project sees the share sitting on it, and can take it back whenever they like.
+- If you lose access, leave, or your account is suspended, it stops — the tiles go back to showing each person their own.
+- The dashboard says when it's on, so nobody has to wonder whose numbers they're reading.
+
 ## Building one
 
 From an initiative's sidebar: **Dashboards → New dashboard**. Add tiles, point each at what it should read, arrange them on the canvas.
@@ -38,6 +51,30 @@ Usually faster than starting from a blank canvas, and often better, because some
 
 !!! tip "Steal a layout, then change it"
     A marketplace dashboard becomes an ordinary dashboard of yours the second you add it. Rename it, rearrange it, delete the tiles you don't like. Nothing phones home and nobody's feelings are hurt.
+
+### Pointing a tile at something
+
+Two steps, and most people never leave the first.
+
+**Build** is clicking. Pick what to read — tasks, documents, queue items, notices, events, your community's own people — then which columns, what to group them by, and what to narrow it to. The dashboard writes the query for you.
+
+**SQL** is the tab beside it, for the question clicking can't describe. It's real SQL, with the tables and columns offered as you type and the statement checked as you pause. One thing to know before you start: once you've edited the text, that tile stays in SQL. The builder can't read arbitrary SQL back, so it stops trying rather than quietly mangling what you wrote.
+
+Either way you can reach what a thing is *attached to* without writing a join. Tasks by the person assigned, by their status, by their project — pick the related column and the rest is worked out.
+
+### Narrowing it
+
+The **Filters** rows say which rows a tile is about. Pick a field, how to compare it, what to compare it against. Bracket a few as *any of these* when "high or urgent, and mine" is the actual question.
+
+Dates are asked as distances rather than as dates. A tile set to *the next 30 days* still means that next month, which is the whole difference between a dashboard and a screenshot.
+
+### A tile that's about whoever's looking
+
+Wherever a filter wants a person, one of the choices is **Me**.
+
+That doesn't mean you. It means whoever is looking at the tile. Place *My open tasks* once and everybody who opens that dashboard sees theirs — one tile, not one per person, and nobody's name stored inside it.
+
+(A tile like that can't also be a published figure. A number that's different for everyone can't be the same for everyone.)
 
 ### Boards
 


### PR DESCRIPTION
Docs only — `docs/en/guides/dashboards.md`.

## What was stale

The guide said you "point each tile at what it should read", which was the whole
story when a binding was one of eight named sources. It isn't now: a tile is a
question, asked by clicking or in SQL, and nothing on the page said so.

## What it says now

**Pointing a tile at something** — the Build step and the SQL tab beside it,
including the one thing that catches people out: once you've edited the text,
that tile stays in SQL, because the builder can't read arbitrary SQL back and
stops trying rather than quietly mangling what you wrote. Plus reaching what a
thing is attached to without writing a join.

**Narrowing it** — filters, "any of these" groups, and why a date is asked as a
distance ("the next 30 days" still means that next month).

**A tile that's about whoever's looking** — `Me` in a person filter meaning the
reader rather than the author.

**Published figures** — placed directly after "Everyone sees their own version",
because it is the one deliberate exception to it, and a page that describes the
rule without the exception is a page that will surprise somebody. Four things
hold: you can only publish what you can open; the owner sees the share and can
take it back; it stops if you lose access, leave or are suspended; and the
dashboard says when it's on.

## Checks

- `zensical build` — **No issues found**
- Nav and files agree
- Nothing describes an attack or what breaks without a guard
- Security and compliance pages untouched