### PR TITLE
T45: accept an overlapping billing secret

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -143,17 +143,6 @@ UPLOADS_DIR=uploads
 # APP_SERVICES_CONFIG=/etc/initiative/app-services.json
 # APP_SERVICE_VERIFY_INTERVAL_SECONDS=3600
 
-# Hosted billing HMAC. Self-hosted deployments leave both unset.
-#
-# PREVIOUS holds a second accepted value so the two sides can change secret
-# without a synchronised restart: set it before cutover, clear it after. Clear
-# it only once `billing.envelope_verified_with_previous_secret` has stopped
-# appearing in the logs, which is what says the far side has moved.
-#
-# The full rotation runbook is in the private infrastructure repository.
-# BILLING_HMAC_SECRET=
-# BILLING_HMAC_SECRET_PREVIOUS=
-
 # --- Advanced --------------------------------------------------------------------
 
 # Rotating SECRET_KEY: move the old key here, set a new SECRET_KEY, and restart —

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -143,6 +143,17 @@ UPLOADS_DIR=uploads
 # APP_SERVICES_CONFIG=/etc/initiative/app-services.json
 # APP_SERVICE_VERIFY_INTERVAL_SECONDS=3600
 
+# Hosted billing HMAC. Self-hosted deployments leave both unset.
+#
+# PREVIOUS holds a second accepted value so the two sides can change secret
+# without a synchronised restart: set it before cutover, clear it after. Clear
+# it only once `billing.envelope_verified_with_previous_secret` has stopped
+# appearing in the logs, which is what says the far side has moved.
+#
+# The full rotation runbook is in the private infrastructure repository.
+# BILLING_HMAC_SECRET=
+# BILLING_HMAC_SECRET_PREVIOUS=
+
 # --- Advanced --------------------------------------------------------------------
 
 # Rotating SECRET_KEY: move the old key here, set a new SECRET_KEY, and restart —

--- a/backend/app/api/v1/platform_endpoints/billing_test.py
+++ b/backend/app/api/v1/platform_endpoints/billing_test.py
@@ -208,7 +208,7 @@ async def test_previous_hmac_secret_is_accepted_during_rotation(
     response = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id, storage_cap_bytes=4096),
+        await _tier_payload(guild.id, storage_cap_bytes=4096),
         secret=_PREVIOUS_HMAC_SECRET,
     )
     assert response.status_code == 200

--- a/backend/app/api/v1/platform_endpoints/billing_test.py
+++ b/backend/app/api/v1/platform_endpoints/billing_test.py
@@ -81,12 +81,14 @@ _OTHER_PUBLIC_PEM = (
 )
 
 _HMAC_SECRET = "test-billing-hmac-secret"
+_PREVIOUS_HMAC_SECRET = "previous-test-billing-hmac-secret"
 
 
 @pytest.fixture(autouse=True)
 def _configure_billing(monkeypatch):
     monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", _PUBLIC_PEM)
     monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET", _HMAC_SECRET)
