### PR TITLE
Let an agent read every tool, not only tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **An assistant can read the rest of your work, not just the tasks** — the MCP server covered projects, tasks and initiatives, so anything asked of it was answered from tasks alone. It now reads documents, queues, counters, calendars and their events, notices and dashboards — including what a dashboard tile currently says, which is usually the fastest answer to "how is this going". Still read-only: the four things it may write are unchanged, and every call goes through the same permission checks you do, so it sees what you see and nothing else. File downloads, who voted in a poll and who has read a notice are deliberately left out.
+
 ## [0.67.0] - 2026-09-09
 
 ### Added
-- **An assistant can read the rest of your work, not just the tasks** — the MCP server covered projects, tasks and initiatives, so anything asked of it was answered from tasks alone. It now reads documents, queues, counters, calendars and their events, notices and dashboards — including what a dashboard tile currently says, which is usually the fastest answer to "how is this going". Still read-only: the four things it may write are unchanged, and every call goes through the same permission checks you do, so it sees what you see and nothing else. File downloads, who voted in a poll and who has read a notice are deliberately left out.
 
 - **The phone app takes the picture, and reads with no signal** — every image upload (profile picture, community icon and banner, document images, notice screenshots) now offers the camera beside the photo library. And silence from the server is no longer read as a rejection: instead of the sign-in screen you get the tasks, documents, notices and calendars this device had already loaded, for up to a day, behind a bar saying when it last updated. Reading only.
 - **Reactions can be turned off per notice** — a switch beside the comments one, on by default; turning it off keeps the reactions already there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.67.0] - 2026-09-09
 
 ### Added
+- **An assistant can read the rest of your work, not just the tasks** — the MCP server covered projects, tasks and initiatives, so anything asked of it was answered from tasks alone. It now reads documents, queues, counters, calendars and their events, notices and dashboards — including what a dashboard tile currently says, which is usually the fastest answer to "how is this going". Still read-only: the four things it may write are unchanged, and every call goes through the same permission checks you do, so it sees what you see and nothing else. File downloads, who voted in a poll and who has read a notice are deliberately left out.
 
 - **The phone app takes the picture, and reads with no signal** — every image upload (profile picture, community icon and banner, document images, notice screenshots) now offers the camera beside the photo library. And silence from the server is no longer read as a rejection: instead of the sign-in screen you get the tasks, documents, notices and calendars this device had already loaded, for up to a day, behind a bar saying when it last updated. Reading only.
 - **Reactions can be turned off per notice** — a switch beside the comments one, on by default; turning it off keeps the reactions already there.

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -16,8 +16,6 @@ become a tool:
     edit a task, move a task, add a comment), each gated client-side by Claude
     Code's per-write permission prompt. Destructive (delete), bulk (archive-all,
     reorder), AI-generation, and property/tag routes are deliberately excluded.
