### PR TITLE
Name the guild by reference across the app boundary

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -165,11 +165,19 @@ async def _authenticate_auto_delegation(
     if await auto_delegation_blocklist.is_jti_redeemed(session, claims.jti):
         return None
 
+    # The token names its guild by reference too, so the id everything below
+    # works in is resolved here rather than taken from the token.
+    from app.services.marketplace.app_refs import resolve_app_guild_ref
+
+    guild_id = await resolve_app_guild_ref(ref=claims.guild_ref)
+    if guild_id is None:
+        return None
+
     # The token names its member by the reference the app was given, not by a
     # user id. Resolving it takes both the guild it was minted in and the app
     # that signed, which together are the sector it belongs to.
     resolved = await registration_lookup.resolve_delegated_member(
-        claims.guild_id, signer.registration.public_id, claims.subject
+        guild_id, signer.registration.public_id, claims.subject
     )
     if resolved is None:
         return None
@@ -193,7 +201,7 @@ async def _authenticate_auto_delegation(
     # The read/write split follows the request method, the same line
     # `_enforce_api_key_scope` draws for a read-only PAT.
     if not await registration_lookup.delegation_allowed(
-        claims.guild_id,
+        guild_id,
         signer.registration.public_id,
         resolved,
         need_write=request.method not in _SAFE_HTTP_METHODS,
@@ -215,7 +223,7 @@ async def _authenticate_auto_delegation(
     # Bind the request to the token's guild (see docstring). Stored on
     # request.state so the guild-context resolver can read it without the
     # claims object having to travel through every auth signature.
-    request.state.delegated_guild_id = claims.guild_id
+    request.state.delegated_guild_id = guild_id
 
     return user
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -165,10 +165,9 @@ async def _authenticate_auto_delegation(
     if await auto_delegation_blocklist.is_jti_redeemed(session, claims.jti):
         return None
 
-    # The token names its member by the pairwise subject the app was given, not
-    # by a user id — an app never learns which Initiative user it is acting for.
-    # Resolving it needs the guild, and it is scoped to the app that signed:
-    # a subject minted for one install must not resolve for another.
+    # The token names its member by the reference the app was given, not by a
+    # user id. Resolving it takes both the guild it was minted in and the app
+    # that signed, which together are the sector it belongs to.
     resolved = await registration_lookup.resolve_delegated_member(
         claims.guild_id, signer.registration.public_id, claims.subject
     )

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -117,12 +117,14 @@ async def _authenticate_auto_delegation(
       1. Token verifies (signature, audience, issuer, required claims).
       2. ``jti`` is not in the blocklist — first presentation only.
 
-    A verified token also pins the request's guild context to the token's
-    ``guild_id`` claim (via ``request.state.delegated_guild_id``): delegation
-    tokens are minted for exactly one guild, and a machine caller has no
-    guild context of its own to resolve from. The claim is validated against
-    the user's memberships and must agree with the ``/g/{guild_id}`` path, so an
-    auto workflow always acts in the guild its token was issued for.
+    A verified token also pins the request's guild context. The token names its
+    guild by a ``guild_ref`` claim — the reference the app was given, not a row
+    id — which is resolved here to the guild it stands for and put on
+    ``request.state.delegated_guild_id``: delegation tokens are minted for
+    exactly one guild, and a machine caller has no guild context of its own to
+    resolve from. The resolved guild is validated against the user's memberships
+    and must agree with the ``/g/{guild_id}`` path, so an auto workflow always
+    acts in the guild its token was issued for.
     """
     if not delegation_possible():
         return None  # no app platform here — let other auth paths run

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -1,9 +1,11 @@
 import logging
+from contextlib import suppress
 from typing import Annotated, List, Optional, Sequence
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Response
 from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
 
 from app.api.deps import UserSessionDep, require_capability
@@ -48,6 +50,7 @@ from app.core.messages import (
     UserMessages,
 )
 from app.services.platform import account_stream
+from app.services.marketplace import app_refs
 from app.services.platform import user_tokens
 from app.services.platform import csv_export
 from app.services import email as email_service
@@ -898,6 +901,10 @@ async def admin_delete_guild(
     # Mirrors the member-facing DELETE /guilds/{id} endpoint.
     await guilds_service.delete_guild(session, guild)
     await session.commit()
+    # See delete_guild: these live on another connection, so they go after the
+    # commit that made the deletion real.
+    with suppress(SQLAlchemyError):
+        await app_refs.drop_guild_app_refs(guild_id=guild_id)
     try:
         await deprovision_guild(guild_id)
     except Exception:

--- a/backend/app/api/v1/platform_endpoints/admin.py
+++ b/backend/app/api/v1/platform_endpoints/admin.py
@@ -1,11 +1,9 @@
 import logging
-from contextlib import suppress
 from typing import Annotated, List, Optional, Sequence
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Response
 from sqlalchemy import func
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select
 
 from app.api.deps import UserSessionDep, require_capability
@@ -903,8 +901,7 @@ async def admin_delete_guild(
     await session.commit()
     # See delete_guild: these live on another connection, so they go after the
     # commit that made the deletion real.
-    with suppress(SQLAlchemyError):
-        await app_refs.drop_guild_app_refs(guild_id=guild_id)
+    await app_refs.forget_guild(guild_id=guild_id)
     try:
         await deprovision_guild(guild_id)
     except Exception:

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -4,6 +4,7 @@ import logging
 from contextlib import suppress
 from typing import Annotated, List
 
+from sqlalchemy.exc import SQLAlchemyError
 from fastapi import (
     APIRouter,
     Depends,
@@ -33,6 +34,7 @@ from app.core.security import (
     verify_password,
 )
 from app.services.platform.identity_refs import billing_refs
+from app.services.marketplace import app_refs
 from app.db.schema_provisioning import deprovision_guild
 from app.db.session import get_admin_session, set_rls_context
 from app.models.platform.guild import (
@@ -513,8 +515,11 @@ async def create_guild(
             await deprovision_guild(guild.id)  # drops the schema + any partial content
         stale = await guilds_service.get_guild(session, guild_id=guild.id)
         if stale:
+            stale_id = stale.id
             await guilds_service.delete_guild(session, stale)
             await session.commit()
+            with suppress(SQLAlchemyError):
+                await app_refs.drop_guild_app_refs(guild_id=stale_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=GuildMessages.GUILD_PROVISION_FAILED,
@@ -1117,6 +1122,10 @@ async def delete_guild(
     # public.guilds guild_delete RLS policy (current_guild_id) matches.
     await guilds_service.delete_guild(session, guild)
     await session.commit()
+    # See delete_guild: these live on another connection, so they go after the
+    # commit that made the deletion real.
+    with suppress(SQLAlchemyError):
+        await app_refs.drop_guild_app_refs(guild_id=guild_id)
     await app_revocation_service.dispatch_revocations(
         app_revocation_service.drain_revocations(session)
     )

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -4,7 +4,6 @@ import logging
 from contextlib import suppress
 from typing import Annotated, List
 
-from sqlalchemy.exc import SQLAlchemyError
 from fastapi import (
     APIRouter,
     Depends,
@@ -518,8 +517,7 @@ async def create_guild(
             stale_id = stale.id
             await guilds_service.delete_guild(session, stale)
             await session.commit()
-            with suppress(SQLAlchemyError):
-                await app_refs.drop_guild_app_refs(guild_id=stale_id)
+            await app_refs.forget_guild(guild_id=stale_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=GuildMessages.GUILD_PROVISION_FAILED,
@@ -1124,8 +1122,7 @@ async def delete_guild(
     await session.commit()
     # See delete_guild: these live on another connection, so they go after the
     # commit that made the deletion real.
-    with suppress(SQLAlchemyError):
-        await app_refs.drop_guild_app_refs(guild_id=guild_id)
+    await app_refs.forget_guild(guild_id=guild_id)
     await app_revocation_service.dispatch_revocations(
         app_revocation_service.drain_revocations(session)
     )

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_registration_test.py
@@ -31,6 +31,7 @@ from app.testing.delegation import (
     foreign_jwks,
     mint_delegation_token,
     register_delegate,
+    delegate_guild_ref,
 )
 
 
@@ -66,12 +67,12 @@ async def _acting_in_a_guild_that_installed_it(session: AsyncSession, email: str
     return await delegate_subject(session, guild, user), guild
 
 
-async def _call_as_delegate(client: AsyncClient, subject: str, guild_id: int) -> int:
+async def _call_as_delegate(client: AsyncClient, subject: str, guild_ref: str) -> int:
     response = await client.get(
         "/api/v1/users/me",
         headers={
             "Authorization": (
-                f"Bearer {mint_delegation_token(subject=subject, guild_id=guild_id)}"
+                f"Bearer {mint_delegation_token(subject=subject, guild_ref=guild_ref)}"
             )
         },
     )
@@ -87,7 +88,12 @@ async def test_a_granted_registration_verifies_the_token(
     )
     await register_delegate(session)
 
-    assert await _call_as_delegate(client, subject, guild.id) == 200
+    assert (
+        await _call_as_delegate(
+            client, subject, await delegate_guild_ref(session, guild)
+        )
+        == 200
+    )
 
 
 @pytest.mark.integration
@@ -99,7 +105,12 @@ async def test_the_kill_switch_ends_delegation(
     )
     await register_delegate(session, enabled=False)
 
-    assert await _call_as_delegate(client, subject, guild.id) == 401
+    assert (
+        await _call_as_delegate(
+            client, subject, await delegate_guild_ref(session, guild)
+        )
+        == 401
+    )
 
 
 @pytest.mark.integration
@@ -112,7 +123,12 @@ async def test_keys_without_the_grant_verify_nothing(
     )
     await register_delegate(session, grants=())
 
-    assert await _call_as_delegate(client, subject, guild.id) == 401
+    assert (
+        await _call_as_delegate(
+            client, subject, await delegate_guild_ref(session, guild)
+        )
+        == 401
+    )
 
 
 @pytest.mark.integration
@@ -124,7 +140,12 @@ async def test_a_kid_no_registration_published_verifies_nothing(
     )
     await register_delegate(session, key_set=delegation_jwks("some-other-generation"))
 
-    assert await _call_as_delegate(client, subject, guild.id) == 401
+    assert (
+        await _call_as_delegate(
+            client, subject, await delegate_guild_ref(session, guild)
+        )
+        == 401
+    )
 
 
 @pytest.mark.integration
@@ -146,7 +167,12 @@ async def test_a_shared_kid_does_not_shadow_the_app_that_signed(
     )
     await register_delegate(session)
 
-    assert await _call_as_delegate(client, subject, guild.id) == 200
+    assert (
+        await _call_as_delegate(
+            client, subject, await delegate_guild_ref(session, guild)
+        )
+        == 200
+    )
 
 
 @pytest.mark.integration
@@ -190,7 +216,7 @@ async def test_an_app_acts_only_where_it_was_installed(
         f"/api/v1/g/{guild.id}/initiatives/",
         headers={
             "Authorization": (
-                f"Bearer {mint_delegation_token(subject=subject, guild_id=guild.id)}"
+                f"Bearer {mint_delegation_token(subject=subject, guild_ref=await delegate_guild_ref(session, guild))}"
             )
         },
     )
@@ -202,7 +228,7 @@ async def test_an_app_acts_only_where_it_was_installed(
         f"/api/v1/g/{guild.id}/initiatives/",
         headers={
             "Authorization": (
-                f"Bearer {mint_delegation_token(subject=subject, guild_id=guild.id)}"
+                f"Bearer {mint_delegation_token(subject=subject, guild_ref=await delegate_guild_ref(session, guild))}"
             )
         },
     )
@@ -230,7 +256,7 @@ async def test_a_switched_off_install_stops_the_app(
         f"/api/v1/g/{guild.id}/initiatives/",
         headers={
             "Authorization": (
-                f"Bearer {mint_delegation_token(subject=subject, guild_id=guild.id)}"
+                f"Bearer {mint_delegation_token(subject=subject, guild_ref=await delegate_guild_ref(session, guild))}"
             )
         },
     )
@@ -245,7 +271,10 @@ async def test_a_token_naming_no_guild_is_refused_not_an_error(
     refused the way every other delegation refusal is rather than faulting."""
     await register_delegate(session)
 
-    assert await _call_as_delegate(client, "subject-for-no-guild", 9_999_999) == 401
+    assert (
+        await _call_as_delegate(client, "subject-for-no-guild", "gapp_never-minted")
+        == 401
+    )
 
 
 @pytest.mark.integration
@@ -280,4 +309,9 @@ async def test_another_apps_install_does_not_let_this_one_act(
 
     # No subject exists for this app here, and the one the other app's install
     # would mint is not one this app may present.
-    assert await _call_as_delegate(client, "not-minted-here", guild.id) == 401
+    assert (
+        await _call_as_delegate(
+            client, "not-minted-here", await delegate_guild_ref(session, guild)
+        )
+        == 401
+    )

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
@@ -5,7 +5,7 @@ JWTs minted by initiative-auto:
 
 * signature, audience, issuer (negative tests against tampered tokens)
 * one-shot replay rejection via the jti blocklist
-* the guild_id JWT claim pins the request's guild context (validated against
+* the guild_ref JWT claim pins the request's guild context (validated against
   the user's memberships, and refused if it disagrees with the ``/g/{guild_id}``
   path)
 * deactivated users can't be impersonated even with a valid token
@@ -38,6 +38,7 @@ from app.testing.delegation import (
     install_delegate,
     mint_delegation_token,
     register_delegate,
+    delegate_guild_ref,
 )
 
 
@@ -89,7 +90,9 @@ async def test_delegation_token_is_one_shot(
     await authorize_delegate(session, delegate_guild, user)
     subject = await delegate_subject(session, delegate_guild, user)
     token = _mint_delegation(
-        subject=subject, guild_id=delegate_guild.id, jti="replay-target-001"
+        subject=subject,
+        guild_ref=await delegate_guild_ref(session, delegate_guild),
+        jti="replay-target-001",
     )
 
     first = await client.get(
@@ -112,7 +115,7 @@ async def test_delegation_token_is_one_shot(
 async def test_delegation_token_guild_claim_pins_context(
     client: AsyncClient, session: AsyncSession, delegate_guild
 ):
-    """The token's guild_id claim IS the request's guild context — it takes
+    """The token's guild_ref claim IS the request's guild context — it takes
     precedence over whatever guild the human happens to be in, and it is
     validated against the user's memberships like any other context. A token
     minted for a guild the user can't access must not reach guild data even
@@ -126,7 +129,9 @@ async def test_delegation_token_guild_claim_pins_context(
     # The human is legitimately in their own guild, and the app is installed in
     # the guild its token names — so what refuses this is the pin itself, not a
     # missing install or an unknown guild.
-    token = _mint_delegation(subject=subject, guild_id=delegate_guild.id)
+    token = _mint_delegation(
+        subject=subject, guild_ref=await delegate_guild_ref(session, delegate_guild)
+    )
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/initiatives/",
@@ -140,7 +145,7 @@ async def test_delegation_token_guild_claim_pins_context(
 async def test_delegation_token_guild_claim_provides_context(
     client: AsyncClient, session: AsyncSession, delegate_guild
 ):
-    """A machine caller has no ambient guild context: the token's guild_id
+    """A machine caller has no ambient guild context: the token's guild_ref
     claim (validated against the user's memberships) supplies the guild for a
     guild-scoped endpoint."""
     user = await create_user(session, email="happy-path@example.com")
@@ -148,7 +153,9 @@ async def test_delegation_token_guild_claim_provides_context(
     await create_guild_membership(session, user=user, guild=guild)
     await authorize_delegate(session, guild, user)
     subject = await delegate_subject(session, guild, user)
-    token = _mint_delegation(subject=subject, guild_id=guild.id)
+    token = _mint_delegation(
+        subject=subject, guild_ref=await delegate_guild_ref(session, guild)
+    )
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/initiatives/",
@@ -168,7 +175,9 @@ async def test_delegation_works_on_cross_guild_endpoints(
     user = await create_user(session, email="cross-guild-allowed@example.com")
     await authorize_delegate(session, delegate_guild, user)
     subject = await delegate_subject(session, delegate_guild, user)
-    token = _mint_delegation(subject=subject, guild_id=delegate_guild.id)
+    token = _mint_delegation(
+        subject=subject, guild_ref=await delegate_guild_ref(session, delegate_guild)
+    )
 
     response = await client.get(
         "/api/v1/users/me",
@@ -191,7 +200,9 @@ async def test_delegation_rejects_deactivated_user(
     await session.refresh(user)
     subject = await delegate_subject(session, delegate_guild, user)
 
-    token = _mint_delegation(subject=subject, guild_id=delegate_guild.id)
+    token = _mint_delegation(
+        subject=subject, guild_ref=await delegate_guild_ref(session, delegate_guild)
+    )
 
     response = await client.get(
         "/api/v1/users/me",
@@ -211,7 +222,8 @@ async def test_delegation_cannot_name_a_member_we_never_minted(
     user id and be refused only because that row was missing. Now the space of
     namable members is exactly the set already minted for this install."""
     token = _mint_delegation(
-        subject="never-minted-anywhere", guild_id=delegate_guild.id
+        subject="never-minted-anywhere",
+        guild_ref=await delegate_guild_ref(session, delegate_guild),
     )
 
     response = await client.get(
@@ -231,7 +243,7 @@ async def test_delegation_rejects_wrong_audience(
     # Refused at verification, so it never reaches subject resolution.
     token = _mint_delegation(
         subject="any-subject",
-        guild_id=delegate_guild.id,
+        guild_ref=await delegate_guild_ref(session, delegate_guild),
         aud="initiative:something-else",
     )
 
@@ -248,7 +260,9 @@ async def test_delegation_rejects_wrong_issuer(
 ):
     """Issuer must match — defense in depth alongside the audience check."""
     token = _mint_delegation(
-        subject="any-subject", guild_id=delegate_guild.id, iss="someone-else"
+        subject="any-subject",
+        guild_ref=await delegate_guild_ref(session, delegate_guild),
+        iss="someone-else",
     )
 
     response = await client.get(
@@ -271,7 +285,9 @@ async def test_delegation_rejects_signature_from_other_key(
         serialization.NoEncryption(),
     ).decode()
     token = _mint_delegation(
-        subject="any-subject", guild_id=delegate_guild.id, private_pem=other_private
+        subject="any-subject",
+        guild_ref=await delegate_guild_ref(session, delegate_guild),
+        private_pem=other_private,
     )
 
     response = await client.get(
@@ -292,7 +308,10 @@ async def test_delegation_is_off_where_no_app_platform_is_configured(
         config_module.settings, "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM", None
     )
 
-    token = _mint_delegation(subject="any-subject", guild_id=delegate_guild.id)
+    token = _mint_delegation(
+        subject="any-subject",
+        guild_ref=await delegate_guild_ref(session, delegate_guild),
+    )
 
     response = await client.get(
         "/api/v1/users/me",

--- a/backend/app/api/v1/tenant_endpoints/guild_app_delegations_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_delegations_test.py
@@ -18,6 +18,7 @@ from app.testing.delegation import (
     install_delegate,
     mint_delegation_token,
     register_delegate,
+    delegate_guild_ref,
 )
 
 
@@ -68,7 +69,8 @@ async def _delegated(session, guild, user) -> dict[str, str]:
     app was given, and the platform resolves it.
     """
     token = mint_delegation_token(
-        subject=await delegate_subject(session, guild, user), guild_id=guild.id
+        subject=await delegate_subject(session, guild, user),
+        guild_ref=await delegate_guild_ref(session, guild),
     )
     return {"Authorization": f"Bearer {token}"}
 

--- a/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_service_test.py
@@ -25,6 +25,7 @@ from app.testing.delegation import (
     install_delegate,
     mint_delegation_token,
     register_delegate,
+    delegate_guild_ref,
 )
 from app.testing.factories import create_guild_app
 from app.testing.schema_harness import route_session_to_guild
@@ -108,9 +109,9 @@ async def scene(session: AsyncSession, acting_user):
     return actor, subject
 
 
-def _headers(subject: str, guild_id: int, jti: str) -> dict[str, str]:
+def _headers(subject: str, guild_ref: str, jti: str) -> dict[str, str]:
     return {
-        "Authorization": f"Bearer {mint_delegation_token(subject=subject, guild_id=guild_id, jti=jti)}"
+        "Authorization": f"Bearer {mint_delegation_token(subject=subject, guild_ref=guild_ref, jti=jti)}"
     }
 
 
@@ -125,7 +126,9 @@ async def test_a_live_delegate_is_told_where_the_app_answers(
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/apps/{app.id}/service",
-        headers=_headers(subject, guild.id, "svc-ok-001"),
+        headers=_headers(
+            subject, await delegate_guild_ref(session, guild), "svc-ok-001"
+        ),
     )
 
     assert response.status_code == 200, response.text
@@ -149,7 +152,9 @@ async def test_the_answer_says_nothing_about_the_person(
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/apps/{app.id}/service",
-        headers=_headers(subject, guild.id, "svc-shape-001"),
+        headers=_headers(
+            subject, await delegate_guild_ref(session, guild), "svc-shape-001"
+        ),
     )
 
     assert set(response.json()) == {"public_id", "base_url", "available"}
@@ -173,7 +178,9 @@ async def test_a_switched_off_install_still_answers_and_says_so(
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/apps/{app.id}/service",
-        headers=_headers(subject, guild.id, "svc-disabled-001"),
+        headers=_headers(
+            subject, await delegate_guild_ref(session, guild), "svc-disabled-001"
+        ),
     )
 
     assert response.status_code == 200, response.text
@@ -225,7 +232,7 @@ async def test_a_delegate_that_may_not_act_is_refused(
     guild, installer = actor.guild, actor.user
     await _register_target(session)
     app = await _install_target(session, guild, installer)
-    headers = _headers(subject, guild.id, f"svc-{case}")
+    headers = _headers(subject, await delegate_guild_ref(session, guild), f"svc-{case}")
 
     # Re-register the delegate with the operator's edit applied. Done after the
     # token is minted, because what is being tested is the check at use rather
@@ -264,7 +271,9 @@ async def test_a_delegate_without_the_directory_grant_is_refused(
     guild, installer = actor.guild, actor.user
     await _register_target(session)
     app = await _install_target(session, guild, installer)
-    headers = _headers(subject, guild.id, "svc-no-directory")
+    headers = _headers(
+        subject, await delegate_guild_ref(session, guild), "svc-no-directory"
+    )
 
     from sqlmodel import delete
 
@@ -308,7 +317,9 @@ async def test_an_app_with_no_service_behind_it_has_no_address(
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/apps/{app.id}/service",
-        headers=_headers(subject, guild.id, "svc-no-service-001"),
+        headers=_headers(
+            subject, await delegate_guild_ref(session, guild), "svc-no-service-001"
+        ),
     )
 
     assert response.status_code == 404
@@ -326,7 +337,9 @@ async def test_a_service_this_deployment_never_wired_up_has_no_address(
 
     response = await client.get(
         f"/api/v1/g/{guild.id}/apps/{app.id}/service",
-        headers=_headers(subject, guild.id, "svc-unregistered-001"),
+        headers=_headers(
+            subject, await delegate_guild_ref(session, guild), "svc-unregistered-001"
+        ),
     )
 
     assert response.status_code == 404

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -511,7 +511,9 @@ class AutoDelegationClaims:
     #: caller resolves it inside the guild the token names — an app that never
     #: learns who somebody is can still act as them.
     subject: str
-    guild_id: int
+    #: The reference the app knows this guild by, NOT a guild id. Resolved by
+    #: the caller, like ``subject``.
+    guild_ref: str
     initiative_id: int | None
 
 
@@ -594,9 +596,9 @@ def verify_auto_delegation_token(
     if not isinstance(subject, str) or not subject:
         raise AutoDelegationVerificationError("sub must be a pairwise subject")
 
-    guild_id = payload.get("guild_id")
-    if not isinstance(guild_id, int):
-        raise AutoDelegationVerificationError("guild_id must be an int")
+    guild_ref = payload.get("guild_ref")
+    if not isinstance(guild_ref, str) or not guild_ref:
+        raise AutoDelegationVerificationError("guild_ref must be a reference")
 
     initiative_id = payload.get("initiative_id")
     if initiative_id is not None and not isinstance(initiative_id, int):
@@ -607,6 +609,6 @@ def verify_auto_delegation_token(
     return AutoDelegationClaims(
         jti=str(payload["jti"]),
         subject=subject,
-        guild_id=guild_id,
+        guild_ref=guild_ref,
         initiative_id=initiative_id,
     )

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -442,6 +442,8 @@ def test_loader_refuses_a_private_key():
 #: for one member at one install, opaque to the app that holds it. These tests
 #: are about key selection and carry it only so it can be read back out.
 _SUBJECT = "mBqR7xK2wPL0vN4tZ8yC6sD1fG3hJ5nA"
+#: The reference the delegate knows the guild by, as it would arrive.
+_GUILD_REF = "gapp_wRkC8mBv1xQ2fTn6JhLpZs4dY7eA0uKq"
 
 
 def _mint_delegation(
@@ -456,7 +458,7 @@ def _mint_delegation(
             "iss": settings.AUTO_DELEGATION_ISSUER,
             "iat": int(now.timestamp()),
             "exp": now + timedelta(seconds=expires_in),
-            "guild_id": 9,
+            "guild_ref": _GUILD_REF,
         },
         private_pem(signed_by),
         algorithm="RS256",
@@ -469,7 +471,7 @@ def test_delegation_accepts_the_key_it_was_given():
     claims = security.verify_auto_delegation_token(
         _mint_delegation(signed_by=0), keys=[public_key(0)]
     )
-    assert (claims.subject, claims.guild_id) == (_SUBJECT, 9)
+    assert (claims.subject, claims.guild_ref) == (_SUBJECT, _GUILD_REF)
 
 
 @pytest.mark.unit

--- a/backend/app/services/marketplace/app_refs.py
+++ b/backend/app/services/marketplace/app_refs.py
@@ -21,10 +21,9 @@ Two things to keep in mind here.
 every read rather than the schema the query runs in. ``resolve_app_ref``
 therefore takes the guild and will not answer without it.
 
-And it is reachable only on the system engine, which splits these functions in
-two: the ones called from the guild-routed request path open a system-engine
-session of their own, and the ones whose callers already hold one take it as an
-argument.
+And it is reachable only on the system engine. Every function here that writes
+therefore opens a session of its own; only ``resolve_app_ref`` takes one, because
+its caller composes it with a guild-routed read in the same transaction.
 """
 
 from __future__ import annotations
@@ -140,11 +139,17 @@ async def drop_install_refs(*, guild_id: int, app_install_id: int) -> int:
     return dropped
 
 
-async def drop_guild_app_refs(session: AsyncSession, *, guild_id: int) -> int:
+async def drop_guild_app_refs(*, guild_id: int) -> int:
     """Remove every app reference minted in one guild. Returns the count.
 
     Called when the guild is deleted, for the same reason as
-    ``drop_install_refs``. Takes a session because guild deletion already runs
-    on the system engine.
+    ``drop_install_refs``, and like it opens its own session: guild deletion
+    reaches this from three call sites holding three different sessions, one of
+    them routed into the guild role being deleted.
     """
-    return await identity_refs.drop_sector_refs(session, sector_guild_id=guild_id)
+    async with db_session.AdminSessionLocal() as session:
+        dropped = await identity_refs.drop_sector_refs(
+            session, sector_guild_id=guild_id
+        )
+        await session.commit()
+    return dropped

--- a/backend/app/services/marketplace/app_refs.py
+++ b/backend/app/services/marketplace/app_refs.py
@@ -40,6 +40,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 __all__ = [
     "REF_MAX_LENGTH",
+    "ensure_app_guild_ref",
+    "resolve_app_guild_ref",
     "drop_guild_app_refs",
     "drop_install_refs",
     "ensure_app_ref",
@@ -69,6 +71,41 @@ async def ensure_app_ref(*, guild_id: int, app_install_id: int, user_id: int) ->
         )
         await session.commit()
     return ref
+
+
+async def ensure_app_guild_ref(*, guild_id: int, app_install_id: int) -> str:
+    """What this install calls the guild it is installed in.
+
+    The guild's own reference at the same sector the member's uses, so an app
+    installed in two guilds holds two unrelated values for them — the same
+    property the member reference has, applied to the tenant.
+    """
+    async with db_session.AdminSessionLocal() as session:
+        ref = await identity_refs.ensure_ref(
+            session,
+            entity_type=IdentityEntity.guild,
+            entity_id=guild_id,
+            purpose=_PURPOSE,
+            sector_guild_id=guild_id,
+            sector_id=app_install_id,
+        )
+        await session.commit()
+    return ref
+
+
+async def resolve_app_guild_ref(*, ref: str) -> int | None:
+    """Which guild a guild reference names, or None.
+
+    The inverse of ``ensure_app_guild_ref``, for a token that names its guild by
+    reference. Opens its own session: the caller at this point holds none.
+    """
+    async with db_session.AdminSessionLocal() as session:
+        row = await identity_refs.resolve_ref(session, ref=ref)
+    if row is None:
+        return None
+    if row.purpose != _PURPOSE or row.entity_type != IdentityEntity.guild:
+        return None
+    return row.entity_id
 
 
 async def resolve_app_ref(

--- a/backend/app/services/marketplace/app_refs.py
+++ b/backend/app/services/marketplace/app_refs.py
@@ -28,6 +28,10 @@ its caller composes it with a guild-routed read in the same transaction.
 
 from __future__ import annotations
 
+import logging
+
+from sqlalchemy.exc import SQLAlchemyError
+
 from app.db import session as db_session
 from app.models.platform.identity_ref import (
     REF_MAX_LENGTH,
@@ -40,6 +44,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 __all__ = [
     "REF_MAX_LENGTH",
+    "forget_guild",
     "ensure_app_guild_ref",
     "resolve_app_guild_ref",
     "drop_guild_app_refs",
@@ -49,6 +54,8 @@ __all__ = [
     "reissue_install_refs",
     "resolve_app_ref",
 ]
+
+logger = logging.getLogger(__name__)
 
 _PURPOSE = IdentityPurpose.app
 
@@ -190,3 +197,21 @@ async def drop_guild_app_refs(*, guild_id: int) -> int:
         )
         await session.commit()
     return dropped
+
+
+async def forget_guild(*, guild_id: int) -> None:
+    """Drop a deleted guild's references, reporting rather than raising.
+
+    Called after the deletion has committed, so there is nothing left to roll
+    back and a failure here must not fail the request. It is logged with the
+    guild, and what it leaves behind is reclaimed by
+    ``identity_refs.purge_orphaned_sector_refs``.
+    """
+    try:
+        await drop_guild_app_refs(guild_id=guild_id)
+    except SQLAlchemyError:
+        logger.warning(
+            "app refs: references for deleted guild %s were not removed; "
+            "the orphan sweep will reclaim them",
+            guild_id,
+        )

--- a/backend/app/services/marketplace/app_refs_test.py
+++ b/backend/app/services/marketplace/app_refs_test.py
@@ -292,6 +292,41 @@ class TestRemoval:
 
         assert await resolve_app_ref(session, ref=ref, guild_id=guild_id) is None
 
+    @pytest.mark.integration
+    async def test_the_sweep_reclaims_a_deleted_guilds_references(self, session):
+        """What a failed post-commit cleanup leaves behind.
+
+        The sector columns cannot be foreign keys, so nothing removes these on
+        the guild's way out except the deletion path. When that does not manage
+        it, this is what reclaims them.
+        """
+        from app.services.platform import guilds as guilds_service
+        from app.services.platform.identity_refs import purge_orphaned_sector_refs
+
+        user = await create_user(session)
+        gone = await create_guild(session, creator=user)
+        kept = await create_guild(session, creator=user)
+        gone_app = await _install(session, gone, user)
+        kept_app = await _install(session, kept, user)
+        await session.commit()
+
+        orphaned = await ensure_app_ref(
+            guild_id=gone.id, app_install_id=gone_app.id, user_id=user.id
+        )
+        live = await ensure_app_ref(
+            guild_id=kept.id, app_install_id=kept_app.id, user_id=user.id
+        )
+
+        # The guild goes and the cleanup does not run — the case this covers.
+        kept_id = kept.id
+        await guilds_service.delete_guild(session, gone)
+        await session.commit()
+
+        assert await purge_orphaned_sector_refs(session) == 1
+        await session.commit()
+        assert await resolve_app_ref(session, ref=orphaned, guild_id=kept_id) is None
+        assert await resolve_app_ref(session, ref=live, guild_id=kept_id) is not None
+
     @pytest.mark.unit
     def test_the_grace_window_is_the_shared_one(self):
         # App references retire on the same clock as every other sector's.

--- a/backend/app/services/marketplace/app_refs_test.py
+++ b/backend/app/services/marketplace/app_refs_test.py
@@ -257,10 +257,36 @@ class TestRemoval:
             guild_id=there.id, app_install_id=app_there.id, user_id=user.id
         )
 
-        assert await drop_guild_app_refs(session, guild_id=here.id) == 1
+        assert await drop_guild_app_refs(guild_id=here.id) == 1
         await session.commit()
         assert await resolve_app_ref(session, ref=gone, guild_id=here.id) is None
         assert await resolve_app_ref(session, ref=kept, guild_id=there.id) is not None
+
+    @pytest.mark.integration
+    async def test_deleting_a_guild_through_the_service_removes_them(self, session):
+        """Through ``delete_guild``, not the helper it calls.
+
+        Guild deletion reaches this from three call sites holding three
+        different sessions — one of them routed into the guild role being
+        deleted, which holds nothing on ``identity_refs``. The cleanup opens
+        its own session so it does not depend on which one it was handed.
+        """
+        from app.services.platform import guilds as guilds_service
+
+        user = await create_user(session)
+        guild = await create_guild(session, creator=user)
+        app = await _install(session, guild, user)
+        await session.commit()
+
+        ref = await ensure_app_ref(
+            guild_id=guild.id, app_install_id=app.id, user_id=user.id
+        )
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is not None
+
+        await guilds_service.delete_guild(session, guild)
+        await session.commit()
+
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is None
 
     @pytest.mark.unit
     def test_the_grace_window_is_the_shared_one(self):

--- a/backend/app/services/marketplace/app_refs_test.py
+++ b/backend/app/services/marketplace/app_refs_test.py
@@ -263,13 +263,13 @@ class TestRemoval:
         assert await resolve_app_ref(session, ref=kept, guild_id=there.id) is not None
 
     @pytest.mark.integration
-    async def test_deleting_a_guild_through_the_service_removes_them(self, session):
-        """Through ``delete_guild``, not the helper it calls.
+    async def test_the_deletion_sequence_its_callers_follow(self, session):
+        """Delete, commit, then drop — the order `delete_guild` documents.
 
-        Guild deletion reaches this from three call sites holding three
-        different sessions — one of them routed into the guild role being
-        deleted, which holds nothing on ``identity_refs``. The cleanup opens
-        its own session so it does not depend on which one it was handed.
+        The references are on a different connection and cannot join the
+        deletion's transaction, so they go after the commit that made it real.
+        A guild whose deletion then failed still holds the identities its apps
+        know its members by.
         """
         from app.services.platform import guilds as guilds_service
 
@@ -278,15 +278,19 @@ class TestRemoval:
         app = await _install(session, guild, user)
         await session.commit()
 
+        guild_id = guild.id
         ref = await ensure_app_ref(
-            guild_id=guild.id, app_install_id=app.id, user_id=user.id
+            guild_id=guild_id, app_install_id=app.id, user_id=user.id
         )
-        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is not None
-
         await guilds_service.delete_guild(session, guild)
-        await session.commit()
 
-        assert await resolve_app_ref(session, ref=ref, guild_id=guild.id) is None
+        # Still resolvable until the deletion is committed.
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild_id) is not None
+
+        await session.commit()
+        await drop_guild_app_refs(guild_id=guild_id)
+
+        assert await resolve_app_ref(session, ref=ref, guild_id=guild_id) is None
 
     @pytest.mark.unit
     def test_the_grace_window_is_the_shared_one(self):

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -7,6 +7,7 @@ import secrets
 
 from sqlalchemy import Integer, bindparam, func, or_, text
 from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -1043,8 +1044,14 @@ async def delete_guild(session: AsyncSession, guild: Guild) -> None:
     await _signal_members_present(session, guild_id=guild.id, action="membership")
     # What this guild's installed apps called its members. A platform-wide
     # table, so the guild row's cascade does not reach it and the schema drop
-    # does not either.
-    await app_refs.drop_guild_app_refs(session, guild_id=guild.id)
+    # does not either. On its own system-engine session, because this is
+    # reached with three different sessions and one of them is routed into the
+    # guild role being deleted; best-effort for the same reason the schema drop
+    # is, so the guild still goes.
+    try:
+        await app_refs.drop_guild_app_refs(guild_id=guild.id)
+    except SQLAlchemyError:
+        logger.warning("app refs: references for guild %s were not removed", guild.id)
     await session.exec(delete(Guild).where(Guild.id == guild.id))
 
 

--- a/backend/app/services/platform/guilds.py
+++ b/backend/app/services/platform/guilds.py
@@ -7,7 +7,6 @@ import secrets
 
 from sqlalchemy import Integer, bindparam, func, or_, text
 from sqlalchemy.dialects.postgresql import ARRAY
-from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -1032,6 +1031,14 @@ async def delete_guild(session: AsyncSession, guild: Guild) -> None:
     ON DELETE CASCADE FKs — ``session.delete`` would walk ORM relationships and
     attempt sync loads in the async context (MissingGreenlet).
 
+    **Callers must follow a successful commit with**
+    ``app_refs.drop_guild_app_refs(guild_id=...)`` — what this guild's installed
+    apps called its members lives in a platform-wide table that neither the
+    guild row's cascade nor the schema drop reaches. After the commit rather
+    than here: those references are on a different connection and cannot join
+    this transaction, so removing them first would leave a guild whose deletion
+    then failed holding none of the identities its apps know its members by.
+
     Everyone in the guild is poked first, because the cascade that clears the
     roster runs in the database: by the time this returns there is no membership
     row left for anything in Python to read, and every one of those people has
@@ -1039,19 +1046,7 @@ async def delete_guild(session: AsyncSession, guild: Guild) -> None:
     the three call sites, so deleting a guild announces itself however it is
     reached.
     """
-    from app.services.marketplace import app_refs
-
     await _signal_members_present(session, guild_id=guild.id, action="membership")
-    # What this guild's installed apps called its members. A platform-wide
-    # table, so the guild row's cascade does not reach it and the schema drop
-    # does not either. On its own system-engine session, because this is
-    # reached with three different sessions and one of them is routed into the
-    # guild role being deleted; best-effort for the same reason the schema drop
-    # is, so the guild still goes.
-    try:
-        await app_refs.drop_guild_app_refs(guild_id=guild.id)
-    except SQLAlchemyError:
-        logger.warning("app refs: references for guild %s were not removed", guild.id)
     await session.exec(delete(Guild).where(Guild.id == guild.id))
 
 

--- a/backend/app/services/platform/identity_refs.py
+++ b/backend/app/services/platform/identity_refs.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_, exists, func, or_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import delete, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.models.platform.guild import Guild
 from app.models.platform.identity_ref import (
     REF_ENTROPY_BYTES,
     REF_MAX_LENGTH,
@@ -38,6 +39,7 @@ __all__ = [
     "drop_sector_refs",
     "ensure_ref",
     "mint_ref",
+    "purge_orphaned_sector_refs",
     "purge_retired_refs",
     "reissue_all_refs",
     "reissue_ref",
@@ -313,6 +315,23 @@ async def drop_sector_refs(
     if sector_id is not None:
         clause = and_(clause, IdentityRef.sector_id == sector_id)
     result = await session.exec(delete(IdentityRef).where(clause))
+    return result.rowcount or 0
+
+
+async def purge_orphaned_sector_refs(session: AsyncSession) -> int:
+    """Drop references whose sector guild no longer exists. Returns the count.
+
+    The sector columns cannot be foreign keys, so a guild's references are
+    removed by the deletion path rather than by a cascade. This reclaims the
+    ones that path did not manage to remove — it runs after the deletion has
+    committed, where there is nothing left to roll back.
+    """
+    result = await session.exec(
+        delete(IdentityRef).where(
+            IdentityRef.sector_guild_id.is_not(None),
+            ~exists(select(Guild.id).where(Guild.id == IdentityRef.sector_guild_id)),
+        )
+    )
     return result.rowcount or 0
 
 

--- a/backend/app/services/tenant/app_handoff.py
+++ b/backend/app/services/tenant/app_handoff.py
@@ -209,6 +209,9 @@ async def mint_embed_handoff(
     subject = await app_refs.ensure_app_ref(
         guild_id=app.guild_id, app_install_id=app.id, user_id=user_id
     )
+    guild_ref = await app_refs.ensure_app_guild_ref(
+        guild_id=app.guild_id, app_install_id=app.id
+    )
 
     now = datetime.now(timezone.utc)
     audience = app_platform_audience(registration.public_id)
@@ -224,7 +227,9 @@ async def mint_embed_handoff(
         "iss": settings.APP_PLATFORM_ISSUER,
         "iat": int(now.timestamp()),
         "exp": now + APP_EMBED_HANDOFF_LIFETIME,
-        "guild_id": app.guild_id,
+        # The guild by reference, for the same reason as the member above: an
+        # index names a row to us, not an entity to somebody else.
+        "guild_ref": guild_ref,
         "app_install_id": app.id,
         "surface_id": surface_id,
     }

--- a/backend/app/services/tenant/app_handoff.py
+++ b/backend/app/services/tenant/app_handoff.py
@@ -216,9 +216,9 @@ async def mint_embed_handoff(
         # One-shot marker: the app blocklists a handoff once it has exchanged
         # it, so a captured token is not replayable inside its short window.
         "jti": str(uuid.uuid4()),
-        # The pairwise subject this install knows the member by, never the row
-        # id: two apps must not be able to compare notes and find they are
-        # talking to the same person (OIDC Core §8.1).
+        # The reference this install knows the member by (OIDC Core §8.1
+        # pairwise), never the row id: it is stable for this install and
+        # unrelated to what any other sector holds for the same person.
         "sub": subject,
         "aud": audience,
         "iss": settings.APP_PLATFORM_ISSUER,

--- a/backend/app/testing/delegation.py
+++ b/backend/app/testing/delegation.py
@@ -80,7 +80,7 @@ def foreign_jwks(kid: str = DELEGATE_KID) -> dict[str, Any]:
 def mint_delegation_token(
     *,
     subject: str,
-    guild_id: int,
+    guild_ref: str,
     initiative_id: Optional[int] = None,
     jti: Optional[str] = None,
     kid: Optional[str] = DELEGATE_KID,
@@ -91,9 +91,9 @@ def mint_delegation_token(
 ) -> str:
     """A delegation JWT as the delegate would mint it.
 
-    ``subject`` is the pairwise identifier the app was given for a member, not
-    a user id — an app never learns which Initiative user it acts for. Get one
-    from :func:`delegate_subject`.
+    ``subject`` is the reference the app was given for a member and ``guild_ref``
+    the one it was given for the guild — neither is a row id. Get them from
+    :func:`delegate_subject` and :func:`delegate_guild_ref`.
     """
     now = datetime.now(timezone.utc)
     payload: dict[str, Any] = {
@@ -103,7 +103,7 @@ def mint_delegation_token(
         "iss": iss,
         "iat": int(now.timestamp()),
         "exp": now + timedelta(seconds=expires_in),
-        "guild_id": guild_id,
+        "guild_ref": guild_ref,
     }
     if initiative_id is not None:
         payload["initiative_id"] = initiative_id
@@ -206,6 +206,19 @@ async def delegate_subject(session: AsyncSession, guild, user) -> str:
     return await ensure_app_ref(
         guild_id=guild.id, app_install_id=app.id, user_id=user.id
     )
+
+
+async def delegate_guild_ref(session: AsyncSession, guild) -> str:
+    """The reference the delegate knows one guild by.
+
+    Installs the app if the guild has not, for the same reason
+    :func:`delegate_subject` does: the sector is the install.
+    """
+    from app.services.marketplace.app_refs import ensure_app_guild_ref
+
+    app = await install_delegate(session, guild)
+    await session.commit()
+    return await ensure_app_guild_ref(guild_id=guild.id, app_install_id=app.id)
 
 
 async def authorize_delegate(


### PR DESCRIPTION
**Stacked on #1531 — merge that first.** Until it does, the diff here includes
its commits.

**⚠️ Breaking: `initiative_auto` needs its counterpart to land with this.** The
delegation token's `guild_id` claim is replaced, not supplemented.

## Why

An index tells *us* which row to join, and lets a person tell two rows apart. It
is not what another system should know an entity by. The member was fixed in
#1529; the guild was still our primary key on both halves of the app boundary.

## What changes

**Outbound** — the app-platform handoff carries `guild_ref` instead of
`guild_id`, minted at the same sector as the member's reference
(`entity=guild, purpose=app, sector=(guild_id, install_id)`). So an app installed
in two guilds holds two unrelated values for them: the property the member
reference already had, applied to the tenant.

**Inbound** — `AutoDelegationClaims.guild_ref` replaces `guild_id`, and the id
everything downstream works in is resolved from the reference rather than taken
from the token.

New in `app_refs`: `ensure_app_guild_ref` and `resolve_app_guild_ref`.

## What auto has to do

Read `guild_ref` from the handoff, store it, and send it back as `guild_ref` in
the delegation token instead of `guild_id`.

It does **not** need to rekey its schema. `Automation.guild_id`,
`WebhookSubscription.guild_id` and the ~510 other internal references stay as
they are — auto resolves our reference to its own key once at the boundary and
keeps its own numbering. That is the same rule this PR applies, seen from the
other side: our index should not be auto's primary key either.

## Not in scope

`initiative_id` still crosses raw. `identity_refs.entity_id` assumes a globally
unique value — true of users and guilds, both in `public`, and false of
initiatives, which are per-guild-schema. Giving them references needs an
entity-home column, distinct from `sector_guild_id` (that names the audience, not
where the entity lives). Separate decision; see §11 of the design doc.

`app_install_id` also still crosses, and is neither a user nor a guild.

## Testing

```
pytest -n 0 app/api/v1/tenant_endpoints/auto_delegation_test.py                    # 10 passed
pytest -n 0 app/api/v1/tenant_endpoints/auto_delegation_registration_test.py \
            app/api/v1/tenant_endpoints/guild_app_delegations_test.py              # 32 passed
pytest -n 0 app/api/v1/tenant_endpoints/guild_app_service_test.py                  #  9 passed
pytest -n 0 app/services/marketplace/app_refs_test.py                              # 15 passed
ruff check app && ruff format app && ty check                                      # clean
```

## Design

`history/opaque-identity-design.md` §11, step 1.