### PR TITLE
Send references, not row ids, across the handoff

### DIFF
--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -32,6 +32,7 @@ from app.core.security import (
     create_billing_portal_handoff_token,
     verify_password,
 )
+from app.services.platform.identity_refs import billing_refs
 from app.db.schema_provisioning import deprovision_guild
 from app.db.session import get_admin_session, set_rls_context
 from app.models.platform.guild import (
@@ -907,10 +908,15 @@ async def create_guild_billing_handoff(
     )
 
     try:
+        user_ref, guild_ref = await billing_refs(
+            user_id=current_user.id, guild_id=guild_id
+        )
         token, expires_in_seconds = create_billing_portal_handoff_token(
             user_id=current_user.id,
             guild_id=guild_id,
             guild_role=GuildRole.admin.value,
+            user_ref=user_ref,
+            guild_ref=guild_ref,
         )
     except HandoffSigningNotConfiguredError as exc:
         raise HTTPException(

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -63,6 +63,7 @@ from app.core.security import (
     BillingSupportHandoffNotConfiguredError,
     create_billing_support_handoff_token,
 )
+from app.services.platform.identity_refs import billing_refs
 from app.services.platform import access_grants as access_grants_service
 from app.services.auth import platform_provider as platform_provider_service
 from app.services.platform import app_settings as app_settings_service
@@ -654,10 +655,13 @@ async def create_platform_guild_billing_service_handoff(
             ) from exc
 
     try:
+        user_ref, guild_ref = await billing_refs(user_id=admin.id, guild_id=guild_id)
         token, expires_in_seconds = create_billing_support_handoff_token(
             user_id=admin.id,
             guild_id=guild_id,
             grant_id=grant.id,
+            user_ref=user_ref,
+            guild_ref=guild_ref,
             approver_id=grant.approved_by_id,
         )
     except BillingSupportHandoffNotConfiguredError as exc:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -361,9 +361,16 @@ def create_billing_portal_handoff_token(
     user_id: int,
     guild_id: int,
     guild_role: str,
+    user_ref: str,
+    guild_ref: str,
     expires_in: timedelta = BILLING_PORTAL_HANDOFF_LIFETIME,
 ) -> tuple[str, int]:
-    """Mint the billing-portal handoff token (RS256; raises if unconfigured)."""
+    """Mint the billing-portal handoff token (RS256; raises if unconfigured).
+
+    ``user_ref`` / ``guild_ref`` are what the receiver names the pair by — see
+    ``services.platform.identity_refs.billing_refs``. The row ids travel
+    alongside them until the receiver reads the references instead.
+    """
     now = datetime.now(timezone.utc)
     payload: dict[str, Any] = {
         "jti": str(uuid.uuid4()),
@@ -374,6 +381,8 @@ def create_billing_portal_handoff_token(
         "exp": now + expires_in,
         "guild_id": guild_id,
         "guild_role": guild_role,
+        "user_ref": user_ref,
+        "guild_ref": guild_ref,
     }
     key, algorithm, kid = _resolve_handoff_signing_material()
     headers: dict[str, Any] | None = {"kid": kid} if kid else None
@@ -438,13 +447,17 @@ def create_billing_support_handoff_token(
     user_id: int,
     guild_id: int,
     grant_id: int | str,
+    user_ref: str,
+    guild_ref: str,
     approver_id: int | str | None = None,
     expires_in: timedelta = BILLING_SUPPORT_HANDOFF_LIFETIME,
 ) -> tuple[str, int]:
     """Mint the billing-support handoff token.
 
     ``grant_id`` names the ``access_grants`` row that authorises the visit, so
-    both sides log the same grant.
+    both sides log the same grant. ``user_ref`` / ``guild_ref`` are what the
+    receiver names the pair by — see
+    ``services.platform.identity_refs.billing_refs``.
     """
     if not billing_support_handoff_enabled():
         raise BillingSupportHandoffNotConfiguredError(
@@ -462,6 +475,8 @@ def create_billing_support_handoff_token(
         "exp": int((now + lifetime).timestamp()),
         "guild_id": int(guild_id),
         "grant_id": str(grant_id),
+        "user_ref": user_ref,
+        "guild_ref": guild_ref,
     }
     if approver_id is not None:
         payload["approver"] = str(approver_id)

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -58,7 +58,11 @@ def _b64url_encode(raw: bytes) -> str:
 def test_billing_portal_handoff_carries_admin_claims_and_distinct_audience():
     """Claims present, and the audience is the portal's own."""
     token, seconds = security.create_billing_portal_handoff_token(
-        user_id=42, guild_id=7, guild_role="admin"
+        user_id=42,
+        guild_id=7,
+        guild_role="admin",
+        user_ref="ubil_test42",
+        guild_ref="gbil_test7",
     )
     assert seconds == int(BILLING_PORTAL_HANDOFF_LIFETIME.total_seconds())
     assert jwt.get_unverified_header(token)["alg"] == "RS256"
@@ -70,6 +74,9 @@ def test_billing_portal_handoff_carries_admin_claims_and_distinct_audience():
     assert payload["guild_id"] == 7
     assert payload["guild_role"] == "admin"
     assert payload["jti"] and isinstance(payload["jti"], str)
+    # What the receiver names the pair by, beside the row ids.
+    assert payload["user_ref"] == "ubil_test42"
+    assert payload["guild_ref"] == "gbil_test7"
 
 
 @pytest.mark.unit
@@ -78,7 +85,11 @@ def test_billing_portal_handoff_refuses_to_mint_without_private_key(monkeypatch)
     monkeypatch.setattr(security.settings, "HANDOFF_SIGNING_PRIVATE_KEY_PEM", None)
     with pytest.raises(HandoffSigningNotConfiguredError):
         security.create_billing_portal_handoff_token(
-            user_id=1, guild_id=2, guild_role="admin"
+            user_id=1,
+            guild_id=2,
+            guild_role="admin",
+            user_ref="ubil_test1",
+            guild_ref="gbil_test2",
         )
 
 
@@ -173,7 +184,11 @@ def test_verify_upload_token_rejects_wrong_audience():
     """A token signed with our secret but carrying a foreign audience (e.g. a
     handoff into another service) must not be honored as an upload token."""
     handoff, _ = security.create_billing_portal_handoff_token(
-        user_id=1, guild_id=2, guild_role="admin"
+        user_id=1,
+        guild_id=2,
+        guild_role="admin",
+        user_ref="ubil_test1",
+        guild_ref="gbil_test2",
     )
     with pytest.raises(UploadTokenError):
         verify_upload_token(handoff)
@@ -291,7 +306,11 @@ def test_decode_session_token_rejects_scoped_upload_token():
 @pytest.mark.unit
 def test_decode_session_token_rejects_handoff_token():
     handoff, _ = security.create_billing_portal_handoff_token(
-        user_id=7, guild_id=1, guild_role="admin"
+        user_id=7,
+        guild_id=1,
+        guild_role="admin",
+        user_ref="ubil_test7",
+        guild_ref="gbil_test1",
     )
     with pytest.raises(jwt.PyJWTError):
         decode_session_token(handoff)

--- a/backend/app/services/platform/billing_claim.py
+++ b/backend/app/services/platform/billing_claim.py
@@ -31,6 +31,7 @@ from app.core.security import (
     HandoffSigningNotConfiguredError,
     create_billing_portal_handoff_token,
 )
+from app.services.platform.identity_refs import billing_refs
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +60,13 @@ def billing_claim_enabled() -> bool:
 async def _send_claim(user_id: int, guild_id: int) -> None:
     """One attempt, no retry; never raises."""
     try:
+        user_ref, guild_ref = await billing_refs(user_id=user_id, guild_id=guild_id)
         token, _ = create_billing_portal_handoff_token(
-            user_id=user_id, guild_id=guild_id, guild_role="admin"
+            user_id=user_id,
+            guild_id=guild_id,
+            guild_role="admin",
+            user_ref=user_ref,
+            guild_ref=guild_ref,
         )
         url = settings.BILLING_SERVICE_URL.rstrip("/") + CLAIM_PATH
         async with httpx.AsyncClient(timeout=_CLAIM_TIMEOUT) as client:

--- a/backend/app/services/platform/identity_refs.py
+++ b/backend/app/services/platform/identity_refs.py
@@ -26,12 +26,14 @@ from app.models.platform.identity_ref import (
     REF_ENTROPY_BYTES,
     REF_MAX_LENGTH,
     IdentityEntity,
+    IdentityPurpose,
     IdentityRef,
     ref_prefix,
 )
 
 __all__ = [
     "REF_GRACE_PERIOD",
+    "billing_refs",
     "drop_entity_refs",
     "ensure_ref",
     "mint_ref",
@@ -97,6 +99,34 @@ async def ensure_ref(
     if stored is None:  # pragma: no cover - the insert either landed or lost
         raise RuntimeError("identity ref was neither inserted nor found")
     return stored.ref
+
+
+async def billing_refs(*, user_id: int, guild_id: int) -> tuple[str, str]:
+    """The references billing knows one user and one guild by.
+
+    Opens a system-engine session of its own: the table is reachable only
+    there (``app.db.system_grants``), while the callers are request handlers
+    routed to other roles and one background task holding no session at all.
+    The same pattern ``services.platform.user_tokens`` uses for its sweep.
+    """
+    from app.db.session import AdminSessionLocal
+
+    purpose = IdentityPurpose.billing.value
+    async with AdminSessionLocal() as session:
+        user_ref = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.user,
+            entity_id=user_id,
+            purpose=purpose,
+        )
+        guild_ref = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.guild,
+            entity_id=guild_id,
+            purpose=purpose,
+        )
+        await session.commit()
+    return user_ref, guild_ref
 
 
 async def resolve_ref(

--- a/backend/app/services/platform/identity_refs_test.py
+++ b/backend/app/services/platform/identity_refs_test.py
@@ -367,3 +367,21 @@ async def drop_live_ref(session, *, entity_id: int) -> None:
             IdentityRef.retired_at.is_(None),
         )
     )
+
+
+class TestTheBillingPair:
+    @pytest.mark.integration
+    async def test_it_names_the_user_and_the_guild_differently(self, session):
+        from app.services.platform.identity_refs import billing_refs
+
+        user_ref, guild_ref = await billing_refs(user_id=1, guild_id=1)
+        assert user_ref.startswith("ubil_")
+        assert guild_ref.startswith("gbil_")
+        assert user_ref != guild_ref
+
+    @pytest.mark.integration
+    async def test_asking_twice_gives_the_same_pair(self, session):
+        from app.services.platform.identity_refs import billing_refs
+
+        first = await billing_refs(user_id=3, guild_id=4)
+        assert await billing_refs(user_id=3, guild_id=4) == first


### PR DESCRIPTION
**Merge after #1527.** This branch sits on top of `feat/identity-refs`, but the
PR targets `dev` (per the repo rule), so the diff below currently includes
#1527's commits as well. Once #1527 merges, this diff reduces to phase 2 alone.
The phase-2 commit is `Send references, not row ids, across the handoff`.

## What changes

Both handoff tokens minted in `app/core/security.py` now carry two more claims:

- `user_ref` — what the receiver names the user by
- `guild_ref` — what it names the guild by

Resolved through `identity_refs.billing_refs`, which mints them on first use.

## Additive on purpose

The row ids (`sub`, `guild_id`) stay in the payload for now. The receiver
verifies a signed contract, so it has to be able to read the new claims before
the old ones can go — swapping them in one step would mean the two sides must
deploy in lockstep. Dropping the row ids is a follow-up on both sides, and it is
the step that finishes the job this design set out to do.

**Worth a decision:** if the receiver is not yet deployed anywhere, that
follow-up can land immediately and the intermediate state never ships. Say so
and I will fold it in rather than leaving it for later.

## Where the session comes from

`billing_refs` opens its own system-engine session (`AdminSessionLocal`). The
table is reachable only there, and the three call sites are two request handlers
routed to other roles plus one background task holding no session at all — the
same pattern `services.platform.user_tokens` uses for its sweep.

Call sites updated: `billing_claim._send_claim`, `guilds.create_guild_billing_handoff`,
and the support handoff in `settings.py`.

## Testing

```
pytest -n 0 app/core/security_test.py \
            app/services/platform/identity_refs_test.py       # 54 passed
pytest -n 0 app/services/platform/billing_claim_test.py       #  9 passed
pytest -n 0 app/api/v1/platform_endpoints/guilds_test.py \
            app/api/v1/platform_endpoints/settings_test.py \
            -k "billing or handoff"                           # 17 passed
ruff check app && ruff format app && ty check                 # clean
```

## Design

`history/opaque-identity-design.md` (phase 2 of 3).