-
-See ``history/mcp-server-design.md``.
 """
 
 from __future__ import annotations

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -6,9 +6,12 @@ authentication and the six RLS gates apply by reuse — never re-implemented.
 
 The surface is curated and default-deny, so a newly added route can't silently
 become a tool:
-  * **Reads** — every ``GET`` route for projects, tasks, and initiatives, plus
-    the two comment reads that pair with the comment write (a parent's thread
-    and a single comment by id).
+  * **Reads** — every ``GET`` route for initiatives and for the tools they hold
+    (projects and tasks, documents, queues, counters, calendars and their
+    events, notices, dashboards), plus the two comment reads that pair with the
+    comment write (a parent's thread and a single comment by id). A handful are
+    carved back out: file downloads, who voted and who has read, and the
+    dashboard editor's own palette.
   * **Writes** — a small, explicit allow-list of safe mutations (create a task,
     edit a task, move a task, add a comment), each gated client-side by Claude
     Code's per-write permission prompt. Destructive (delete), bulk (archive-all,
@@ -40,7 +43,27 @@ if TYPE_CHECKING:
 # ``task-statuses`` exposes only its GET (list a project's statuses) — its
 # POST/PATCH/reorder routes aren't in the write allow-list, so they stay
 # excluded — giving a caller the status ids needed to place or move a task.
-READ_TAGS = ("projects", "tasks", "initiatives", "task-statuses")
+#
+# Every tool an initiative holds is readable, not only the two it starts with.
+# An agent asked "how is this going" was previously answering from tasks alone,
+# which is the shape of the question rather than the shape of the work: the
+# rota is a queue, the write-up is a document, the numbers are counters, and
+# what somebody would actually look at first is a dashboard. Writes stay where
+# they were — the four in ``_WRITE_ROUTE_MAPS`` — so this widens what can be
+# read and nothing else.
+READ_TAGS = (
+    "projects",
+    "tasks",
+    "initiatives",
+    "task-statuses",
+    "documents",
+    "queues",
+    "counters",
+    "calendars",
+    "calendar-events",
+    "posts",
+    "dashboards",
+)
 
 # Curated safe writes: an explicit allow-list matched by exact path *shape* so
 # only these four mutations are exposed — create a task (``POST /tasks/``), edit a
@@ -76,9 +99,33 @@ _COMMENT_READ_ROUTE_MAPS = [
     RouteMap(methods=["GET"], pattern=r".*/comments/\{[^}]+\}$", mcp_type=MCPType.TOOL),
 ]
 
+# Carved out of the tag rules below, each for a reason the tag itself cannot
+# express. Ordered ahead of them so the exclusion wins.
+_TOOL_READ_EXCLUSIONS = [
+    # Bytes rather than an answer. A download hands back a file — a document's
+    # contents, or one of its versions — and an export hands back a calendar
+    # file. Neither is something a tool result can carry usefully, and a large
+    # one would fill a caller's context with an attachment it cannot open.
+    RouteMap(pattern=r".*/download$", mcp_type=MCPType.EXCLUDE),
+    RouteMap(pattern=r".*/export\.ics$", mcp_type=MCPType.EXCLUDE),
+    # Who voted which way, and who has read a notice. Both are about people
+    # rather than about the work, and neither is answerable from the thing an
+    # agent was asked to do — the same reason join requests are carved out of
+    # the initiatives tag.
+    RouteMap(pattern=r".*/poll/voters$", mcp_type=MCPType.EXCLUDE),
+    RouteMap(pattern=r".*/reads$", mcp_type=MCPType.EXCLUDE),
+    # The editor's own vocabulary. ``widget-catalog`` is the palette a person
+    # arranges a dashboard from and ``installed-listings`` is what the
+    # marketplace has put in this guild; both describe the authoring surface
+    # rather than anything a dashboard is showing.
+    RouteMap(pattern=r".*/widget-catalog$", mcp_type=MCPType.EXCLUDE),
+    RouteMap(pattern=r".*/installed-listings$", mcp_type=MCPType.EXCLUDE),
+]
+
 _ROUTE_MAPS = [
     *_WRITE_ROUTE_MAPS,
     *_COMMENT_READ_ROUTE_MAPS,
+    *_TOOL_READ_EXCLUSIONS,
     # Carved out of the ``initiatives`` read surface below: a join request names
     # who asked to be let in and carries their free-text note, which is
     # membership administration for a manager to answer rather than part of the

--- a/backend/app/mcp_server_test.py
+++ b/backend/app/mcp_server_test.py
@@ -13,6 +13,7 @@ import pytest
 from fastmcp.tools.base import ToolResult
 from mcp.types import TextContent
 
+from app.core.tools import Tool
 from app.main import app
 from app.mcp_server import Base64FilterMiddleware, _redact_base64, build_mcp_server
 
@@ -57,18 +58,61 @@ async def test_mcp_tools_are_curated():
 
     assert names, "expected the curated tools to be present"
 
-    # Every tool is for an allowed resource (projects / tasks / initiatives, plus
-    # adding a comment). Excluded surfaces (admin, auth, settings, documents,
-    # queues, users, uploads, grants, …) carry none of these words, so this also
+    # Every tool is for an initiative, one of the tools an initiative holds, or
+    # the comment surface they share. Everything else (admin, auth, settings,
+    # users, uploads, grants, …) carries none of these words, so this also
     # proves none of them leaked through.
-    allowed = ("project", "task", "initiative", "comment")
+    allowed = (
+        "initiative",
+        "comment",
+        # The things a tool holds, which the enum names only their parent of:
+        # a task belongs to a project, a counter to a counter group.
+        "task",
+        "counter",
+        "backlink",
+        "widget",
+        *(tool.value for tool in Tool),
+        *(tool.plural for tool in Tool),
+    )
     off_list = [n for n in names if not any(a in n for a in allowed)]
     assert not off_list, f"tools outside the allow-list: {off_list}"
+
+    # And every tool an initiative holds is readable. Derived from the enum
+    # rather than listed, so a seventh kind arrives here as a failure rather
+    # than as a surface nobody remembered to open.
+    for tool in Tool:
+        stem = tool.value.replace("_", "")
+        assert any(stem in n.replace("_", "") for n in names), (
+            f"no MCP tool reads {tool.value}"
+        )
 
     # Join requests sit on the initiatives router and would otherwise ride in on
     # its tag, but they name who asked to be let in and quote their note — a
     # manager's queue, not a working surface. Carved out explicitly.
     assert not [n for n in names if "join_request" in n]
+
+
+@pytest.mark.unit
+async def test_the_tool_reads_stop_short_of_these():
+    """What riding in on a tag would have brought, and why each stays out.
+
+    Opening a tool's tag exposes every GET it carries, and a few of those are
+    not the working surface the rest are. Named here so removing one is a
+    decision somebody makes rather than a line that quietly stops matching.
+    """
+    names = [t.name.lower() for t in await build_mcp_server(app).list_tools()]
+
+    # Bytes rather than an answer: a document, one of its versions, a calendar
+    # file. None is something a tool result carries usefully.
+    assert not [n for n in names if "download" in n or "export" in n]
+    # People rather than work: who voted which way, who has read a notice.
+    assert not [n for n in names if "voter" in n or n.endswith("_reads")]
+    # The dashboard editor's own vocabulary, not anything a dashboard shows.
+    assert not [n for n in names if "widget_catalog" in n or "installed_listing" in n]
+
+    # The one that has to be present, because it is the whole point of reading
+    # a dashboard: what a tile on it currently says.
+    assert any("run_widget_query" in n for n in names)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## The problem

The MCP read surface was `projects`, `tasks`, `initiatives`, `task-statuses`. So
an agent asked "how is this going" answered from tasks alone — which is the shape
of the question rather than the shape of the work. The rota is a queue, the
write-up is a document, the numbers are counters, and the thing somebody would
actually open first is a dashboard.

## What this adds

Every tool an initiative holds becomes readable: **documents, queues, counters,
calendars and their events, notices, dashboards** — 57 tools, up from 28.

The one worth calling out is `run_widget_query`: an agent can read **what a
dashboard tile currently says**, which is usually the shortest path to the
answer. It rides in on the endpoint added in #1505, so what runs is the statement
stored on the widget — an agent cannot ask a different question of a published
view any more than a browser can.

**Writes are untouched.** The same four (`create_task`, `update_task`,
`move_task`, `create_comment`), asserted by the existing test.

**Nothing new for tenancy.** Tools stay route-backed, so every call runs through
the real route and its six gates. This widens which routes are offered, not what
any of them allows.

## Five carve-outs

Opening a tag exposes every `GET` it carries, and a few aren't the working
surface the rest are:

| Left out | Why |
|---|---|
| `…/download`, `…/export.ics` | Bytes rather than an answer — a document, a version, a calendar file |
| `…/poll/voters`, `…/reads` | Who voted which way, who has read a notice: people rather than work |
| `…/widget-catalog`, `…/installed-listings` | The dashboard editor's own vocabulary, not anything a dashboard shows |

The first two follow the reasoning already applied to `join-requests` and
`comments/recent`.

## The curation test now derives from the enum

It asserted an allow-list of four words. It now checks that **every `Tool` member
has a read tool**, so a seventh kind of tool arrives here as a failing test rather
than as a surface nobody remembered to open — and a second test names each
carve-out, so removing one is a decision somebody makes rather than a pattern that
quietly stops matching.

## Testing

```
cd backend && pytest app/mcp_server_test.py     # 8 passed
ruff check app · ty check app                   # clean
```