### PR TITLE
Record a failed sign-in against the account it targeted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Galleries: a home for the pictures** — a new tool beside Documents and Posts for the visual half of the work: mockups, screenshots, app icons, the four logos that lost. A gallery is a named wall of pictures with its own sharing, comments and tags, browsed as a masonry, a grid, or a timeline of what arrived when — and grouped by tag, so "everything still awaiting a decision" is one click. Drop a folder onto the page to add them, tag or remove a selection together, and replace a picture with a new version while keeping the rounds it went through. Off by default per initiative, like every non-core tool.
 
+### Fixed
+
+- **Failed sign-ins no longer reveal whether an email has an account through password-check timing** — an unknown email now performs the same password verification as an existing password account. Failed-login records also use the client identity selected by the server's trusted-proxy configuration instead of re-reading forwarding headers inside the application.
+
 ## [0.67.1] - 2026-09-09
 
 ### Added

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -140,6 +140,10 @@ async def _upgrade_password_hash(
 
 logger = logging.getLogger(__name__)
 
+# Keep the password-verification path uniform when an address does not resolve
+# to a password account. This value never belongs to a user.
+_DUMMY_PASSWORD_HASH = get_password_hash("initiative-login-dummy-password")
+
 # Shared across requests so provider discovery + JWKS caching work; the
 # per-request OidcProvider is just configuration composed around them.
 _oidc_discovery = OidcDiscovery()
@@ -408,35 +412,13 @@ async def login_access_token(
     statement = select(User).where(User.email_hash == hash_email(normalized_email))
     result = await session.exec(statement)
     user = result.one_or_none()
-    if not user or not verify_password(form_data.password, user.hashed_password):
-        # Nothing recorded a failed sign-in, so nothing could tell that one
-        # account was being attacked from many addresses. The per-IP limit above
-        # bounds one client and says nothing about that shape.
-        #
-        # The user id is logged when the account exists and omitted when it does
-        # not, which is what makes this useful to alert on — repeated failures
-        # carrying the same id are one account under attack, rather than a
-        # spray. The HTTP response is byte-identical either way, so this adds
-        # nothing a caller can read off the response.
-        #
-        # It does NOT make the endpoint enumeration-proof, and this line should
-        # not be read as claiming that. The condition above short-circuits, so
-        # verify_password never runs for an unknown address: the hit path pays
-        # ~88 ms of password hashing (measured on this branch) and the miss path
-        # pays none, which is observable over a network. That timing oracle
-        # predates this change and is untouched by it; closing it means a
-        # dummy-hash verify on the miss path, which is its own change.
-        #
-        # Never the submitted address: it would put an unverified,
-        # attacker-chosen string into the log, and every log reader downstream
-        # would inherit it. get_inet_client_ip applies the same rule to the
-        # address — under BEHIND_PROXY the raw value is the leftmost
-        # X-Forwarded-For entry, which the client supplies and can pack with
-        # spaces and "key=value" text to forge a different account's id into a
-        # parsed log line. It returns the NORMALIZED address or None, never the
-        # raw header text: validating a string is not the same as sanitizing it,
-        # and ipaddress.ip_address() accepts an IPv6 zone identifier containing
-        # spaces.
+    password_hash = (
+        user.hashed_password if user and user.hashed_password else _DUMMY_PASSWORD_HASH
+    )
+    password_matches = verify_password(form_data.password, password_hash)
+    if not user or not password_matches:
+        # Record the target account when available while keeping the submitted
+        # address out of logs and preserving the generic failure response.
         logger.warning(
             "auth.login_failed user_id=%s ip=%s reason=%s",
             user.id if user else "-",
@@ -448,11 +430,7 @@ async def login_access_token(
             detail=AuthMessages.INCORRECT_CREDENTIALS,
         )
 
-    # The two branches below are also failed sign-ins, and they are the ones
-    # worth waking up for: the password was CORRECT. A hit here means someone
-    # holds a live credential for an account that cannot currently be used, so
-    # a disabled account is not the end of the story — that password is valid
-    # and may be valid elsewhere.
+    # These are failed sign-ins even though the password itself matched.
     if user.status != UserStatus.active:
         logger.warning(
             "auth.login_failed user_id=%s ip=%s reason=%s",

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -433,8 +433,10 @@ async def login_access_token(
         # address — under BEHIND_PROXY the raw value is the leftmost
         # X-Forwarded-For entry, which the client supplies and can pack with
         # spaces and "key=value" text to forge a different account's id into a
-        # parsed log line. get_inet_client_ip returns it only if it parses as an
-        # IP address, and None if it does not.
+        # parsed log line. It returns the NORMALIZED address or None, never the
+        # raw header text: validating a string is not the same as sanitizing it,
+        # and ipaddress.ip_address() accepts an IPv6 zone identifier containing
+        # spaces.
         logger.warning(
             "auth.login_failed user_id=%s ip=%s reason=%s",
             user.id if user else "-",

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -409,16 +409,65 @@ async def login_access_token(
     result = await session.exec(statement)
     user = result.one_or_none()
     if not user or not verify_password(form_data.password, user.hashed_password):
+        # Nothing recorded a failed sign-in, so nothing could tell that one
+        # account was being attacked from many addresses. The per-IP limit above
+        # bounds one client and says nothing about that shape.
+        #
+        # The user id is logged when the account exists and omitted when it does
+        # not, which is what makes this useful to alert on — repeated failures
+        # carrying the same id are one account under attack, rather than a
+        # spray. The HTTP response is byte-identical either way, so this adds
+        # nothing a caller can read off the response.
+        #
+        # It does NOT make the endpoint enumeration-proof, and this line should
+        # not be read as claiming that. The condition above short-circuits, so
+        # verify_password never runs for an unknown address: the hit path pays
+        # ~88 ms of password hashing (measured on this branch) and the miss path
+        # pays none, which is observable over a network. That timing oracle
+        # predates this change and is untouched by it; closing it means a
+        # dummy-hash verify on the miss path, which is its own change.
+        #
+        # Never the submitted address: it would put an unverified,
+        # attacker-chosen string into the log, and every log reader downstream
+        # would inherit it. get_inet_client_ip applies the same rule to the
+        # address — under BEHIND_PROXY the raw value is the leftmost
+        # X-Forwarded-For entry, which the client supplies and can pack with
+        # spaces and "key=value" text to forge a different account's id into a
+        # parsed log line. get_inet_client_ip returns it only if it parses as an
+        # IP address, and None if it does not.
+        logger.warning(
+            "auth.login_failed user_id=%s ip=%s reason=%s",
+            user.id if user else "-",
+            get_inet_client_ip(request) or "-",
+            "bad_password" if user else "no_such_account",
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=AuthMessages.INCORRECT_CREDENTIALS,
         )
 
+    # The two branches below are also failed sign-ins, and they are the ones
+    # worth waking up for: the password was CORRECT. A hit here means someone
+    # holds a live credential for an account that cannot currently be used, so
+    # a disabled account is not the end of the story — that password is valid
+    # and may be valid elsewhere.
     if user.status != UserStatus.active:
+        logger.warning(
+            "auth.login_failed user_id=%s ip=%s reason=%s",
+            user.id,
+            get_inet_client_ip(request) or "-",
+            "account_not_active",
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=AuthMessages.INACTIVE_USER
         )
     if not user.email_verified:
+        logger.warning(
+            "auth.login_failed user_id=%s ip=%s reason=%s",
+            user.id,
+            get_inet_client_ip(request) or "-",
+            "email_unverified",
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=AuthMessages.EMAIL_NOT_VERIFIED,

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -9,12 +9,11 @@ Tests the auth API endpoints including:
 - Password reset
 """
 
+import logging
 from datetime import timedelta
 from urllib.parse import parse_qs, urlsplit
 
 import httpx
-import logging
-
 import pytest
 from httpx import AsyncClient
 from sqlmodel import select
@@ -41,7 +40,6 @@ from app.models.platform.auth_session import AuthSession
 from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.federated_identity_secret import FederatedIdentitySecret
 from app.models.platform.user import User, UserStatus
-from app.core.config import settings
 from app.services.auth.oidc.provider import OidcClientConfig, OidcProvider
 from app.services.auth.platform_provider import PLATFORM_OIDC_SLUG
 from app.testing.factories import (
@@ -443,28 +441,12 @@ async def test_login_wrong_password(client: AsyncClient, session: AsyncSession):
 async def test_login_failure_is_recorded_against_the_account(
     client: AsyncClient, session: AsyncSession, caplog
 ):
-    """A failed attempt names the account in the log, and nothing in the response.
-
-    Repeated failures carrying the same user id are one account under attack;
-    the per-IP rate limit cannot see that shape. The HTTP response stays
-    byte-identical to the unknown-account case, so nothing readable off the
-    response changes. This does not make the endpoint enumeration-proof — the
-    miss path short-circuits before verify_password and so returns much faster.
-    That oracle predates this change; see the comment in auth.py.
-    """
-    password = "correct_password"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("recorded@example.com"),
-        email_encrypted=encrypt_field("recorded@example.com", SALT_EMAIL),
-        full_name="Test User",
-        hashed_password=get_password_hash(password),
-        status=UserStatus.active,
-        email_verified=True,
+    """A failed attempt names a known account only in the server-side log."""
+    user = await create_user(
+        session,
+        email="recorded@example.com",
+        hashed_password=get_password_hash("correct_password"),
     )
-    session.add(user)
-    await session.commit()
 
     with caplog.at_level(logging.WARNING):
         response = await client.post(
@@ -478,47 +460,55 @@ async def test_login_failure_is_recorded_against_the_account(
     ]
     assert logged, "a failed sign-in was not recorded"
     assert f"user_id={user.id}" in logged[-1]
-    # The submitted address never reaches the log: it is attacker-chosen and
-    # unverified, and every reader downstream would inherit it.
     assert "recorded@example.com" not in logged[-1]
+
+    unknown_response = await client.post(
+        "/api/v1/auth/token",
+        data={"username": "unknown@example.com", "password": "wrong_password"},
+    )
+    assert unknown_response.status_code == response.status_code
+    assert unknown_response.json() == response.json()
+    assert unknown_response.headers["content-type"] == response.headers["content-type"]
+
+
+async def test_unknown_account_still_runs_password_verification(
+    client: AsyncClient, monkeypatch
+):
+    """An unknown address must pay the same password-check cost as a known one."""
+    checked: list[tuple[str, str | None]] = []
+
+    def record_verification(password: str, stored_hash: str | None) -> bool:
+        checked.append((password, stored_hash))
+        return False
+
+    monkeypatch.setattr(
+        "app.api.v1.platform_endpoints.auth.verify_password", record_verification
+    )
+    response = await client.post(
+        "/api/v1/auth/token",
+        data={"username": "unknown@example.com", "password": "offered-password"},
+    )
+
+    assert response.status_code == 400
+    assert len(checked) == 1
+    assert checked[0][0] == "offered-password"
+    assert checked[0][1]
 
 
 async def test_login_failure_log_cannot_be_forged_through_x_forwarded_for(
-    client: AsyncClient, session: AsyncSession, caplog, monkeypatch
+    client: AsyncClient, session: AsyncSession, caplog
 ):
-    """A client-supplied X-Forwarded-For cannot inject fields into the log line.
-
-    Under BEHIND_PROXY the client IP is read from the leftmost X-Forwarded-For
-    entry, which the client controls. If that value reached the log unparsed, an
-    attacker could append " user_id=1 ip=10.0.0.1" and have any parser splitting
-    on key=value attribute a failure to an account of their choosing — which is
-    exactly the detection this log line exists to support.
-    """
-    monkeypatch.setattr(settings, "BEHIND_PROXY", True)
-    password = "correct_password"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("forge@example.com"),
-        email_encrypted=encrypt_field("forge@example.com", SALT_EMAIL),
-        full_name="Test User",
-        hashed_password=get_password_hash(password),
-        status=UserStatus.active,
-        email_verified=True,
+    """The log uses the client selected by the ASGI proxy trust boundary."""
+    user = await create_user(
+        session,
+        email="forge@example.com",
+        hashed_password=get_password_hash("correct_password"),
     )
-    session.add(user)
-    await session.commit()
 
     with caplog.at_level(logging.WARNING):
         response = await client.post(
             "/api/v1/auth/token",
             data={"username": "forge@example.com", "password": "wrong_password"},
-            # An IPv6 zone identifier, not an IPv4-shaped payload. This is the
-            # one that matters: ipaddress.ip_address() ACCEPTS
-            # "fe80::1% user_id=1 ip=10.0.0.1" and barely checks the zone, so a
-            # validate-then-return-the-raw-string implementation lets the whole
-            # payload through. An IPv4-shaped attempt fails parsing and would
-            # pass this test without proving anything.
             headers={"X-Forwarded-For": "fe80::1% user_id=1 ip=10.0.0.1"},
         )
 
@@ -528,14 +518,10 @@ async def test_login_failure_log_cannot_be_forged_through_x_forwarded_for(
     ]
     assert logged, "a failed sign-in was not recorded"
     line = logged[-1]
-    # Exactly one user_id field, and it is the real account.
     assert line.count("user_id=") == 1
     assert f"user_id={user.id}" in line
-    # Exactly one ip field. The zone identifier carrying the payload is dropped,
-    # leaving the normalized address.
     assert line.count("ip=") == 1
-    assert "ip=fe80::1 " in line
-    # No fragment of the payload survives anywhere in the line.
+    assert "ip=127.0.0.1 " in line
     assert "10.0.0.1" not in line
     assert "%" not in line
     assert "forge@example.com" not in line
@@ -544,25 +530,14 @@ async def test_login_failure_log_cannot_be_forged_through_x_forwarded_for(
 async def test_login_failure_is_recorded_for_a_correct_password_on_a_blocked_account(
     client: AsyncClient, session: AsyncSession, caplog
 ):
-    """A correct password against an unusable account is still recorded.
-
-    This is the case worth waking up for: the credential is valid. Logging only
-    the wrong-password branch would make a live credential against a disabled
-    account the one failed sign-in that produces no signal at all.
-    """
+    """A matching password against an unusable account is still recorded."""
     password = "correct_password"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("blocked@example.com"),
-        email_encrypted=encrypt_field("blocked@example.com", SALT_EMAIL),
-        full_name="Test User",
+    user = await create_user(
+        session,
+        email="blocked@example.com",
         hashed_password=get_password_hash(password),
         status=UserStatus.deactivated,
-        email_verified=True,
     )
-    session.add(user)
-    await session.commit()
 
     with caplog.at_level(logging.WARNING):
         response = await client.post(

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -513,7 +513,13 @@ async def test_login_failure_log_cannot_be_forged_through_x_forwarded_for(
         response = await client.post(
             "/api/v1/auth/token",
             data={"username": "forge@example.com", "password": "wrong_password"},
-            headers={"X-Forwarded-For": "1.2.3.4 user_id=1 ip=10.0.0.1"},
+            # An IPv6 zone identifier, not an IPv4-shaped payload. This is the
+            # one that matters: ipaddress.ip_address() ACCEPTS
+            # "fe80::1% user_id=1 ip=10.0.0.1" and barely checks the zone, so a
+            # validate-then-return-the-raw-string implementation lets the whole
+            # payload through. An IPv4-shaped attempt fails parsing and would
+            # pass this test without proving anything.
+            headers={"X-Forwarded-For": "fe80::1% user_id=1 ip=10.0.0.1"},
         )
 
     assert response.status_code == 400
@@ -525,13 +531,14 @@ async def test_login_failure_log_cannot_be_forged_through_x_forwarded_for(
     # Exactly one user_id field, and it is the real account.
     assert line.count("user_id=") == 1
     assert f"user_id={user.id}" in line
-    # The forged payload is dropped whole, not partially escaped.
-    assert "10.0.0.1" not in line
-    assert "1.2.3.4" not in line
-    # Exactly one ip field, holding the sentinel: the unparseable header value
-    # was discarded rather than trimmed down to something that still parses.
+    # Exactly one ip field. The zone identifier carrying the payload is dropped,
+    # leaving the normalized address.
     assert line.count("ip=") == 1
-    assert "ip=- " in line or line.endswith("ip=-")
+    assert "ip=fe80::1 " in line
+    # No fragment of the payload survives anywhere in the line.
+    assert "10.0.0.1" not in line
+    assert "%" not in line
+    assert "forge@example.com" not in line
 
 
 async def test_login_failure_is_recorded_for_a_correct_password_on_a_blocked_account(

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -13,6 +13,8 @@ from datetime import timedelta
 from urllib.parse import parse_qs, urlsplit
 
 import httpx
+import logging
+
 import pytest
 from httpx import AsyncClient
 from sqlmodel import select
@@ -39,6 +41,7 @@ from app.models.platform.auth_session import AuthSession
 from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.federated_identity_secret import FederatedIdentitySecret
 from app.models.platform.user import User, UserStatus
+from app.core.config import settings
 from app.services.auth.oidc.provider import OidcClientConfig, OidcProvider
 from app.services.auth.platform_provider import PLATFORM_OIDC_SLUG
 from app.testing.factories import (
@@ -435,6 +438,158 @@ async def test_login_wrong_password(client: AsyncClient, session: AsyncSession):
 
     assert response.status_code == 400
     assert "incorrect" in response.json()["detail"].lower()
+
+
+async def test_login_failure_is_recorded_against_the_account(
+    client: AsyncClient, session: AsyncSession, caplog
+):
+    """A failed attempt names the account in the log, and nothing in the response.
+
+    Repeated failures carrying the same user id are one account under attack;
+    the per-IP rate limit cannot see that shape. The HTTP response stays
+    byte-identical to the unknown-account case, so nothing readable off the
+    response changes. This does not make the endpoint enumeration-proof — the
+    miss path short-circuits before verify_password and so returns much faster.
+    That oracle predates this change; see the comment in auth.py.
+    """
+    password = "correct_password"
+    user = User(
+        username=usernames.random_name(),
+        discriminator=usernames.random_discriminator(),
+        email_hash=hash_email("recorded@example.com"),
+        email_encrypted=encrypt_field("recorded@example.com", SALT_EMAIL),
+        full_name="Test User",
+        hashed_password=get_password_hash(password),
+        status=UserStatus.active,
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+
+    with caplog.at_level(logging.WARNING):
+        response = await client.post(
+            "/api/v1/auth/token",
+            data={"username": "recorded@example.com", "password": "wrong_password"},
+        )
+
+    assert response.status_code == 400
+    logged = [
+        r.getMessage() for r in caplog.records if "auth.login_failed" in r.getMessage()
+    ]
+    assert logged, "a failed sign-in was not recorded"
+    assert f"user_id={user.id}" in logged[-1]
+    # The submitted address never reaches the log: it is attacker-chosen and
+    # unverified, and every reader downstream would inherit it.
+    assert "recorded@example.com" not in logged[-1]
+
+
+async def test_login_failure_log_cannot_be_forged_through_x_forwarded_for(
+    client: AsyncClient, session: AsyncSession, caplog, monkeypatch
+):
+    """A client-supplied X-Forwarded-For cannot inject fields into the log line.
+
+    Under BEHIND_PROXY the client IP is read from the leftmost X-Forwarded-For
+    entry, which the client controls. If that value reached the log unparsed, an
+    attacker could append " user_id=1 ip=10.0.0.1" and have any parser splitting
+    on key=value attribute a failure to an account of their choosing — which is
+    exactly the detection this log line exists to support.
+    """
+    monkeypatch.setattr(settings, "BEHIND_PROXY", True)
+    password = "correct_password"
+    user = User(
+        username=usernames.random_name(),
+        discriminator=usernames.random_discriminator(),
+        email_hash=hash_email("forge@example.com"),
+        email_encrypted=encrypt_field("forge@example.com", SALT_EMAIL),
+        full_name="Test User",
+        hashed_password=get_password_hash(password),
+        status=UserStatus.active,
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+
+    with caplog.at_level(logging.WARNING):
+        response = await client.post(
+            "/api/v1/auth/token",
+            data={"username": "forge@example.com", "password": "wrong_password"},
+            headers={"X-Forwarded-For": "1.2.3.4 user_id=1 ip=10.0.0.1"},
+        )
+
+    assert response.status_code == 400
+    logged = [
+        r.getMessage() for r in caplog.records if "auth.login_failed" in r.getMessage()
+    ]
+    assert logged, "a failed sign-in was not recorded"
+    line = logged[-1]
+    # Exactly one user_id field, and it is the real account.
+    assert line.count("user_id=") == 1
+    assert f"user_id={user.id}" in line
+    # The forged payload is dropped whole, not partially escaped.
+    assert "10.0.0.1" not in line
+    assert "1.2.3.4" not in line
+    # Exactly one ip field, holding the sentinel: the unparseable header value
+    # was discarded rather than trimmed down to something that still parses.
+    assert line.count("ip=") == 1
+    assert "ip=- " in line or line.endswith("ip=-")
+
+
+async def test_login_failure_is_recorded_for_a_correct_password_on_a_blocked_account(
+    client: AsyncClient, session: AsyncSession, caplog
+):
+    """A correct password against an unusable account is still recorded.
+
+    This is the case worth waking up for: the credential is valid. Logging only
+    the wrong-password branch would make a live credential against a disabled
+    account the one failed sign-in that produces no signal at all.
+    """
+    password = "correct_password"
+    user = User(
+        username=usernames.random_name(),
+        discriminator=usernames.random_discriminator(),
+        email_hash=hash_email("blocked@example.com"),
+        email_encrypted=encrypt_field("blocked@example.com", SALT_EMAIL),
+        full_name="Test User",
+        hashed_password=get_password_hash(password),
+        status=UserStatus.deactivated,
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+
+    with caplog.at_level(logging.WARNING):
+        response = await client.post(
+            "/api/v1/auth/token",
+            data={"username": "blocked@example.com", "password": password},
+        )
+
+    assert response.status_code == 400
+    logged = [
+        r.getMessage() for r in caplog.records if "auth.login_failed" in r.getMessage()
+    ]
+    assert logged, "a correct password on a deactivated account was not recorded"
+    assert f"user_id={user.id}" in logged[-1]
+    assert "reason=account_not_active" in logged[-1]
+    assert "blocked@example.com" not in logged[-1]
+
+
+async def test_login_failure_for_unknown_account_names_no_user(
+    client: AsyncClient, caplog
+):
+    """No account, no id — and the same 400 the caller gets when one exists."""
+    with caplog.at_level(logging.WARNING):
+        response = await client.post(
+            "/api/v1/auth/token",
+            data={"username": "nobody@example.com", "password": "whatever"},
+        )
+
+    assert response.status_code == 400
+    logged = [
+        r.getMessage() for r in caplog.records if "auth.login_failed" in r.getMessage()
+    ]
+    assert logged, "a failed sign-in was not recorded"
+    assert "user_id=-" in logged[-1]
+    assert "nobody@example.com" not in logged[-1]
 
 
 async def test_login_refused_for_account_without_password(

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -10,23 +10,12 @@ from app.core.config import settings
 
 
 def get_real_client_ip(request: Request) -> str:
+    """Return the client selected by the configured ASGI proxy trust boundary.
+
+    Uvicorn validates the immediate peer against ``FORWARDED_ALLOW_IPS`` and
+    updates ``request.client`` before the application receives the request.
+    Reading forwarding headers again here would bypass that decision.
     """
-    Get the real client IP address, accounting for proxies.
-
-    Only trusts X-Forwarded-For/X-Real-IP headers when BEHIND_PROXY=True,
-    preventing header spoofing when directly exposed to the internet.
-    """
-    if settings.BEHIND_PROXY:
-        # X-Forwarded-For may contain multiple IPs: client, proxy1, proxy2, ...
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            return forwarded_for.split(",")[0].strip()
-
-        real_ip = request.headers.get("X-Real-IP")
-        if real_ip:
-            return real_ip.strip()
-
-    # Direct connection IP (or BEHIND_PROXY not set)
     return get_remote_address(request)
 
 
@@ -35,26 +24,11 @@ def get_inet_client_ip(request: Request) -> str | None:
     isn't a parseable address (e.g. the ``testclient`` peer). Guards session
     bookkeeping writes from faulting on a non-IP host string.
 
-    Returns the NORMALIZED address, never the raw header text. Under
-    ``BEHIND_PROXY`` the raw value is the leftmost ``X-Forwarded-For`` entry,
-    which the client supplies, and validating it is not the same as sanitizing
-    it. ``ipaddress.ip_address`` accepts an IPv6 zone identifier and barely
-    checks it, so::
-
-        ipaddress.ip_address("fe80::1% user_id=1 ip=10.0.0.1")
-
-    parses. An earlier version validated the raw string and then returned that
-    same string, so spaces and ``=`` reached the caller: enough to forge fields
-    into a ``key=value`` log line, and enough for Postgres to reject the write
-    this function exists to protect, since ``inet`` does not accept a zone id
-    at all.
-
-    The zone is dropped before parsing, and the parsed object is rendered back
-    out, so the result contains only hex digits, dots and colons.
+    The address is normalized and any IPv6 zone identifier is dropped because
+    Postgres ``inet`` stores network addresses without an interface scope.
     """
     raw = get_real_client_ip(request)
-    # Drop any IPv6 zone identifier: meaningless off-host, rejected by inet,
-    # and the part of the grammar that is not validated.
+    # A zone identifies a local interface and is not meaningful in stored data.
     candidate = raw.split("%", 1)[0]
     try:
         parsed = ipaddress.ip_address(candidate)

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -33,12 +33,34 @@ def get_real_client_ip(request: Request) -> str:
 def get_inet_client_ip(request: Request) -> str | None:
     """The client IP as a value an INET column accepts, or ``None`` when it
     isn't a parseable address (e.g. the ``testclient`` peer). Guards session
-    bookkeeping writes from faulting on a non-IP host string."""
+    bookkeeping writes from faulting on a non-IP host string.
+
+    Returns the NORMALIZED address, never the raw header text. Under
+    ``BEHIND_PROXY`` the raw value is the leftmost ``X-Forwarded-For`` entry,
+    which the client supplies, and validating it is not the same as sanitizing
+    it. ``ipaddress.ip_address`` accepts an IPv6 zone identifier and barely
+    checks it, so::
+
+        ipaddress.ip_address("fe80::1% user_id=1 ip=10.0.0.1")
+
+    parses. An earlier version validated the raw string and then returned that
+    same string, so spaces and ``=`` reached the caller: enough to forge fields
+    into a ``key=value`` log line, and enough for Postgres to reject the write
+    this function exists to protect, since ``inet`` does not accept a zone id
+    at all.
+
+    The zone is dropped before parsing, and the parsed object is rendered back
+    out, so the result contains only hex digits, dots and colons.
+    """
+    raw = get_real_client_ip(request)
+    # Drop any IPv6 zone identifier: meaningless off-host, rejected by inet,
+    # and the part of the grammar that is not validated.
+    candidate = raw.split("%", 1)[0]
     try:
-        ipaddress.ip_address(get_real_client_ip(request))
+        parsed = ipaddress.ip_address(candidate)
     except ValueError:
         return None
-    return get_real_client_ip(request)
+    return str(parsed)
 
 
 def _default_limits() -> list[str]:

--- a/backend/app/core/rate_limit_test.py
+++ b/backend/app/core/rate_limit_test.py
@@ -16,7 +16,12 @@ from slowapi.middleware import SlowAPIMiddleware
 
 from app.core import rate_limit
 from app.core.config import settings
-from app.core.rate_limit import _default_limits, get_real_client_ip, limiter
+from app.core.rate_limit import (
+    _default_limits,
+    get_inet_client_ip,
+    get_real_client_ip,
+    limiter,
+)
 from app.main import app
 
 
@@ -119,3 +124,59 @@ class TestDefaultLimitThrottlesUndecoratedRoute:
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             statuses = [(await c.get("/undecorated")).status_code for _ in range(10)]
         assert all(code == 200 for code in statuses)
+
+
+class TestInetClientIp:
+    """``get_inet_client_ip`` must SANITIZE, not merely validate.
+
+    Under ``BEHIND_PROXY`` the raw value is the leftmost ``X-Forwarded-For``
+    entry, which the client supplies. Callers write it to an ``inet`` column and
+    into log lines assembled as ``key=value``, so anything that survives here
+    reaches both.
+    """
+
+    @staticmethod
+    def _request(monkeypatch, forwarded: str):
+        monkeypatch.setattr(settings, "BEHIND_PROXY", True)
+
+        class _Req:
+            headers = {"X-Forwarded-For": forwarded}
+            client = None
+
+        return _Req()
+
+    def test_an_ipv6_zone_identifier_cannot_smuggle_a_payload(self, monkeypatch):
+        """The zone id is the part of the grammar that is barely validated.
+
+        ``ipaddress.ip_address("fe80::1% user_id=1 ip=10.0.0.1")`` PARSES. A
+        validate-then-return-the-raw-string implementation therefore passes
+        spaces and ``=`` straight through to the caller.
+        """
+        req = self._request(monkeypatch, "fe80::1% user_id=1 ip=10.0.0.1")
+        result = get_inet_client_ip(req)
+        assert result == "fe80::1"
+        assert "%" not in result
+        assert " " not in result
+        assert "=" not in result
+
+    def test_a_plain_zone_identifier_is_dropped(self, monkeypatch):
+        """``inet`` does not accept a zone id, and it is meaningless off-host."""
+        assert (
+            get_inet_client_ip(self._request(monkeypatch, "fe80::1%eth0")) == "fe80::1"
+        )
+
+    def test_addresses_come_back_normalized(self, monkeypatch):
+        assert (
+            get_inet_client_ip(self._request(monkeypatch, "2001:DB8::1"))
+            == "2001:db8::1"
+        )
+        assert (
+            get_inet_client_ip(self._request(monkeypatch, "203.0.113.9"))
+            == "203.0.113.9"
+        )
+
+    def test_a_non_address_is_refused(self, monkeypatch):
+        assert (
+            get_inet_client_ip(self._request(monkeypatch, "1.2.3.4 user_id=1")) is None
+        )
+        assert get_inet_client_ip(self._request(monkeypatch, "not-an-ip")) is None

--- a/backend/app/core/rate_limit_test.py
+++ b/backend/app/core/rate_limit_test.py
@@ -13,6 +13,7 @@ from httpx import ASGITransport, AsyncClient
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from starlette.datastructures import Headers
 
 from app.core import rate_limit
 from app.core.config import settings
@@ -127,56 +128,46 @@ class TestDefaultLimitThrottlesUndecoratedRoute:
 
 
 class TestInetClientIp:
-    """``get_inet_client_ip`` must SANITIZE, not merely validate.
-
-    Under ``BEHIND_PROXY`` the raw value is the leftmost ``X-Forwarded-For``
-    entry, which the client supplies. Callers write it to an ``inet`` column and
-    into log lines assembled as ``key=value``, so anything that survives here
-    reaches both.
-    """
+    """``get_inet_client_ip`` returns a value suitable for Postgres ``inet``."""
 
     @staticmethod
-    def _request(monkeypatch, forwarded: str):
-        monkeypatch.setattr(settings, "BEHIND_PROXY", True)
+    def _request(address: str):
+        class _Client:
+            host = address
 
         class _Req:
-            headers = {"X-Forwarded-For": forwarded}
-            client = None
+            headers = {}
+            client = _Client()
 
         return _Req()
 
-    def test_an_ipv6_zone_identifier_cannot_smuggle_a_payload(self, monkeypatch):
-        """The zone id is the part of the grammar that is barely validated.
-
-        ``ipaddress.ip_address("fe80::1% user_id=1 ip=10.0.0.1")`` PARSES. A
-        validate-then-return-the-raw-string implementation therefore passes
-        spaces and ``=`` straight through to the caller.
-        """
-        req = self._request(monkeypatch, "fe80::1% user_id=1 ip=10.0.0.1")
+    def test_an_ipv6_zone_identifier_is_removed(self):
+        req = self._request("fe80::1%eth0")
         result = get_inet_client_ip(req)
         assert result == "fe80::1"
         assert "%" not in result
-        assert " " not in result
-        assert "=" not in result
 
-    def test_a_plain_zone_identifier_is_dropped(self, monkeypatch):
-        """``inet`` does not accept a zone id, and it is meaningless off-host."""
-        assert (
-            get_inet_client_ip(self._request(monkeypatch, "fe80::1%eth0")) == "fe80::1"
-        )
+    def test_addresses_come_back_normalized(self):
+        assert get_inet_client_ip(self._request("2001:DB8::1")) == "2001:db8::1"
+        assert get_inet_client_ip(self._request("203.0.113.9")) == "203.0.113.9"
 
-    def test_addresses_come_back_normalized(self, monkeypatch):
-        assert (
-            get_inet_client_ip(self._request(monkeypatch, "2001:DB8::1"))
-            == "2001:db8::1"
-        )
-        assert (
-            get_inet_client_ip(self._request(monkeypatch, "203.0.113.9"))
-            == "203.0.113.9"
-        )
+    def test_a_non_address_is_refused(self):
+        assert get_inet_client_ip(self._request("not-an-ip")) is None
 
-    def test_a_non_address_is_refused(self, monkeypatch):
-        assert (
-            get_inet_client_ip(self._request(monkeypatch, "1.2.3.4 user_id=1")) is None
-        )
-        assert get_inet_client_ip(self._request(monkeypatch, "not-an-ip")) is None
+
+class TestRealClientIp:
+    def test_forwarded_headers_do_not_bypass_the_asgi_trust_boundary(self):
+        """The ASGI server, not application code, decides which proxy to trust."""
+        class _Client:
+            host = "198.51.100.7"
+
+        class _Request:
+            headers = Headers(
+                {
+                    "X-Forwarded-For": "203.0.113.9",
+                    "X-Real-IP": "203.0.113.10",
+                }
+            )
+            client = _Client()
+
+        assert get_real_client_ip(_Request()) == "198.51.100.7"

--- a/backend/app/core/rate_limit_test.py
+++ b/backend/app/core/rate_limit_test.py
@@ -158,6 +158,7 @@ class TestInetClientIp:
 class TestRealClientIp:
     def test_forwarded_headers_do_not_bypass_the_asgi_trust_boundary(self):
         """The ASGI server, not application code, decides which proxy to trust."""
+
         class _Client:
             host = "198.51.100.7"
 


### PR DESCRIPTION
**Threat:** T20 (`Morelitea/security`, Boundary 3). Severity **Medium**. NIST AC-7, AU-2, SI-4.
**Work item:** WI-13 — **partially met**, deliberately. See below.

## Why

Nothing recorded a failed sign-in. The per-IP rate limit on `/auth/token` bounds one client and **cannot see one account being attacked from many addresses** — which is the shape credential stuffing actually has.

Being precise about what that rate limit actually does, since this change is partly justified by its gap: `limiter` keys on `get_real_client_ip`, which under `BEHIND_PROXY` is the client-supplied leftmost `X-Forwarded-For` entry. Unless the edge overwrites that header, an attacker picks their own bucket and the `5/15minutes` limit bounds nothing. So the case for recording failures per account is stronger than "the rate limit covers a different shape" — on that path it may cover nothing.

## What it logs, and what it does not

The **user id** when the account exists, and `-` when it does not. That is what makes it worth alerting on: repeated failures carrying the same id are one account under attack rather than a spray.

**The response is byte-identical either way**, so nothing a caller can observe changes and `PreventUserExistenceErrors` still holds. Both tests assert that.

**The submitted address is never logged.** It is attacker-chosen and unverified, and every log reader downstream would inherit it — a log is a place strings go to be read by other systems.

## The half that is not here

WI-13 asked for a per-account counter that a successful sign-in clears. That is not in this PR, and I would rather say so than quietly redefine the item:

- **A counter means a migration on the `users` table.** Feasible — this repo has alembic — but it is a schema change on every deployment for a Medium finding, and it deserves its own review.
- **A lockout built on it turns a credential-stuffing nuisance into a denial-of-service tool** against named users. Anyone who knows an address can lock its owner out. That is a product decision about which failure mode you prefer, not something to pick inside a security fix.

What is here is the part that needs neither: nothing recorded these events at all, and now something does.

## Verification

**Four** new tests: the id is present for a known account and absent for an unknown one; a correct password on a deactivated account is still recorded; a forged `X-Forwarded-For` cannot inject a second `user_id` field; and the submitted address appears in none of them.

Plus four in `rate_limit_test.py`, which had no coverage of `get_inet_client_ip` at all.

Against a local Postgres, each suite **run on its own** — two concurrent pytest runs against one Postgres deadlock and produce spurious failures:

```
app/core/rate_limit_test.py                   15 passed
app/api/v1/platform_endpoints/auth_test.py    78 passed
```

`ruff check` and `ruff format --check` clean. (An earlier revision said "76 tests" — that is the count of `def test_` functions, not what pytest collects.)

### One behaviour change worth knowing

`get_inet_client_ip` now returns the **normalized** address, so `::ffff:1.2.3.4` is stored as `::ffff:102:304`. Six call sites write that value into session bookkeeping. Nothing compares stored IPs for equality outside test assertions, so nothing breaks — but rows written before and after this change differ in form.

I ran the auth file rather than the whole suite: the full run wants the two-port PgBouncer topology CI builds, and this change touches one code path. CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5xdKhPXJT4HMWwUyENiu1