+    monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET_PREVIOUS", None)
 
 
 def _mint_token(
@@ -192,6 +194,24 @@ async def test_wrong_hmac_secret_rejected(client: AsyncClient, session: AsyncSes
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_SIGNATURE"
+
+
+async def test_previous_hmac_secret_is_accepted_during_rotation(
+    client: AsyncClient, session: AsyncSession, monkeypatch
+):
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_HMAC_SECRET_PREVIOUS",
+        _PREVIOUS_HMAC_SECRET,
+    )
+    guild = await create_guild(session)
+    response = await _post(
+        client,
+        "guild-tier",
+        _tier_payload(guild.id, storage_cap_bytes=4096),
+        secret=_PREVIOUS_HMAC_SECRET,
+    )
+    assert response.status_code == 200
 
 
 async def test_tampered_body_rejected(client: AsyncClient, session: AsyncSession):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -735,8 +735,8 @@ class Settings(BaseSettings):
     # The public key accepts more than one key, as concatenated PEM blocks, so
     # billing can rotate its signing key without downtime: append the new key,
     # let billing start signing with it, then drop the old block. A token is
-    # accepted if any block verifies it. (The shared secret takes one value —
-    # rotating it is a separate change on both sides.)
+    # accepted if any block verifies it. The HMAC has a second accepted value
+    # for the same staged rotation protocol.
     # --- A bundled service's own channel ----------------------------------
     # An app this deployment ships rather than installs from the marketplace,
     # named by the ``public_id`` its registration carries, plus the secret it
@@ -754,6 +754,10 @@ class Settings(BaseSettings):
 
     BILLING_PUBLIC_KEY_PEM: str | None = None
     BILLING_HMAC_SECRET: str | None = None
+    # Second accepted HMAC value during a staged rotation. It may hold the next
+    # value before the cutover or the old value afterwards; clear it only once
+    # every billing instance signs with BILLING_HMAC_SECRET.
+    BILLING_HMAC_SECRET_PREVIOUS: str | None = None
     BILLING_AUDIENCE: str = "initiative:billing"
     BILLING_ISSUER: str = "initiative-billing"
     # Max |now - signed timestamp| accepted, in seconds. Never 0.

--- a/backend/app/services/platform/billing.py
+++ b/backend/app/services/platform/billing.py
@@ -130,11 +130,24 @@ def verify_billing_envelope(
     message = "\n".join(
         [method.upper(), path, ts_header, hashlib.sha256(body).hexdigest()]
     ).encode()
-    expected = hmac.new(
-        settings.BILLING_HMAC_SECRET.encode(), message, hashlib.sha256
-    ).hexdigest()
-    if not hmac.compare_digest(expected, signature.lower()):
+    offered = signature.lower()
+    matched_index = -1
+    for index, secret in enumerate(
+        (settings.BILLING_HMAC_SECRET, settings.BILLING_HMAC_SECRET_PREVIOUS)
+    ):
+        if not secret:
+            continue
+        expected = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+        if hmac.compare_digest(expected, offered) and matched_index < 0:
+            matched_index = index
+    if matched_index < 0:
         raise BillingEnvelopeError(BillingMessages.INVALID_SIGNATURE)
+    if matched_index > 0:
+        logger.warning(
+            "billing.envelope_verified_with_previous_secret "
+            "rotation is still in progress; clear BILLING_HMAC_SECRET_PREVIOUS "
+            "once this stops appearing"
+        )
 
     try:
         keys = load_verification_keys(settings.BILLING_PUBLIC_KEY_PEM)

--- a/backend/app/services/platform/billing_envelope_test.py
+++ b/backend/app/services/platform/billing_envelope_test.py
@@ -1,5 +1,6 @@
 """Fast contract tests for the billing envelope's rotation overlap."""
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 import jwt
@@ -69,15 +70,28 @@ def envelope(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, str], str]:
     return headers, token
 
 
-def test_previous_hmac_secret_verifies_during_rotation(envelope) -> None:
+def test_previous_hmac_secret_verifies_during_rotation(envelope, caplog) -> None:
+    """The overlap verifies, and says so.
+
+    The rotation procedure tells an operator to wait for
+    `billing.envelope_verified_with_previous_secret` to stop appearing before
+    retiring the old key. That signal is the only thing distinguishing "the far
+    side has cut over" from "nothing has been sent recently", so a rename or a
+    removal must fail a test rather than quietly leave the operator without it.
+    """
     headers, _ = envelope
-    claims = verify_billing_envelope(
-        method=METHOD,
-        path=PATH,
-        headers=headers,
-        body=BODY,
-    )
+    with caplog.at_level(logging.WARNING):
+        claims = verify_billing_envelope(
+            method=METHOD,
+            path=PATH,
+            headers=headers,
+            body=BODY,
+        )
     assert claims.jti == "rotation-contract"
+    assert any(
+        "billing.envelope_verified_with_previous_secret" in record.getMessage()
+        for record in caplog.records
+    ), "traffic on the retiring key produced no cutover signal"
 
 
 def test_previous_hmac_secret_is_rejected_after_overlap(envelope, monkeypatch) -> None:

--- a/backend/app/services/platform/billing_envelope_test.py
+++ b/backend/app/services/platform/billing_envelope_test.py
@@ -1,0 +1,110 @@
+"""Fast contract tests for the billing envelope's rotation overlap."""
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.core import config as config_module
+from app.core.messages import BillingMessages
+from app.services.platform.billing import (
+    BillingEnvelopeError,
+    verify_billing_envelope,
+)
+
+NOW = 2_000_000_000
+METHOD = "POST"
+PATH = "/api/v1/billing/guild-tier"
+BODY = b'{"guild_id":1}'
+CURRENT_SIGNATURE = "4fedc9943a673e2f49696595ff0d6dfb666afeb5f1bd8ae0470aab3a501d4857"
+PREVIOUS_SIGNATURE = "20c9eb333669a3bccbce217bd922d8701c14cb0122914e856e45f2c8be8b2fa9"
+
+
+@pytest.fixture
+def envelope(monkeypatch: pytest.MonkeyPatch) -> tuple[dict[str, str], str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", public_pem)
+    monkeypatch.setattr(
+        config_module.settings, "BILLING_HMAC_SECRET", "current-secret-value"
+    )
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_HMAC_SECRET_PREVIOUS",
+        "previous-secret-value",
+    )
+    monkeypatch.setattr("app.services.platform.billing.time.time", lambda: NOW)
+
+    real_now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "jti": "rotation-contract",
+            "aud": "initiative:billing",
+            "iss": "initiative-billing",
+            "iat": real_now,
+            "exp": real_now + timedelta(minutes=5),
+        },
+        private_pem,
+        algorithm="RS256",
+    )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Billing-Timestamp": str(NOW),
+        "X-Billing-Signature": PREVIOUS_SIGNATURE,
+    }
+    return headers, token
+
+
+def test_previous_hmac_secret_verifies_during_rotation(envelope) -> None:
+    headers, _ = envelope
+    claims = verify_billing_envelope(
+        method=METHOD,
+        path=PATH,
+        headers=headers,
+        body=BODY,
+    )
+    assert claims.jti == "rotation-contract"
+
+
+def test_previous_hmac_secret_is_rejected_after_overlap(envelope, monkeypatch) -> None:
+    headers, _ = envelope
+    monkeypatch.setattr(config_module.settings, "BILLING_HMAC_SECRET_PREVIOUS", None)
+    with pytest.raises(BillingEnvelopeError) as exc_info:
+        verify_billing_envelope(
+            method=METHOD,
+            path=PATH,
+            headers=headers,
+            body=BODY,
+        )
+    assert exc_info.value.code == BillingMessages.INVALID_SIGNATURE
+
+
+def test_duplicate_current_value_does_not_log_old_key_traffic(
+    envelope, monkeypatch, caplog
+) -> None:
+    headers, _ = envelope
+    headers["X-Billing-Signature"] = CURRENT_SIGNATURE
+    monkeypatch.setattr(
+        config_module.settings,
+        "BILLING_HMAC_SECRET_PREVIOUS",
+        "current-secret-value",
+    )
+    verify_billing_envelope(method=METHOD, path=PATH, headers=headers, body=BODY)
+    assert not any(
+        "verified_with_previous_secret" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
Tracked internally as **T45**. This public description intentionally omits the finding details.

**Scope:** the billing-envelope sender accepts one optional overlap value. It is unset by default, so existing self-hosted deployments retain their current behavior.

**Verification:** the focused billing-envelope tests and lint passed; the current head also runs the complete repository CI suite.