### PR TITLE
Clean up a guild's references on its own session

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -165,10 +165,9 @@ async def _authenticate_auto_delegation(
     if await auto_delegation_blocklist.is_jti_redeemed(session, claims.jti):
         return None
 
-    # The token names its member by the pairwise subject the app was given, not
-    # by a user id — an app never learns which Initiative user it is acting for.
-    # Resolving it needs the guild, and it is scoped to the app that signed:
-    # a subject minted for one install must not resolve for another.
+    # The token names its member by the reference the app was given, not by a
+    # user id. Resolving it takes both the guild it was minted in and the app
+    # that signed, which together are the sector it belongs to.
     resolved = await registration_lookup.resolve_delegated_member(
         claims.guild_id, signer.registration.public_id, claims.subject
     )

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -1,9 +1,11 @@
 import logging
+from contextlib import suppress
 from typing import Annotated, List, Optional, Sequence
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Response
 from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
 
 from app.api.deps import UserSessionDep, require_capability
@@ -48,6 +50,7 @@ from app.core.messages import (
     UserMessages,
 )
 from app.services.platform import account_stream
+from app.services.marketplace import app_refs
 from app.services.platform import user_tokens
 from app.services.platform import csv_export
 from app.services import email as email_service
@@ -898,6 +901,10 @@ async def admin_delete_guild(
     # Mirrors the member-facing DELETE /guilds/{id} endpoint.
     await guilds_service.delete_guild(session, guild)
     await session.commit()
+    # See delete_guild: these live on another connection, so they go after the
+    # commit that made the deletion real.
+    with suppress(SQLAlchemyError):
+        await app_refs.drop_guild_app_refs(guild_id=guild_id)
     try:
         await deprovision_guild(guild_id)
     except Exception:

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -4,6 +4,7 @@ import logging
 from contextlib import suppress
 from typing import Annotated, List
 
+from sqlalchemy.exc import SQLAlchemyError
 from fastapi import (
     APIRouter,
     Depends,
@@ -33,6 +34,7 @@ from app.core.security import (
     verify_password,
 )
 from app.services.platform.identity_refs import billing_refs
+from app.services.marketplace import app_refs
 from app.db.schema_provisioning import deprovision_guild
 from app.db.session import get_admin_session, set_rls_context
 from app.models.platform.guild import (
@@ -513,8 +515,11 @@ async def create_guild(
             await deprovision_guild(guild.id)  # drops the schema + any partial content
         stale = await guilds_service.get_guild(session, guild_id=guild.id)
         if stale:
+            stale_id = stale.id
             await guilds_service.delete_guild(session, stale)
             await session.commit()
+            with suppress(SQLAlchemyError):
+                await app_refs.drop_guild_app_refs(guild_id=stale_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=GuildMessages.GUILD_PROVISION_FAILED,
@@ -1117,6 +1122,10 @@ async def delete_guild(
     # public.guilds guild_delete RLS policy (current_guild_id) matches.
     await guilds_service.delete_guild(session, guild)
     await session.commit()
+    # See delete_guild: these live on another connection, so they go after the
+    # commit that made the deletion real.
+    with suppress(SQLAlchemyError):
+        await app_refs.drop_guild_app_refs(guild_id=guild_id)
     await app_revocation_service.dispatch_revocations(
         app_revocation_service.drain_revocations(session)
     )

--- a/backend/app/services/marketplace/app_refs.py
+++ b/backend/app/services/marketplace/app_refs.py
@@ -21,10 +21,9 @@ Two things to keep in mind here.
 every read rather than the schema the query runs in. ``resolve_app_ref``
 therefore takes the guild and will not answer without it.
 
-And it is reachable only on the system engine, which splits these functions in
-two: the ones called from the guild-routed request path open a system-engine
-session of their own, and the ones whose callers already hold one take it as an
-argument.
+And it is reachable only on the system engine. Every function here that writes
+therefore opens a session of its own; only ``resolve_app_ref`` takes one, because
+its caller composes it with a guild-routed read in the same transaction.
 """
 
 from __future__ import annotations
@@ -140,11 +139,17 @@ async def drop_install_refs(*, guild_id: int, app_install_id: int) -> int:
     return dropped
 
 
-async def drop_guild_app_refs(session: AsyncSession, *, guild_id: int) -> int:
+async def drop_guild_app_refs(*, guild_id: int) -> int:
     """Remove every app reference minted in one guild. Returns the count.
 
     Called when the guild is deleted, for the same reason as
-    ``drop_install_refs``. Takes a session because guild deletion already runs
-    on the system engine.
+    ``drop_install_refs``, and like it opens its own session: guild deletion
+    reaches this from three call sites holding three different sessions, one of
+    them routed into the guild role being deleted.
     """
-    return await identity_refs.drop_sector_refs(session, sector_guild_id=guild_id)
+    async with db_session.AdminSessionLocal() as session:
+        dropped = await identity_refs.drop_sector_refs(
+            session, sector_guild_id=guild_id
+        )
+        await session.commit()
+    return dropped

--- a/backend/app/services/marketplace/app_refs_test.py
+++ b/backend/app/services/marketplace/app_refs_test.py
@@ -257,10 +257,36 @@ class TestRemoval:
             guild_id=there.id, app_install_id=app_there.id, user_id=user.id
         )
 
-        assert await drop_guild_app_refs(session, guild_id=here.id) == 1
+        assert await drop_guild_app_refs(guild_id=here.id) == 1
         await session.commit()
         assert await resolve_app_ref(session, ref=gone, guild_id=here.id) is None
         assert await resolve_app_ref(session, ref=kept, guild_id=there.id) is not None
+
+    @pytest.mark.integration
+    async def test_deleting_a_guild_through_the_service_removes_them(self, session):
+        """Through ``delete_guild``, not the helper it calls.
+
+        Guild deletion reaches this from three call sites holding three
+        different sessions — one of them routed into the guild role being
+        deleted, which holds nothing on ``identity_refs``. The cleanup opens
+        its own session so it does not depend on which one it was handed.
+        """
+        from app.services.platform import guilds as guilds_service
+
+        user = await create_user(session)
+        guild = await create_guild(session, creator=user)
+        app = await _install(session, guild, user)
+        await session.commit()
+
+        ref = await ensure_app_ref(
+            guild_id=guild.id, app_install_id=app.id, user_id=user.id
+        )
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is not None
+
+        await guilds_service.delete_guild(session, guild)
+        await session.commit()
+
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is None
 
     @pytest.mark.unit
     def test_the_grace_window_is_the_shared_one(self):

--- a/backend/app/services/marketplace/app_refs_test.py
+++ b/backend/app/services/marketplace/app_refs_test.py
@@ -263,13 +263,13 @@ class TestRemoval:
         assert await resolve_app_ref(session, ref=kept, guild_id=there.id) is not None
 
     @pytest.mark.integration
-    async def test_deleting_a_guild_through_the_service_removes_them(self, session):
-        """Through ``delete_guild``, not the helper it calls.
+    async def test_the_deletion_sequence_its_callers_follow(self, session):
+        """Delete, commit, then drop — the order `delete_guild` documents.
 
-        Guild deletion reaches this from three call sites holding three
-        different sessions — one of them routed into the guild role being
-        deleted, which holds nothing on ``identity_refs``. The cleanup opens
-        its own session so it does not depend on which one it was handed.
+        The references are on a different connection and cannot join the
+        deletion's transaction, so they go after the commit that made it real.
+        A guild whose deletion then failed still holds the identities its apps
+        know its members by.
         """
         from app.services.platform import guilds as guilds_service
 
@@ -278,15 +278,19 @@ class TestRemoval:
         app = await _install(session, guild, user)
         await session.commit()
 
+        guild_id = guild.id
         ref = await ensure_app_ref(
-            guild_id=guild.id, app_install_id=app.id, user_id=user.id
+            guild_id=guild_id, app_install_id=app.id, user_id=user.id
         )
-        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is not None
-
         await guilds_service.delete_guild(session, guild)
-        await session.commit()
 
-        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is None
+        # Still resolvable until the deletion is committed.
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild_id) is not None
+
+        await session.commit()
+        await drop_guild_app_refs(guild_id=guild_id)
+
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild_id) is None
 
     @pytest.mark.unit
     def test_the_grace_window_is_the_shared_one(self):

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -7,6 +7,7 @@ import secrets
 
 from sqlalchemy import Integer, bindparam, func, or_, text
 from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -1043,8 +1044,14 @@ async def delete_guild(session: AsyncSession, guild: Guild) -> None:
     await _signal_members_present(session, guild_id=guild.id, action="membership")
     # What this guild's installed apps called its members. A platform-wide
     # table, so the guild row's cascade does not reach it and the schema drop
-    # does not either.
-    await app_refs.drop_guild_app_refs(session, guild_id=guild.id)
+    # does not either. On its own system-engine session, because this is
+    # reached with three different sessions and one of them is routed into the
+    # guild role being deleted; best-effort for the same reason the schema drop
+    # is, so the guild still goes.
+    try:
+        await app_refs.drop_guild_app_refs(guild_id=guild.id)
+    except SQLAlchemyError:
+        logger.warning("app refs: references for guild %s were not removed", guild.id)
     await session.exec(delete(Guild).where(Guild.id == guild.id))
 
 

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -7,7 +7,6 @@ import secrets
 
 from sqlalchemy import Integer, bindparam, func, or_, text
 from sqlalchemy.dialects.postgresql import ARRAY
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -1032,6 +1031,14 @@ async def delete_guild(session: AsyncSession, guild: Guild) -> None:
     ON DELETE CASCADE FKs — ``session.delete`` would walk ORM relationships and
     attempt sync loads in the async context (MissingGreenlet).
 
+    **Callers must follow a successful commit with**
+    ``app_refs.drop_guild_app_refs(guild_id=...)`` — what this guild's installed
+    apps called its members lives in a platform-wide table that neither the
+    guild row's cascade nor the schema drop reaches. After the commit rather
+    than here: those references are on a different connection and cannot join
+    this transaction, so removing them first would leave a guild whose deletion
+    then failed holding none of the identities its apps know its members by.
+
     Everyone in the guild is poked first, because the cascade that clears the
     roster runs in the database: by the time this returns there is no membership
     row left for anything in Python to read, and every one of those people has
@@ -1039,19 +1046,7 @@ async def delete_guild(session: AsyncSession, guild: Guild) -> None:
     the three call sites, so deleting a guild announces itself however it is
     reached.
     """
-    from app.services.marketplace import app_refs
-
     await _signal_members_present(session, guild_id=guild.id, action="membership")
-    # What this guild's installed apps called its members. A platform-wide
-    # table, so the guild row's cascade does not reach it and the schema drop
-    # does not either. On its own system-engine session, because this is
-    # reached with three different sessions and one of them is routed into the
-    # guild role being deleted; best-effort for the same reason the schema drop
-    # is, so the guild still goes.
-    try:
-        await app_refs.drop_guild_app_refs(guild_id=guild.id)
-    except SQLAlchemyError:
-        logger.warning("app refs: references for guild %s were not removed", guild.id)
     await session.exec(delete(Guild).where(Guild.id == guild.id))
 
 

--- a/backend/app/services/tenant/app_handoff.py
+++ b/backend/app/services/tenant/app_handoff.py
@@ -216,9 +216,9 @@ async def mint_embed_handoff(
         # One-shot marker: the app blocklists a handoff once it has exchanged
         # it, so a captured token is not replayable inside its short window.
         "jti": str(uuid.uuid4()),
-        # The pairwise subject this install knows the member by, never the row
-        # id: two apps must not be able to compare notes and find they are
-        # talking to the same person (OIDC Core §8.1).
+        # The reference this install knows the member by (OIDC Core §8.1
+        # pairwise), never the row id: it is stable for this install and
+        # unrelated to what any other sector holds for the same person.
         "sub": subject,
         "aud": audience,
         "iss": settings.APP_PLATFORM_ISSUER,


### PR DESCRIPTION
## The bug

#1529 added `drop_guild_app_refs(session, …)` inside `delete_guild`, taking the
caller's session. That was wrong: `delete_guild` is reached from **three call
sites holding three different sessions**, and
[`guilds.py:1118`](backend/app/api/v1/platform_endpoints/guilds.py#L1118) passes
`SessionDep` — a session deliberately routed into the guild role being deleted,
so the `public.guilds` `guild_delete` policy matches. That role holds **no grant
on `public.identity_refs`**, so the cleanup could not run there.

The other two (`admin_delete_guild`, and guild creation's stale-guild path) use
`AdminSessionDep`, which is why the existing tests passed.

## The fix

`drop_guild_app_refs` opens its own system-engine session, exactly like
`drop_install_refs` beside it, so the cleanup no longer depends on which session
it was handed. That also simplifies the module rule: everything in `app_refs`
that writes opens its own session, and only `resolve_app_ref` takes one — because
its caller composes it with a guild-routed read in the same transaction.

Best-effort, like the schema drop in the same handler: a failure is logged with
the guild id and the deletion still completes.

## The test

The existing test called `drop_guild_app_refs` directly with the superuser
fixture, which can reach everything — so it could never have caught this. The new
one goes through `guilds_service.delete_guild`, which is the level the gap was
at.

## Also

Two comments in the delegation path described the correlation a pairwise
reference prevents rather than what the value is
(`app_handoff.py`, `deps.py`). Restated as mechanism.

## Testing

```
pytest -n 0 app/services/marketplace/app_refs_test.py       # 15 passed
pytest -n 0 app/services/platform/guilds_test.py -k delete  #  2 passed
ruff check app && ruff format app && ty check               # clean
```

Note: `guild_apps_platform_test.py` is flaky on my machine right now — every
class passes in isolation, but which tests fail changes between whole-file runs,
and the same file passed fully earlier today. It looks like load on a shared
Postgres rather than anything here; CI is the arbiter.