### PR TITLE
Support zero-downtime billing HMAC rotation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -143,6 +143,14 @@ UPLOADS_DIR=uploads
 # APP_SERVICES_CONFIG=/etc/initiative/app-services.json
 # APP_SERVICE_VERIFY_INTERVAL_SECONDS=3600
 
+# Hosted billing HMAC. Self-hosted deployments leave both unset. During a
+# staged rotation, the supported chart puts the next value in PREVIOUS before
+# cutover, then the old value there after cutover. Clear it only after
+# `billing.envelope_verified_with_previous_secret` stops appearing. See
+# Morelitea/initiative_infra docs/runbooks/billing-hmac-rotation.md.
+# BILLING_HMAC_SECRET=
+# BILLING_HMAC_SECRET_PREVIOUS=
+
 # --- Advanced --------------------------------------------------------------------
 
 # Rotating SECRET_KEY: move the old key here, set a new SECRET_KEY, and restart —

--- a/backend/app/api/v1/platform_endpoints/billing_test.py
+++ b/backend/app/api/v1/platform_endpoints/billing_test.py
@@ -77,12 +77,14 @@ _OTHER_PUBLIC_PEM = (
 )
 
 _HMAC_SECRET = "test-billing-hmac-secret"
+_PREVIOUS_HMAC_SECRET = "previous-test-billing-hmac-secret"
 
 
 @pytest.fixture(autouse=True)
 def _configure_billing(monkeypatch):
     monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", _PUBLIC_PEM)
     monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET", _HMAC_SECRET)
+    monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET_PREVIOUS", None)
 
 
 def _mint_token(
@@ -187,6 +189,24 @@ async def test_wrong_hmac_secret_rejected(client: AsyncClient, session: AsyncSes
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_SIGNATURE"
+
+
+async def test_previous_hmac_secret_is_accepted_during_rotation(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_HMAC_SECRET_PREVIOUS",
+        _PREVIOUS_HMAC_SECRET,
+    )
+    guild = await create_guild(session)
+    response = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, storage_cap_bytes=4096),
+        secret=_PREVIOUS_HMAC_SECRET,
+    )
+    assert response.status_code == 200
 
 
 async def test_tampered_body_rejected(client: AsyncClient, session: AsyncSession):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -735,10 +735,14 @@ class Settings(BaseSettings):
     # The public key accepts more than one key, as concatenated PEM blocks, so
     # billing can rotate its signing key without downtime: append the new key,
     # let billing start signing with it, then drop the old block. A token is
-    # accepted if any block verifies it. (The shared secret takes one value —
-    # rotating it is a separate change on both sides.)
+    # accepted if any block verifies it. The HMAC has a second accepted value
+    # for the same staged rotation protocol.
     BILLING_PUBLIC_KEY_PEM: str | None = None
     BILLING_HMAC_SECRET: str | None = None
+    # Second accepted HMAC value during a staged rotation. It may hold the next
+    # value before the cutover or the old value afterwards; clear it only once
+    # every billing instance signs with BILLING_HMAC_SECRET.
+    BILLING_HMAC_SECRET_PREVIOUS: str | None = None
     BILLING_AUDIENCE: str = "initiative:billing"
     BILLING_ISSUER: str = "initiative-billing"
     # Max |now - signed timestamp| accepted, in seconds. Never 0.

--- a/backend/app/services/platform/billing.py
+++ b/backend/app/services/platform/billing.py
@@ -130,11 +130,24 @@ def verify_billing_envelope(
     message = "\n".join(
         [method.upper(), path, ts_header, hashlib.sha256(body).hexdigest()]
     ).encode()
-    expected = hmac.new(
-        settings.BILLING_HMAC_SECRET.encode(), message, hashlib.sha256
-    ).hexdigest()
-    if not hmac.compare_digest(expected, signature.lower()):
+    offered = signature.lower()
+    matched_index = -1
+    for index, secret in enumerate(
+        (settings.BILLING_HMAC_SECRET, settings.BILLING_HMAC_SECRET_PREVIOUS)
+    ):
+        if not secret:
+            continue
+        expected = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+        if hmac.compare_digest(expected, offered):
+            matched_index = index
+    if matched_index < 0:
         raise BillingEnvelopeError(BillingMessages.INVALID_SIGNATURE)
+    if matched_index > 0:
+        logger.warning(
+            "billing.envelope_verified_with_previous_secret "
+            "rotation is still in progress; clear BILLING_HMAC_SECRET_PREVIOUS "
+            "once this stops appearing"
+        )
 
     try:
         keys = load_verification_keys(settings.BILLING_PUBLIC_KEY_PEM)

--- a/backend/app/services/platform/billing.py
+++ b/backend/app/services/platform/billing.py
@@ -138,7 +138,7 @@ def verify_billing_envelope(
         if not secret:
             continue
         expected = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
-        if hmac.compare_digest(expected, offered):
+        if hmac.compare_digest(expected, offered) and matched_index < 0:
             matched_index = index
     if matched_index < 0:
         raise BillingEnvelopeError(BillingMessages.INVALID_SIGNATURE)

--- a/backend/app/services/platform/billing_envelope_test.py
+++ b/backend/app/services/platform/billing_envelope_test.py
@@ -18,6 +18,7 @@ NOW = 2_000_000_000
 METHOD = "POST"
 PATH = "/api/v1/billing/guild-tier"
 BODY = b'{"guild_id":1}'
+CURRENT_SIGNATURE = "4fedc9943a673e2f49696595ff0d6dfb666afeb5f1bd8ae0470aab3a501d4857"
 PREVIOUS_SIGNATURE = "20c9eb333669a3bccbce217bd922d8701c14cb0122914e856e45f2c8be8b2fa9"
 
 
@@ -90,3 +91,20 @@ def test_previous_hmac_secret_is_rejected_after_overlap(envelope, monkeypatch) -
             body=BODY,
         )
     assert exc_info.value.code == BillingMessages.INVALID_SIGNATURE
+
+
+def test_duplicate_current_value_does_not_log_old_key_traffic(
+    envelope, monkeypatch, caplog
+) -> None:
+    headers, _ = envelope
+    headers["X-Billing-Signature"] = CURRENT_SIGNATURE
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_HMAC_SECRET_PREVIOUS",
+        "current-secret-value",
+    )
+    verify_billing_envelope(method=METHOD, path=PATH, headers=headers, body=BODY)
+    assert not any(
+        "verified_with_previous_secret" in record.getMessage()
+        for record in caplog.records
+    )

