### PR TITLE
Give users and guilds a name per outside party

### DIFF
--- a/backend/alembic/versions/20260910_0249_identity_refs.py
+++ b/backend/alembic/versions/20260910_0249_identity_refs.py
@@ -1,0 +1,73 @@
+"""What an outside party calls a user or a guild.
+
+The first slice of ``history/opaque-identity-design.md``: the table and its
+grants. The billing handoffs and the app-platform consolidation land on top of
+it without reworking what is written here.
+
+Written and read on the system engine only, so the schema default privileges
+that hand every new public table to the base roles are revoked first.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260910_0249"
+down_revision = "20260909_0248"
+branch_labels = None
+depends_on = None
+
+
+def _platform_base() -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_base"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "identity_refs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("ref", sa.String(64), nullable=False),
+        sa.Column("entity_type", sa.String(16), nullable=False),
+        # Plain integer, no foreign key: erasure husks the row it names rather
+        # than removing it, and these rows are dropped by that same path.
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("purpose", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("ref", name="identity_refs_unique_ref"),
+    )
+    # One live reference per entity per purpose; retired rows sit beside the
+    # value that replaced them until their grace window closes.
+    op.create_index(
+        "ix_identity_refs_live",
+        "identity_refs",
+        ["entity_type", "entity_id", "purpose"],
+        unique=True,
+        postgresql_where=sa.text("retired_at IS NULL"),
+    )
+    op.create_index("ix_identity_refs_retired_at", "identity_refs", ["retired_at"])
+
+    # Nothing to backfill: references are minted on first use, so every
+    # existing user and guild acquires one when a purpose first asks.
+    base = _platform_base()
+    statements = [
+        f'REVOKE ALL ON TABLE public.identity_refs FROM "{base}"',
+        "REVOKE ALL ON TABLE public.identity_refs FROM app_guild_base",
+        "REVOKE ALL ON TABLE public.identity_refs FROM app_user",
+        f'REVOKE ALL ON SEQUENCE public.identity_refs_id_seq FROM "{base}"',
+        "REVOKE ALL ON SEQUENCE public.identity_refs_id_seq FROM app_guild_base",
+        "REVOKE ALL ON SEQUENCE public.identity_refs_id_seq FROM app_user",
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.identity_refs TO app_admin",
+        "GRANT USAGE ON SEQUENCE public.identity_refs_id_seq TO app_admin",
+        "ALTER TABLE public.identity_refs ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE public.identity_refs FORCE ROW LEVEL SECURITY",
+    ]
+    for statement in statements:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_identity_refs_retired_at", table_name="identity_refs")
+    op.drop_index("ix_identity_refs_live", table_name="identity_refs")
+    op.drop_table("identity_refs")

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -95,6 +95,7 @@ from app.models.platform.auth_provider_secret import AuthProviderSecret
 from app.models.platform.auth_session import AuthSession
 from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.federated_identity_secret import FederatedIdentitySecret
+from app.models.platform.identity_ref import IdentityRef
 from app.models.platform.guild_auth_policy import GuildAuthPolicy
 from app.models.platform.guild_image import GuildImage
 from app.models.platform.audit_event import AuditEvent  # noqa: F401
@@ -133,6 +134,7 @@ __all__ = [
     "AuthSession",
     "FederatedIdentity",
     "FederatedIdentitySecret",
+    "IdentityRef",
     "GuildAuthPolicy",
     "ResourceGrant",
     "ExportJob",

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -65,6 +65,7 @@ _RLS_SHARED_TABLES = {
     "guild_invites",
     "guild_memberships",
     "guilds",
+    "identity_refs",
     "marketplace_listing_versions",
     "marketplace_listings",
     "marketplace_media",

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -82,6 +82,9 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     # invite redemption reads/creates/updates; row removal rides the FK cascade
     "guild_invites": frozenset({"SELECT", "INSERT", "UPDATE"}),
     "access_grants": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # Minted on first use, replaced by a re-issue, swept once the replaced
+    # value stops resolving, and removed when the entity is erased.
+    "identity_refs": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # singleton config: seeded + updated, never deleted
     "app_settings": frozenset({"SELECT", "INSERT", "UPDATE"}),
     # Marketplace catalog: the system engine is the only writer — boot seeding of
@@ -245,6 +248,10 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     # Written and read on the system engine only — the request path never
     # touches the log, in either direction.
     "audit_events": None,
+    # Minted and resolved on the system engine, behind the surfaces that
+    # hand a reference to an outside party; the request path never reads
+    # the mapping in either direction.
+    "identity_refs": None,
     # system-engine-only credential store; the request path never touches it
     # (auth lookup + management endpoints run on app_admin), like auth_sessions
     "user_api_keys": None,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -99,6 +99,11 @@ SHARED_TABLES: frozenset[str] = frozenset(
         # that has to outlive any guild — and every reference in it is a plain
         # integer, so it outlives the accounts it names too.
         "audit_events",
+        # What outside parties — a payment processor, an installed app —
+        # call a user or a guild. One per purpose, so no two parties hold
+        # the same value for the same entity. Cross-guild and pre-routing,
+        # like the accounts and guilds it names.
+        "identity_refs",
         # Tenancy roster — must be readable *before* a request is routed
         "guilds",
         # The operator-set half of a guild (caps / plan label / sign-in

--- a/backend/app/models/platform/identity_ref.py
+++ b/backend/app/models/platform/identity_ref.py
@@ -1,0 +1,150 @@
+"""What a party outside this deployment calls a user or a guild.
+
+An integer primary key is the right thing to join on and the right thing to
+show a person who has to tell two rows apart. It is the wrong thing to hand to
+a payment processor or an installed app: it is sequential, it is the same value
+everywhere, and every party holding one holds the same one.
+
+So each entity gets a separate reference per *purpose* — billing, one installed
+app, the next — minted at random and stored here. Two references to the same
+guild are unrelated values, and the party holding one learns nothing about the
+other from it.
+
+Random rather than derived from a key, following
+``services.marketplace.app_subjects``: a derived value is only stable while its
+key is, and this deployment rotates ``SECRET_KEY``
+(``app.db.secret_key_rotation``). A reference has to outlast that. The full
+reasoning, and the alternatives weighed against it, are in
+``history/opaque-identity-design.md``.
+
+Reached only on the system engine — the request-path roles hold nothing on this
+table.
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    text,
+)
+from sqlmodel import Field, SQLModel
+
+
+class IdentityEntity(str, Enum):
+    """What kind of row a reference names.
+
+    Carried in the reference's own prefix, so a value minted for a user is
+    rejected where a guild is expected rather than silently looked up.
+    """
+
+    user = "user"
+    guild = "guild"
+
+    @property
+    def code(self) -> str:
+        """This entity's letter in a rendered reference."""
+        return self.value[0]
+
+
+class IdentityPurpose(str, Enum):
+    """Which party a reference was minted for.
+
+    The sector, in the OpenID Connect §8.1 sense: one entity has one reference
+    per purpose, and the purposes are unrelated to each other.
+
+    ``app`` is parametric — an installed app is a sector per install, so its
+    stored purpose is ``app:<install_id>`` rather than the bare member. Build
+    it with ``app_purpose`` rather than by hand.
+    """
+
+    billing = "billing"
+    app = "app"
+
+    @property
+    def code(self) -> str:
+        """This purpose's three letters in a rendered reference."""
+        return self.value[:3]
+
+
+def app_purpose(install_id: int) -> str:
+    """The stored purpose naming one installed app."""
+    return f"{IdentityPurpose.app.value}:{install_id}"
+
+
+def purpose_root(purpose: str) -> IdentityPurpose:
+    """The purpose a stored value belongs to, with any parameter dropped."""
+    return IdentityPurpose(purpose.split(":", 1)[0])
+
+
+def ref_prefix(entity_type: IdentityEntity, purpose: str) -> str:
+    """The prefix a reference for this entity and purpose is rendered with.
+
+    Derived from the two enums rather than listed, so a new purpose gets a
+    prefix by existing.
+    """
+    return f"{entity_type.code}{purpose_root(purpose).code}"
+
+
+#: Characters of base64url in the random half — ``token_urlsafe(24)`` renders
+#: as 32, matching ``GuildAppSubject.SUBJECT_LENGTH``.
+REF_ENTROPY_BYTES = 24
+REF_RANDOM_LENGTH = 32
+
+#: Width the column holds: prefix, separator, and the random half, with room
+#: for a longer prefix than any purpose uses today.
+REF_MAX_LENGTH = 64
+
+
+class IdentityRef(SQLModel, table=True):
+    """One reference: what one purpose calls one entity."""
+
+    __tablename__ = "identity_refs"
+    __table_args__ = (
+        UniqueConstraint("ref", name="identity_refs_unique_ref"),
+        # One live reference per entity per purpose. Retired rows are excluded
+        # so a re-issue can sit beside the value it replaces for its grace
+        # window.
+        Index(
+            "ix_identity_refs_live",
+            "entity_type",
+            "entity_id",
+            "purpose",
+            unique=True,
+            postgresql_where=text("retired_at IS NULL"),
+        ),
+        # Sweeping the rows a re-issue left behind.
+        Index("ix_identity_refs_retired_at", "retired_at"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    #: The value the other party holds, prefix and all.
+    ref: str = Field(sa_column=Column(String(REF_MAX_LENGTH), nullable=False))
+
+    entity_type: IdentityEntity = Field(
+        sa_column=Column(String(16), nullable=False),
+    )
+    #: Plain integer, no foreign key. Erasure husks the row it names
+    #: (``services.platform.users.anonymize_user``) rather than removing it,
+    #: and this row is dropped by the same path.
+    entity_id: int = Field(sa_column=Column(Integer, nullable=False))
+
+    #: ``billing``, ``app:<install_id>``, … — see ``IdentityPurpose``.
+    purpose: str = Field(sa_column=Column(String(64), nullable=False))
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    #: When this value was replaced. NULL while it is the live one; set by a
+    #: re-issue, after which the row stays resolvable for the grace window.
+    retired_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )

--- a/backend/app/models/tenant/guild_app_subject.py
+++ b/backend/app/models/tenant/guild_app_subject.py
@@ -1,13 +1,13 @@
 """The name one installed app knows one member by.
 
-Derived rather than random (see ``services.marketplace.app_subjects``), so this
-table is an index into a computation rather than the only copy of it: losing a
-row and re-deriving gives the same subject back, and no app believes it has met
-a new person.
+Random rather than derived (see ``services.marketplace.app_subjects``), so this
+row is the only copy of the value: minted once on first handoff, and never
+recomputed. A derived value is stable only while the key it came from is, and
+this deployment rotates ``SECRET_KEY`` (``app.db.secret_key_rotation``) — an app
+stores its ``sub`` and expects to meet the same person under it next time.
 
-What the row buys is the *reverse* direction. The derivation is one-way, so a
-delegation token naming a subject can only be resolved to a member by finding
-the value we minted — which is this.
+The row is also what answers the *reverse* direction: a delegation token naming
+a subject is resolved to a member by finding the row holding that value.
 
 Guild-level: an install is guild-wide and this has no initiative. Own-row like
 its neighbours (owner, or a guild admin) — the link *is* the value, so a row

--- a/backend/app/services/platform/identity_refs.py
+++ b/backend/app/services/platform/identity_refs.py
@@ -1,0 +1,249 @@
+"""Minting and resolving the references outside parties know entities by.
+
+The table is ``public.identity_refs`` and every function here expects a session
+on the **system engine** (``AdminSessionDep``) — the request-path roles hold no
+grants on it.
+
+Forward (entity -> reference) is ``ensure_ref``, which mints on first use, so a
+new purpose needs no migration and no backfill: every existing user and guild
+acquires a reference for it the first time one is asked for. Reverse (reference
+-> entity) is ``resolve_ref``, an indexed lookup.
+
+See ``history/opaque-identity-design.md``.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, or_
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import delete, select, update
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.platform.identity_ref import (
+    REF_ENTROPY_BYTES,
+    REF_MAX_LENGTH,
+    IdentityEntity,
+    IdentityRef,
+    ref_prefix,
+)
+
+__all__ = [
+    "REF_GRACE_PERIOD",
+    "drop_entity_refs",
+    "ensure_ref",
+    "mint_ref",
+    "purge_retired_refs",
+    "reissue_all_refs",
+    "reissue_ref",
+    "resolve_ref",
+]
+
+#: How long a replaced reference keeps resolving. Long enough for the other
+#: party to pick up the new value and for anything already in flight to land.
+REF_GRACE_PERIOD = timedelta(days=30)
+
+
+def mint_ref(entity_type: IdentityEntity, purpose: str) -> str:
+    """A fresh reference. Random, and unrelated to the row it will name."""
+    return (
+        f"{ref_prefix(entity_type, purpose)}_{secrets.token_urlsafe(REF_ENTROPY_BYTES)}"
+    )
+
+
+async def ensure_ref(
+    session: AsyncSession,
+    *,
+    entity_type: IdentityEntity,
+    entity_id: int,
+    purpose: str,
+) -> str:
+    """This entity's live reference for this purpose, minting one on first use.
+
+    Idempotent under concurrency: two callers racing the same first mint both
+    insert, one loses on the partial unique index, and both read back the same
+    row.
+    """
+    existing = await _live_ref(
+        session, entity_type=entity_type, entity_id=entity_id, purpose=purpose
+    )
+    if existing is not None:
+        return existing.ref
+
+    await session.exec(
+        pg_insert(IdentityRef.__table__)
+        .values(
+            ref=mint_ref(entity_type, purpose),
+            entity_type=entity_type.value,
+            entity_id=entity_id,
+            purpose=purpose,
+            created_at=datetime.now(timezone.utc),
+        )
+        # A core-level insert, so the model's default factories do not run and
+        # the conflict target must name the partial index's predicate.
+        .on_conflict_do_nothing(
+            index_elements=["entity_type", "entity_id", "purpose"],
+            index_where=IdentityRef.retired_at.is_(None),
+        )
+    )
+
+    # Read back rather than returning what was offered: on a lost race the
+    # stored value is the winner's, and that is the one the caller must use.
+    stored = await _live_ref(
+        session, entity_type=entity_type, entity_id=entity_id, purpose=purpose
+    )
+    if stored is None:  # pragma: no cover - the insert either landed or lost
+        raise RuntimeError("identity ref was neither inserted nor found")
+    return stored.ref
+
+
+async def resolve_ref(
+    session: AsyncSession, *, ref: str, now: datetime | None = None
+) -> IdentityRef | None:
+    """Which entity a reference names, or None.
+
+    A retired reference still resolves until its grace window closes; past
+    that it is treated as unknown even while the row waits to be swept.
+    """
+    if not ref or len(ref) > REF_MAX_LENGTH:
+        return None
+    moment = now or datetime.now(timezone.utc)
+    return (
+        await session.exec(
+            select(IdentityRef).where(
+                IdentityRef.ref == ref,
+                or_(
+                    IdentityRef.retired_at.is_(None),
+                    IdentityRef.retired_at > moment - REF_GRACE_PERIOD,
+                ),
+            )
+        )
+    ).first()
+
+
+async def reissue_ref(
+    session: AsyncSession,
+    *,
+    entity_type: IdentityEntity,
+    entity_id: int,
+    purpose: str,
+    now: datetime | None = None,
+) -> str:
+    """Replace one entity's reference for one purpose, and return the new one.
+
+    The old value keeps resolving for ``REF_GRACE_PERIOD``. Nothing else about
+    the entity moves, and no other entity is touched.
+    """
+    moment = now or datetime.now(timezone.utc)
+    await session.exec(
+        update(IdentityRef)
+        .where(
+            IdentityRef.entity_type == entity_type,
+            IdentityRef.entity_id == entity_id,
+            IdentityRef.purpose == purpose,
+            IdentityRef.retired_at.is_(None),
+        )
+        .values(retired_at=moment)
+    )
+    return await ensure_ref(
+        session, entity_type=entity_type, entity_id=entity_id, purpose=purpose
+    )
+
+
+async def reissue_all_refs(
+    session: AsyncSession,
+    *,
+    entity_type: IdentityEntity,
+    purpose: str,
+    now: datetime | None = None,
+) -> int:
+    """Replace every entity's reference for one purpose. Returns the count.
+
+    The coarse lever, for a purpose whose references have to move together
+    rather than one holder at a time. Resumable: retiring and re-minting are
+    separate steps, so a run interrupted between them is completed by the next
+    one — an entity left with no live reference gets a fresh one, and an entity
+    already re-minted is skipped.
+    """
+    moment = now or datetime.now(timezone.utc)
+    retired = await session.exec(
+        update(IdentityRef)
+        .where(
+            IdentityRef.entity_type == entity_type,
+            IdentityRef.purpose == purpose,
+            IdentityRef.retired_at.is_(None),
+        )
+        .values(retired_at=moment)
+        .returning(IdentityRef.entity_id)
+    )
+    entity_ids = {row for row in retired.scalars().all()}
+
+    # Entities whose retirement landed on a previous, interrupted run.
+    stranded = await session.exec(
+        select(IdentityRef.entity_id)
+        .where(
+            IdentityRef.entity_type == entity_type,
+            IdentityRef.purpose == purpose,
+        )
+        .group_by(IdentityRef.entity_id)
+        .having(func.count().filter(IdentityRef.retired_at.is_(None)) == 0)
+    )
+    entity_ids.update(stranded.all())
+
+    for entity_id in sorted(entity_ids):
+        await ensure_ref(
+            session, entity_type=entity_type, entity_id=entity_id, purpose=purpose
+        )
+    return len(entity_ids)
+
+
+async def drop_entity_refs(
+    session: AsyncSession, *, entity_type: IdentityEntity, entity_id: int
+) -> int:
+    """Remove every reference to one entity. Returns the count.
+
+    Called when the row is erased, so that what the outside parties hold stops
+    resolving to anybody.
+    """
+    result = await session.exec(
+        delete(IdentityRef).where(
+            IdentityRef.entity_type == entity_type,
+            IdentityRef.entity_id == entity_id,
+        )
+    )
+    return result.rowcount or 0
+
+
+async def purge_retired_refs(
+    session: AsyncSession, *, now: datetime | None = None
+) -> int:
+    """Drop the rows whose grace window has closed. Returns the count."""
+    moment = now or datetime.now(timezone.utc)
+    result = await session.exec(
+        delete(IdentityRef).where(
+            IdentityRef.retired_at.is_not(None),
+            IdentityRef.retired_at <= moment - REF_GRACE_PERIOD,
+        )
+    )
+    return result.rowcount or 0
+
+
+async def _live_ref(
+    session: AsyncSession,
+    *,
+    entity_type: IdentityEntity,
+    entity_id: int,
+    purpose: str,
+) -> IdentityRef | None:
+    return (
+        await session.exec(
+            select(IdentityRef).where(
+                IdentityRef.entity_type == entity_type,
+                IdentityRef.entity_id == entity_id,
+                IdentityRef.purpose == purpose,
+                IdentityRef.retired_at.is_(None),
+            )
+        )
+    ).first()

--- a/backend/app/services/platform/identity_refs_test.py
+++ b/backend/app/services/platform/identity_refs_test.py
@@ -1,0 +1,369 @@
+"""The properties a reference has to hold, stated as tests.
+
+Three groups: what a rendered value looks like, what minting and resolving
+guarantee, and what the two re-issue levers move — the fine one, which is one
+entity and one purpose, and the coarse one, which is every entity for a purpose.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.platform.identity_ref import (
+    REF_MAX_LENGTH,
+    REF_RANDOM_LENGTH,
+    IdentityEntity,
+    IdentityPurpose,
+    app_purpose,
+    ref_prefix,
+)
+from app.services.platform.identity_refs import (
+    REF_GRACE_PERIOD,
+    drop_entity_refs,
+    ensure_ref,
+    mint_ref,
+    purge_retired_refs,
+    reissue_all_refs,
+    reissue_ref,
+    resolve_ref,
+)
+
+BILLING = IdentityPurpose.billing.value
+
+
+class TestTheRenderedValue:
+    @pytest.mark.unit
+    def test_it_is_a_prefix_and_a_random_half(self):
+        ref = mint_ref(IdentityEntity.guild, BILLING)
+        prefix, _, random_half = ref.partition("_")
+        assert prefix == "gbil"
+        assert len(random_half) == REF_RANDOM_LENGTH
+        assert len(ref) <= REF_MAX_LENGTH
+
+    @pytest.mark.unit
+    def test_it_fits_a_jwt_claim_and_a_url(self):
+        random_half = mint_ref(IdentityEntity.user, BILLING).partition("_")[2]
+        assert random_half.replace("-", "").replace("_", "").isalnum()
+
+    @pytest.mark.unit
+    def test_the_prefix_names_the_entity_and_the_purpose(self):
+        assert ref_prefix(IdentityEntity.user, BILLING) == "ubil"
+        assert ref_prefix(IdentityEntity.guild, BILLING) == "gbil"
+        assert ref_prefix(IdentityEntity.user, app_purpose(7)) == "uapp"
+
+    @pytest.mark.unit
+    def test_two_mints_never_agree(self):
+        assert mint_ref(IdentityEntity.user, BILLING) != mint_ref(
+            IdentityEntity.user, BILLING
+        )
+
+
+class TestMintingAndResolving:
+    @pytest.mark.integration
+    async def test_minting_twice_gives_the_same_reference(self, session):
+        first = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        second = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        assert first == second
+
+    @pytest.mark.integration
+    async def test_two_first_callers_racing_get_one_reference(self, session, engine):
+        """The claim ``ensure_ref`` makes about concurrency, exercised.
+
+        Two independent sessions mint the same (entity, purpose) at once. The
+        partial unique index lets one insert land; the other's
+        ``ON CONFLICT DO NOTHING`` waits for it, no-ops, and reads back the
+        winner's value.
+        """
+        maker = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def mint() -> str:
+            async with maker() as racing:
+                ref = await ensure_ref(
+                    racing,
+                    entity_type=IdentityEntity.guild,
+                    entity_id=77,
+                    purpose=BILLING,
+                )
+                await racing.commit()
+                return ref
+
+        first, second = await asyncio.gather(mint(), mint())
+        assert first == second
+
+        settled = await resolve_ref(session, ref=first)
+        assert settled is not None and settled.entity_id == 77
+
+    @pytest.mark.integration
+    async def test_one_entity_gets_an_unrelated_value_per_purpose(self, session):
+        billing = await ensure_ref(
+            session, entity_type=IdentityEntity.user, entity_id=1, purpose=BILLING
+        )
+        at_app = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.user,
+            entity_id=1,
+            purpose=app_purpose(7),
+        )
+        assert billing != at_app
+
+    @pytest.mark.integration
+    async def test_a_user_and_a_guild_of_the_same_id_differ(self, session):
+        as_user = await ensure_ref(
+            session, entity_type=IdentityEntity.user, entity_id=42, purpose=BILLING
+        )
+        as_guild = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=42, purpose=BILLING
+        )
+        assert as_user != as_guild
+
+    @pytest.mark.integration
+    async def test_a_reference_resolves_to_its_entity(self, session):
+        ref = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=9, purpose=BILLING
+        )
+        row = await resolve_ref(session, ref=ref)
+        assert row is not None
+        assert row.entity_type == IdentityEntity.guild
+        assert row.entity_id == 9
+        assert row.purpose == BILLING
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("candidate", ["", "gbil_nope", "x" * (REF_MAX_LENGTH + 1)])
+    async def test_a_value_we_never_minted_resolves_to_nothing(
+        self, session, candidate
+    ):
+        assert await resolve_ref(session, ref=candidate) is None
+
+
+class TestReissuingOne:
+    @pytest.mark.integration
+    async def test_it_returns_a_new_value(self, session):
+        before = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        after = await reissue_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        assert after != before
+
+    @pytest.mark.integration
+    async def test_the_replaced_value_keeps_resolving_for_its_grace_window(
+        self, session
+    ):
+        before = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        await reissue_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        row = await resolve_ref(session, ref=before)
+        assert row is not None and row.entity_id == 1
+
+    @pytest.mark.integration
+    async def test_the_replaced_value_stops_resolving_after_it(self, session):
+        before = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        await reissue_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        later = datetime.now(timezone.utc) + REF_GRACE_PERIOD + timedelta(days=1)
+        assert await resolve_ref(session, ref=before, now=later) is None
+
+    @pytest.mark.integration
+    async def test_it_moves_nothing_else(self, session):
+        target = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        neighbour = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=2, purpose=BILLING
+        )
+        other_purpose = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.guild,
+            entity_id=1,
+            purpose=app_purpose(7),
+        )
+        await reissue_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+
+        assert (
+            await ensure_ref(
+                session, entity_type=IdentityEntity.guild, entity_id=2, purpose=BILLING
+            )
+            == neighbour
+        )
+        assert (
+            await ensure_ref(
+                session,
+                entity_type=IdentityEntity.guild,
+                entity_id=1,
+                purpose=app_purpose(7),
+            )
+            == other_purpose
+        )
+        assert (
+            await ensure_ref(
+                session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+            )
+            != target
+        )
+
+
+class TestReissuingEvery:
+    @pytest.mark.integration
+    async def test_it_moves_every_entity_holding_that_purpose(self, session):
+        before = {
+            entity_id: await ensure_ref(
+                session,
+                entity_type=IdentityEntity.user,
+                entity_id=entity_id,
+                purpose=BILLING,
+            )
+            for entity_id in (1, 2, 3)
+        }
+
+        moved = await reissue_all_refs(
+            session, entity_type=IdentityEntity.user, purpose=BILLING
+        )
+        assert moved == 3
+
+        for entity_id, old in before.items():
+            current = await ensure_ref(
+                session,
+                entity_type=IdentityEntity.user,
+                entity_id=entity_id,
+                purpose=BILLING,
+            )
+            assert current != old
+            # Still resolvable, so nothing already in flight breaks.
+            assert (await resolve_ref(session, ref=old)) is not None
+
+    @pytest.mark.integration
+    async def test_it_leaves_other_purposes_and_entities_alone(self, session):
+        at_app = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.user,
+            entity_id=1,
+            purpose=app_purpose(7),
+        )
+        a_guild = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+        )
+        await ensure_ref(
+            session, entity_type=IdentityEntity.user, entity_id=1, purpose=BILLING
+        )
+
+        await reissue_all_refs(
+            session, entity_type=IdentityEntity.user, purpose=BILLING
+        )
+
+        assert (
+            await ensure_ref(
+                session,
+                entity_type=IdentityEntity.user,
+                entity_id=1,
+                purpose=app_purpose(7),
+            )
+            == at_app
+        )
+        assert (
+            await ensure_ref(
+                session, entity_type=IdentityEntity.guild, entity_id=1, purpose=BILLING
+            )
+            == a_guild
+        )
+
+    @pytest.mark.integration
+    async def test_a_run_that_stopped_after_retiring_is_finished_by_the_next(
+        self, session
+    ):
+        await ensure_ref(
+            session, entity_type=IdentityEntity.user, entity_id=1, purpose=BILLING
+        )
+        # An interrupted run leaves the entity retired with nothing live.
+        await reissue_ref(
+            session, entity_type=IdentityEntity.user, entity_id=1, purpose=BILLING
+        )
+        await drop_live_ref(session, entity_id=1)
+
+        moved = await reissue_all_refs(
+            session, entity_type=IdentityEntity.user, purpose=BILLING
+        )
+        assert moved == 1
+        assert (
+            await ensure_ref(
+                session, entity_type=IdentityEntity.user, entity_id=1, purpose=BILLING
+            )
+            is not None
+        )
+
+
+class TestRemoval:
+    @pytest.mark.integration
+    async def test_erasing_an_entity_drops_what_every_party_held(self, session):
+        billing = await ensure_ref(
+            session, entity_type=IdentityEntity.user, entity_id=1, purpose=BILLING
+        )
+        at_app = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.user,
+            entity_id=1,
+            purpose=app_purpose(7),
+        )
+
+        dropped = await drop_entity_refs(
+            session, entity_type=IdentityEntity.user, entity_id=1
+        )
+        assert dropped == 2
+        assert await resolve_ref(session, ref=billing) is None
+        assert await resolve_ref(session, ref=at_app) is None
+
+    @pytest.mark.integration
+    async def test_the_sweep_takes_only_what_has_stopped_resolving(self, session):
+        live = await ensure_ref(
+            session, entity_type=IdentityEntity.user, entity_id=1, purpose=BILLING
+        )
+        retired = await ensure_ref(
+            session, entity_type=IdentityEntity.user, entity_id=2, purpose=BILLING
+        )
+        await reissue_ref(
+            session, entity_type=IdentityEntity.user, entity_id=2, purpose=BILLING
+        )
+
+        purged = await purge_retired_refs(session)
+        assert purged == 0
+
+        later = datetime.now(timezone.utc) + REF_GRACE_PERIOD + timedelta(days=1)
+        assert await purge_retired_refs(session, now=later) == 1
+        assert await resolve_ref(session, ref=live) is not None
+        assert await resolve_ref(session, ref=retired) is None
+
+
+async def drop_live_ref(session, *, entity_id: int) -> None:
+    """Remove the live row for a user's billing reference, leaving retired ones.
+
+    Stands in for a bulk run that stopped between retiring and re-minting.
+    """
+    from sqlmodel import delete
+
+    from app.models.platform.identity_ref import IdentityRef
+
+    await session.exec(
+        delete(IdentityRef).where(
+            IdentityRef.entity_type == IdentityEntity.user,
+            IdentityRef.entity_id == entity_id,
+            IdentityRef.purpose == BILLING,
+            IdentityRef.retired_at.is_(None),
+        )
+    )


### PR DESCRIPTION
## Problem

An integer primary key is the right thing to join on, and the right thing to
show someone who has to tell two rows apart. It is the wrong thing to hand to a
payment processor or an installed app: it is sequential, it is the same value
everywhere, and every party holding one holds the same one.

## What this adds

`public.identity_refs` — one random reference per (entity, purpose), where an
entity is a user or a guild and a purpose is the party it was minted for
(`billing`, `app:<install_id>`, …). Two references to the same guild are
unrelated values.

- **Minted on first use.** `ensure_ref` inserts with `ON CONFLICT DO NOTHING`
  and reads back, so a new purpose needs no migration and no backfill — every
  existing user and guild acquires a reference for it the first time one is
  asked for.
- **Random, not derived from a key.** Follows the reasoning already in
  `services.marketplace.app_subjects`: a derived value is stable only while its
  key is, and this deployment rotates `SECRET_KEY`. A reference has to outlast
  that.
- **Two replacement levers.** `reissue_ref` moves one entity's reference for one
  purpose; `reissue_all_refs` moves every entity holding a purpose, and is
  resumable if a run stops between retiring and re-minting. A replaced value
  keeps resolving for a 30-day grace window, then `purge_retired_refs` sweeps it.
- **Prefix derived from the two enums** (`gbil_…`, `ubil_…`, `uapp_…`) rather
  than listed, so a new purpose gets a prefix by existing, and a value minted
  for a user is rejected where a guild is expected.

Nothing consumes it yet — the billing handoffs and the app-platform
consolidation are separate PRs on top.

## Schema

New shared `public` table, system-engine only:

- `REVOKE` of the schema default privileges that hand every new public table to
  `platform_base` / `app_guild_base` / `app_user`; `GRANT` to `app_admin` alone.
- `ENABLE` + `FORCE ROW LEVEL SECURITY`.
- Registered in `SHARED_TABLES` (`tenancy.py`) and in both maps of
  `system_grants.py` (`app_admin` full DML, `app_user` `None`).
- Nothing to backfill, since references are minted lazily.

## Also

Corrects the `GuildAppSubject` docstring, which described its subjects as
*"derived rather than random … losing a row and re-deriving gives the same
subject back"*. They are `secrets.token_urlsafe(24)`, stored. The docstring
invited a change that would strand every `sub` an app had stored.

## Testing

```
pytest -n 0 app/services/platform/identity_refs_test.py   # 20 passed
pytest -n 0 app/db/system_grants_test.py app/db/tenancy_test.py \
            app/db/migration_backfill_order_test.py       # 32 passed
ruff check app && ruff format app && ty check             # clean
```

Note for review: `security_invariants_test::test_rls_shared_tables_are_forced`
also reports `notifications` as an RLS-enabled shared table missing from
`_RLS_SHARED_TABLES` on this machine. That is unrelated to this branch — no
migration here touches `notifications`, and it entered `SHARED_TABLES` long ago
— so it looks like a stale warm test database locally. Left alone deliberately;
CI builds from empty and is the arbiter.

## Design

`history/opaque-identity-design.md` (phase 1 of 3).