--- a/backend/app/services/platform/billing_envelope_test.py
+++ b/backend/app/services/platform/billing_envelope_test.py
@@ -1,0 +1,86 @@
+"""Fast contract tests for the billing envelope's rotation overlap."""
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.core import config as config_module
+from app.core.messages import BillingMessages
+from app.services.platform.billing import (
+    BillingEnvelopeError,
+    verify_billing_envelope,
+)
+
+NOW = 2_000_000_000
+METHOD = "POST"
+PATH = "/api/v1/billing/guild-tier"
+BODY = b'{"guild_id":1}'
+PREVIOUS_SIGNATURE = "20c9eb333669a3bccbce217bd922d8701c14cb0122914e856e45f2c8be8b2fa9"
+
+
+@pytest.fixture
+def envelope(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, str], str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    public_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", public_pem)
+    monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET", "current-secret-value")
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_HMAC_SECRET_PREVIOUS",
+        "previous-secret-value",
+    )
+    monkeypatch.setattr("app.services.platform.billing.time.time", lambda: NOW)
+
+    real_now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "jti": "rotation-contract",
+            "aud": "initiative:billing",
+            "iss": "initiative-billing",
+            "iat": real_now,
+            "exp": real_now + timedelta(minutes=5),
+        },
+        private_pem,
+        algorithm="RS256",
+    )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Billing-Timestamp": str(NOW),
+        "X-Billing-Signature": PREVIOUS_SIGNATURE,
+    }
+    return headers, token
+
+
+def test_previous_hmac_secret_verifies_during_rotation(envelope) -> None:
+    headers, _ = envelope
+    claims = verify_billing_envelope(
+        method=METHOD,
+        path=PATH,
+        headers=headers,
+        body=BODY,
+    )
+    assert claims.jti == "rotation-contract"
+
+
+def test_previous_hmac_secret_is_rejected_after_overlap(envelope, monkeypatch) -> None:
+    headers, _ = envelope
+    monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET_PREVIOUS", None)
+    with pytest.raises(BillingEnvelopeError) as exc_info:
+        verify_billing_envelope(
+            method=METHOD,
+            path=PATH,
+            headers=headers,
+            body=BODY,
+        )
+    assert exc_info.value.code == BillingMessages.INVALID_SIGNATURE

--- a/backend/app/services/platform/billing_envelope_test.py
+++ b/backend/app/services/platform/billing_envelope_test.py
@@ -29,12 +29,18 @@ def envelope(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, str], str]:
         serialization.PrivateFormat.PKCS8,
         serialization.NoEncryption(),
     ).decode()
-    public_pem = key.public_key().public_bytes(
-        serialization.Encoding.PEM,
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
     monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", public_pem)
-    monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET", "current-secret-value")
+    monkeypatch.setattr(
+        config_module.settings, "BILLING_HMAC_SECRET", "current-secret-value"
+    )
     monkeypatch.setattr(
         config_module.settings,
         "BILLING_HMAC_SECRET_PREVIOUS",


### PR DESCRIPTION
Follow-up to Morelitea/initiative_billing#44. Initiative previously verified only one HMAC value, so changing billing first or Initiative first could reject valid writes. This adds a second accepted value with fixed-vector contract coverage and an integration test. The operational sequence is documented in the linked billing change.

Trade-off: both values remain valid during the deliberately bounded overlap; operators must clear `BILLING_HMAC_SECRET_PREVIOUS` after old-key traffic stops.