### PR TITLE
Say the sharing rule once

### DIFF
--- a/backend/app/api/resource_access.py
+++ b/backend/app/api/resource_access.py
@@ -34,10 +34,13 @@ from app.core.messages import (
 )
 from app.core.pam_context import has_active_grant
 from app.core.tools import Tool
+from app.db.initiative_rls import governing_path
 from app.models.platform.guild import GuildRole
+from app.models.tenant.initiative import PermissionKey
 from app.models.platform.user import User
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.services import permissions as permissions_service
+from app.services import rls as rls_service
 from app.services import reachability
 from app.services.tenant import ownership as ownership_service
 from app.services.tenant import calendars as calendars_service
@@ -59,6 +62,7 @@ class ResourceAccessConfig:
     feature_attr: Optional[str] = None  # initiative flag gating the feature
     feature_disabled_msg: Optional[str] = None
     grant_cannot_manage_msg: Optional[str] = None
+    create_denied_msg: Optional[str] = None  # 403 when the role may not create one
     loader: Optional[Callable[..., Awaitable[Any]]] = (
         None  # async (session, id) -> row|None
     )
@@ -83,6 +87,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.queue: ResourceAccessConfig(
         dac_kind=Tool.queue,
+        create_denied_msg=QueueMessages.CREATE_PERMISSION_REQUIRED,
         feature_attr=Tool.queue.view_permission,
         feature_disabled_msg=QueueMessages.FEATURE_DISABLED,
         loader=queues_service.get_queue,
@@ -91,6 +96,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.counter_group: ResourceAccessConfig(
         dac_kind=Tool.counter_group,
+        create_denied_msg=CounterMessages.CREATE_PERMISSION_REQUIRED,
         feature_attr=Tool.counter_group.view_permission,
         feature_disabled_msg=CounterMessages.FEATURE_DISABLED,
         grant_cannot_manage_msg=CounterMessages.GRANT_CANNOT_MANAGE,
@@ -100,6 +106,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.calendar: ResourceAccessConfig(
         dac_kind=Tool.calendar,
+        create_denied_msg=CalendarMessages.CREATE_PERMISSION_REQUIRED,
         feature_attr=Tool.calendar.view_permission,
         feature_disabled_msg=CalendarMessages.FEATURE_DISABLED,
         grant_cannot_manage_msg=CalendarMessages.GRANT_CANNOT_MANAGE_MEMBERS,
@@ -109,6 +116,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.dashboard: ResourceAccessConfig(
         dac_kind=Tool.dashboard,
+        create_denied_msg=DashboardMessages.CREATE_PERMISSION_REQUIRED,
         feature_attr=Tool.dashboard.view_permission,
         feature_disabled_msg=DashboardMessages.FEATURE_DISABLED,
         grant_cannot_manage_msg=DashboardMessages.GRANT_CANNOT_MANAGE_MEMBERS,
@@ -118,6 +126,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.post: ResourceAccessConfig(
         dac_kind=Tool.post,
+        create_denied_msg=PostMessages.CREATE_PERMISSION_REQUIRED,
         feature_attr=Tool.post.view_permission,
         feature_disabled_msg=PostMessages.FEATURE_DISABLED,
         grant_cannot_manage_msg=PostMessages.GRANT_CANNOT_MANAGE_MEMBERS,
@@ -127,6 +136,7 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
     ),
     Tool.gallery: ResourceAccessConfig(
         dac_kind=Tool.gallery,
+        create_denied_msg=GalleryMessages.CREATE_PERMISSION_REQUIRED,
         feature_attr=Tool.gallery.view_permission,
         feature_disabled_msg=GalleryMessages.FEATURE_DISABLED,
         grant_cannot_manage_msg=GalleryMessages.GRANT_CANNOT_MANAGE_MEMBERS,
@@ -140,6 +150,57 @@ RESOURCE_ACCESS: dict[Tool, ResourceAccessConfig] = {
 # (``set_resource_grants`` / the bulk endpoint) — exactly the tools registered
 # above, derived so the two never drift.
 GRANTABLE_KINDS: tuple[Tool, ...] = tuple(RESOURCE_ACCESS)
+
+
+def governing_tool(table: str) -> Tool:
+    """The tool whose sharing governs one content table's rows.
+
+    Read from ``initiative_rls.governing_path`` — the same registry the table's
+    RLS policy is rendered from — so an endpoint that reaches a sub-resource's
+    parent cannot name a different tool from the one the database asked about.
+    A task's is ``project``, and it is one edit away from staying that way if
+    the hierarchy ever changes.
+    """
+    path = governing_path(table)
+    if path is None:
+        # Config bug, not a request error: the caller named a table whose
+        # governing tool is a property of the row (a comment, a reaction) or
+        # that no tool's sharing governs at all.
+        raise RuntimeError(f"no single tool governs {table!r}")
+    return path[0]
+
+
+async def require_create(
+    session: Any,
+    kind: Tool,
+    initiative: Any,
+    user: User,
+    guild_context: GuildContext,
+) -> None:
+    """Raise 403 unless this caller may create a ``kind`` in ``initiative``.
+
+    Gate 3 at the moment of creation: the initiative role's create right for
+    the tool, with a guild admin above it. The permission key comes from the
+    tool (``Tool.create_permission``) and the message from the registry, so a
+    ninth tool is gated by registering it rather than by copying this.
+
+    The database asks the same question on INSERT — the rendered policy's
+    ``initiative_role_permits(..., create_<plural>, false)`` leg. This one runs
+    first so the answer is a named 403.
+    """
+    if rls_service.is_guild_admin(guild_context.role):
+        return
+    if await rls_service.check_initiative_permission(
+        session,
+        initiative_id=initiative.id,
+        user=user,
+        permission_key=PermissionKey(kind.create_permission),
+    ):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=RESOURCE_ACCESS[kind].create_denied_msg,
+    )
 
 
 def authorize(

--- a/backend/app/api/v1/tenant_endpoints/calendar_events.py
+++ b/backend/app/api/v1/tenant_endpoints/calendar_events.py
@@ -97,9 +97,11 @@ async def _get_event_or_404(
             detail=CalendarEventMessages.NOT_FOUND,
         )
     # Feature gate + DAC, both resolved on the parent calendar: read to see the
-    # event, write for any mutation.
+    # event, write for any mutation. The parent's tool comes from the registry
+    # the event table's own policy is rendered from, so the two agree on what
+    # governs an event by construction.
     resource_access.authorize(
-        Tool.calendar,
+        resource_access.governing_tool("calendar_events"),
         event.calendar,
         user,
         access=access,

--- a/backend/app/api/v1/tenant_endpoints/calendars.py
+++ b/backend/app/api/v1/tenant_endpoints/calendars.py
@@ -34,7 +34,7 @@ from app.services.cross_guild import gather_across_guilds, member_guild_ids
 from app.core.tools import Tool
 from app.models.tenant.calendar import Calendar
 from app.models.tenant.guild_app import GuildApp
-from app.models.tenant.initiative import Initiative, PermissionKey
+from app.models.tenant.initiative import Initiative
 from app.models.platform.user import User
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.schemas.tenant.calendar import (
@@ -49,7 +49,6 @@ from app.schemas.tenant.initiative import InitiativeGroupedCountsResponse
 from app.schemas.tenant.recent_view import RecentViewWrite
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.services import permissions as permissions_service
-from app.services import rls as rls_service
 from app.services.tenant import calendars as calendars_service
 from app.services.tenant import my_tools as my_tools_service
 from app.services.tenant import guild_apps as guild_apps_service
@@ -93,27 +92,6 @@ async def _get_initiative_for_calendar(
             detail=InitiativeMessages.NOT_FOUND,
         )
     return initiative
-
-
-async def _check_create_permission(
-    session: RLSSessionDep,
-    initiative: Initiative,
-    user: User,
-    guild_context: GuildContext,
-) -> None:
-    if rls_service.is_guild_admin(guild_context.role):
-        return
-    has_perm = await rls_service.check_initiative_permission(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        permission_key=PermissionKey.create_calendars,
-    )
-    if not has_perm:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=CalendarMessages.CREATE_PERMISSION_REQUIRED,
-        )
 
 
 async def _refetch_calendar(session: RLSSessionDep, calendar_id: int) -> Calendar:
@@ -331,7 +309,9 @@ async def create_calendar(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=CalendarMessages.FEATURE_DISABLED,
             )
-        await _check_create_permission(session, initiative, current_user, guild_context)
+        await resource_access.require_create(
+            session, Tool.calendar, initiative, current_user, guild_context
+        )
 
     initiative_id = initiative.id if initiative is not None else None
 

--- a/backend/app/api/v1/tenant_endpoints/counters.py
+++ b/backend/app/api/v1/tenant_endpoints/counters.py
@@ -40,7 +40,6 @@ from app.models.tenant.counter import (
 )
 from app.models.tenant.initiative import (
     Initiative,
-    PermissionKey,
 )
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.platform.user import User
@@ -69,7 +68,6 @@ from app.api import resource_access
 from app.core.tools import Tool
 from app.services.tenant import search as search_service
 from app.services.tenant import tool_listing
-from app.services import rls as rls_service
 from app.services.stream_authz import authority as stream_authority
 from app.services.platform.ws_auth import authenticate_ws_token
 from app.schemas.tenant.recent_view import RecentViewWrite
@@ -141,28 +139,6 @@ async def _get_initiative_for_counter_group(
             detail=InitiativeMessages.NOT_FOUND,
         )
     return initiative
-
-
-async def _check_initiative_permission(
-    session: RLSSessionDep,
-    initiative: Initiative,
-    user: User,
-    guild_context: GuildContext,
-    permission_key: PermissionKey,
-) -> None:
-    if rls_service.is_guild_admin(guild_context.role):
-        return
-    has_perm = await rls_service.check_initiative_permission(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        permission_key=permission_key,
-    )
-    if not has_perm:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=CounterMessages.CREATE_PERMISSION_REQUIRED,
-        )
 
 
 async def _get_counter_group_with_access(
@@ -397,12 +373,8 @@ async def create_counter_group(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=CounterMessages.FEATURE_DISABLED,
         )
-    await _check_initiative_permission(
-        session,
-        initiative,
-        current_user,
-        guild_context,
-        PermissionKey.create_counter_groups,
+    await resource_access.require_create(
+        session, Tool.counter_group, initiative, current_user, guild_context
     )
 
     group = CounterGroup(

--- a/backend/app/api/v1/tenant_endpoints/dashboards.py
+++ b/backend/app/api/v1/tenant_endpoints/dashboards.py
@@ -43,7 +43,7 @@ from app.models.platform.marketplace import (
 )
 from app.models.platform.user import User
 from app.models.tenant.dashboard import Dashboard
-from app.models.tenant.initiative import Initiative, PermissionKey
+from app.models.tenant.initiative import Initiative
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.schemas.tenant.dashboard import (
     PublishedOver,
@@ -67,7 +67,6 @@ from app.db.session import rls_context_params
 from app.schemas.sql_query import QueryColumnDescription, QueryResponse
 from app.services import query as query_service
 from app.services import permissions as permissions_service
-from app.services import rls as rls_service
 from app.services.marketplace import catalog as catalog_service
 from app.services.marketplace.installs import (
     ListingInstallError,
@@ -204,27 +203,6 @@ async def _get_initiative_for_dashboard(
             detail=InitiativeMessages.NOT_FOUND,
         )
     return initiative
-
-
-async def _check_create_permission(
-    session: RLSSessionDep,
-    initiative: Initiative,
-    user: User,
-    guild_context: GuildContext,
-) -> None:
-    if rls_service.is_guild_admin(guild_context.role):
-        return
-    has_perm = await rls_service.check_initiative_permission(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        permission_key=PermissionKey.create_dashboards,
-    )
-    if not has_perm:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=DashboardMessages.CREATE_PERMISSION_REQUIRED,
-        )
 
 
 async def _refetch_dashboard(session: RLSSessionDep, dashboard_id: int) -> Dashboard:
@@ -461,7 +439,9 @@ async def create_dashboard(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=DashboardMessages.FEATURE_DISABLED,
         )
-    await _check_create_permission(session, initiative, current_user, guild_context)
+    await resource_access.require_create(
+        session, Tool.dashboard, initiative, current_user, guild_context
+    )
 
     listing_id: Optional[int] = None
     listing_version: Optional[str] = None

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -355,8 +355,8 @@ def _build_visible_docs_filters(
 ):
     """Build common WHERE conditions for visible-document queries.
 
-    Guild scope + RLS apply either way; ``dac_scope_clause`` adds the sharing
-    gate, resolving to a no-op for a request that reaches the whole guild.
+    Guild scope and the document table's own policies apply either way;
+    ``listing_scope_clause`` adds only what a list spanning initiatives needs.
     """
     conditions = [
         Initiative.guild_id == guild_id,

--- a/backend/app/api/v1/tenant_endpoints/documents_scope_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_scope_test.py
@@ -4,7 +4,7 @@ The schema-per-guild cutover removed the DB-level RESTRICTIVE
 ``is_initiative_member`` policies; these tests pin the app-level replacement:
 removal from an initiative must end document access — the permission rows are
 cleaned up, and a stale row alone would not grant access anyway
-(``initiative_scope_ok`` gate, covered in ``services/permissions_test``).
+(the initiative gate, now the table's own policy).
 """
 
 import pytest

--- a/backend/app/api/v1/tenant_endpoints/galleries.py
+++ b/backend/app/api/v1/tenant_endpoints/galleries.py
@@ -58,7 +58,7 @@ from app.core.messages import (
 from app.core.tools import Tool
 from app.models.platform.user import User
 from app.models.tenant.gallery import Gallery, GalleryImage, GalleryImageVersion
-from app.models.tenant.initiative import Initiative, PermissionKey
+from app.models.tenant.initiative import Initiative
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
 from app.models.tenant.upload import Upload
 from app.schemas.tenant.gallery import (
@@ -83,7 +83,6 @@ from app.schemas.tenant.recent_view import RecentViewWrite
 from app.schemas.tenant.resource_grant import ResourceGrantSchema
 from app.schemas.tenant.timeline import TimelineResponse
 from app.services import permissions as permissions_service
-from app.services import rls as rls_service
 from app.services import storage_config
 from app.services.tenant import attachments as attachments_service
 from app.services.tenant import comments as comments_service
@@ -164,27 +163,6 @@ async def _get_initiative_for_gallery(
             detail=InitiativeMessages.NOT_FOUND,
         )
     return initiative
-
-
-async def _check_create_permission(
-    session: RLSSessionDep,
-    initiative: Initiative,
-    user: User,
-    guild_context: GuildContext,
-) -> None:
-    if rls_service.is_guild_admin(guild_context.role):
-        return
-    has_perm = await rls_service.check_initiative_permission(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        permission_key=PermissionKey.create_galleries,
-    )
-    if not has_perm:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=GalleryMessages.CREATE_PERMISSION_REQUIRED,
-        )
 
 
 async def _refetch_gallery(
@@ -568,7 +546,9 @@ async def create_gallery(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=GalleryMessages.FEATURE_DISABLED,
         )
-    await _check_create_permission(session, initiative, current_user, guild_context)
+    await resource_access.require_create(
+        session, Tool.gallery, initiative, current_user, guild_context
+    )
 
     gallery = Gallery(
         guild_id=guild_context.guild_id,

--- a/backend/app/api/v1/tenant_endpoints/posts.py
+++ b/backend/app/api/v1/tenant_endpoints/posts.py
@@ -48,7 +48,7 @@ from app.api.deps import (
 from app.core.messages import CommonMessages, InitiativeMessages, PostMessages
 from app.core.tools import Tool
 from app.models.platform.user import User
-from app.models.tenant.initiative import Initiative, PermissionKey
+from app.models.tenant.initiative import Initiative
 from app.models.tenant.post import Post, board_time
 from app.models.tenant.post_poll import PostPoll
 from app.models.tenant.resource_grant import ResourceAccessLevel, ResourceGrant
@@ -128,27 +128,6 @@ async def _get_initiative_for_post(
             detail=InitiativeMessages.NOT_FOUND,
         )
     return initiative
-
-
-async def _check_create_permission(
-    session: RLSSessionDep,
-    initiative: Initiative,
-    user: User,
-    guild_context: GuildContext,
-) -> None:
-    if rls_service.is_guild_admin(guild_context.role):
-        return
-    has_perm = await rls_service.check_initiative_permission(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        permission_key=PermissionKey.create_posts,
-    )
-    if not has_perm:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=PostMessages.CREATE_PERMISSION_REQUIRED,
-        )
 
 
 def _validated_body(body: dict | None) -> dict:
@@ -584,7 +563,9 @@ async def create_post(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=PostMessages.FEATURE_DISABLED,
         )
-    await _check_create_permission(session, initiative, current_user, guild_context)
+    await resource_access.require_create(
+        session, Tool.post, initiative, current_user, guild_context
+    )
 
     now = datetime.now(timezone.utc)
     # A schedule in the past is somebody asking for it now, which is what an

--- a/backend/app/api/v1/tenant_endpoints/projects.py
+++ b/backend/app/api/v1/tenant_endpoints/projects.py
@@ -508,9 +508,10 @@ def _visible_project_conditions(
 
     ``archived``/``template``/``search``/``initiative_id`` are pushed into SQL
     (mirroring the old ``_matches_filters``: ``None`` means "exclude" for the
-    boolean flags, and "every initiative" for the initiative). ``dac_scope_clause``
-    supplies the sharing gate — it resolves to a no-op for a request that reaches
-    the whole guild, so there is nothing to branch on here.
+    boolean flags, and "every initiative" for the initiative). The projects
+    table carries its own sharing gate, so ``listing_scope_clause`` adds only
+    what a list spanning initiatives needs and there is nothing to branch on
+    here.
     """
     conditions = [
         Initiative.guild_id == guild_id,

--- a/backend/app/api/v1/tenant_endpoints/queues.py
+++ b/backend/app/api/v1/tenant_endpoints/queues.py
@@ -42,7 +42,6 @@ from app.models.tenant.queue import (
 from app.models.tenant.resource_grant import ResourceGrant, ResourceAccessLevel
 from app.models.tenant.initiative import (
     Initiative,
-    PermissionKey,
 )
 from app.models.platform.user import User
 from app.core.messages import QueueMessages, InitiativeMessages
@@ -71,7 +70,6 @@ from app.services.tenant import tags as tags_service
 from app.services.tenant import search as search_service
 from app.services.tenant import tool_listing
 from app.schemas.tenant.tag import TagSetRequest
-from app.services import rls as rls_service
 from app.schemas.tenant.recent_view import RecentViewWrite
 from app.services.stream_authz import authority as stream_authority
 from app.services.platform.ws_auth import authenticate_ws_token
@@ -144,30 +142,6 @@ async def _get_initiative_for_queue(
             detail=InitiativeMessages.NOT_FOUND,
         )
     return initiative
-
-
-async def _check_initiative_permission(
-    session: RLSSessionDep,
-    initiative: Initiative,
-    user: User,
-    guild_context: GuildContext,
-    permission_key: PermissionKey,
-) -> None:
-    """Check initiative role permission, raise 403 if denied."""
-    # Guild admins bypass initiative permissions
-    if rls_service.is_guild_admin(guild_context.role):
-        return
-    has_perm = await rls_service.check_initiative_permission(
-        session,
-        initiative_id=initiative.id,
-        user=user,
-        permission_key=permission_key,
-    )
-    if not has_perm:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=QueueMessages.CREATE_PERMISSION_REQUIRED,
-        )
 
 
 async def _get_queue_with_access(
@@ -428,12 +402,8 @@ async def create_queue(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=QueueMessages.FEATURE_DISABLED,
         )
-    await _check_initiative_permission(
-        session,
-        initiative,
-        current_user,
-        guild_context,
-        PermissionKey.create_queues,
+    await resource_access.require_create(
+        session, Tool.queue, initiative, current_user, guild_context
     )
 
     queue = Queue(

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -73,6 +73,7 @@ from app.schemas.tenant.tag import TagSetRequest
 from app.schemas.tenant.property import PropertyValuesSetRequest
 from app.services import notifications as notifications_service
 from app.services.platform import accounts as accounts_service
+from app.api import resource_access
 from app.services import permissions as permissions_service
 from app.services.tenant.recurrence import get_next_due_date
 from app.services.tenant import filter_presets as filter_presets_service
@@ -669,11 +670,14 @@ async def _get_project_with_access(
     guild_id: int,
     access: str = "read",
 ) -> Project:
-    """Get project with DAC permission check.
+    """Load the project a task hangs off, and authorize against it.
 
-    Tasks inherit access from their project's permission levels:
-    - read: any permission level (owner, write, read) — user or role-based
-    - write: owner or write permission level — user or role-based
+    A task has no sharing of its own: it is reached through the project, at
+    the project's level. Which tool that is comes from
+    ``resource_access.governing_tool("tasks")`` rather than a literal here —
+    the same registry entry the ``tasks`` policy is rendered from, where the
+    row's sharing leg is an EXISTS onto ``projects``. One declaration, so the
+    endpoint and the policy cannot disagree about a task's parent.
     """
     project_stmt = (
         select(Project)
@@ -700,8 +704,10 @@ async def _get_project_with_access(
             status_code=status.HTTP_400_BAD_REQUEST, detail=ProjectMessages.IS_ARCHIVED
         )
 
-    # project.grants is eager-loaded above; require_project_access reads it.
-    permissions_service.require_project_access(project, user, access=access)
+    # project.grants is eager-loaded above; the DAC engine reads it.
+    resource_access.authorize(
+        resource_access.governing_tool("tasks"), project, user, access=access
+    )
 
     return project
 

--- a/backend/app/db/guild_rls_test.py
+++ b/backend/app/db/guild_rls_test.py
@@ -325,25 +325,56 @@ def test_no_single_parent_names_only_real_tables():
     assert stale == [], stale
 
 
-def test_every_declared_hop_is_a_real_column():
-    """``via`` names the FK chain an endpoint walks to reach the parent.
+def test_every_declared_hop_walks_a_real_column_to_a_real_table():
+    """``via`` is walked to load a parent, so every step of it has to exist.
 
-    It is used to load a row, so a stale column name would be an attribute
-    error at request time rather than at import. Checked against the mapped
-    models, which is where the policy's join gets its columns too.
+    Each hop names a column on the table reached so far and the table that
+    column points at, and the walk has to arrive at the governing tool's own
+    table. Checking only the first hop would let a renamed intermediate — the
+    ``tasks`` in ``task_tags -> tasks -> projects`` — reach CI green and fail
+    at the moment something followed it.
+
+    A table absent from the mapped metadata fails rather than skips: it means
+    the registry names something the models do not, which is the drift this
+    is here to catch.
     """
+    import app.db.base  # noqa: F401 — imported for its side effect
     from sqlmodel import SQLModel
 
     from app.db.initiative_rls import INITIATIVE_PATHS, governing_path
 
-    tables = SQLModel.metadata.tables
-    missing = []
-    for table, path in sorted(INITIATIVE_PATHS.items()):
+    # app.db.base registers every model, so the metadata is complete whether
+    # this runs alone or in a suite. Without it an unimported model looks like
+    # registry drift.
+    mapped = SQLModel.metadata.tables
+    problems: list[str] = []
+
+    for table, _path in sorted(INITIATIVE_PATHS.items()):
         derived = governing_path(table)
-        if derived is None or not derived[1]:
+        if derived is None:
             continue
-        first_hop = derived[1][0]
-        mapped = tables.get(table)
-        if mapped is not None and first_hop not in mapped.columns:
-            missing.append(f"{table}.{first_hop}")
-    assert missing == [], missing
+        tool, hops = derived
+
+        current = table
+        if current not in mapped:
+            problems.append(f"{current}: registered but not a mapped table")
+            continue
+
+        for column, target in hops:
+            if column not in mapped[current].columns:
+                problems.append(f"{current}.{column}: no such column")
+                break
+            if target not in mapped:
+                problems.append(f"{current}.{column} -> {target}: no such mapped table")
+                break
+            current = target
+        else:
+            # The walk has to end AT the governing resource, not merely near
+            # it — that is what makes the tool and the chain one declaration.
+            if current != tool.plural:
+                problems.append(
+                    f"{table}: chain ends at {current}, governed by {tool.value} "
+                    f"(expected {tool.plural})"
+                )
+
+    assert problems == [], problems

--- a/backend/app/db/guild_rls_test.py
+++ b/backend/app/db/guild_rls_test.py
@@ -7,6 +7,10 @@ honest:
   ``INITIATIVE_SCOPED_TABLES`` table actually has ``FORCE`` RLS + all four
   ``initiative_member_*`` policies, and no ``GUILD_LEVEL_TABLES`` table does.
   So an initiative-level table cannot reach a live schema without its policies.
+- **Agreement** (pure): the governing tool the app layer reads out of the
+  registry is the one the rendered policy actually asks about. The endpoints
+  resolving a sub-resource's parent and the policy gating that sub-resource's
+  rows come from one declaration, and this is what keeps them there.
 """
 
 import pytest
@@ -251,3 +255,95 @@ async def test_soft_delete_tables_have_admin_only_purge_policy(engine):
     finally:
         async with engine.begin() as conn:
             await drop_guild_schema(conn, _GID_PURGE)
+
+
+# ---------------------------------------------------------------------------
+# Agreement: one declaration, read two ways
+# ---------------------------------------------------------------------------
+
+
+#: Tables the app layer deliberately derives NO single governing tool for, and
+#: why. Stated rather than tolerated: a new sub-resource that the app cannot
+#: resolve a parent for has to be added here on purpose, which is the moment to
+#: notice it needs one.
+_NO_SINGLE_PARENT = {
+    # Polymorphic — the governing tool is a property of the row, and the policy
+    # is a CASE over the column naming it.
+    "comments": "one of eight tools, per row",
+    "reactions": "one of eight tools, per row",
+    "reaction_digest_items": "gated exactly like the reaction it describes",
+    "recent_views": "one of eight tools, per row",
+    "search_entries": "names its tool in dac_tool",
+    # One tool, two parents: a link must clear the gate on BOTH documents, so
+    # there is no single row to authorize against.
+    "document_links": "source and target must both clear it",
+    # No sharing leg at all — see the registry for each.
+    "event_outbox": "the change log is no tool's own table",
+    "property_definitions": "initiative configuration, not a tool's content",
+    "resource_grants": "sharing itself; resource_access reads this table",
+    "webhook_subscriptions": "integration config, gated by the initiative",
+}
+
+
+def test_the_app_reads_the_same_governing_tool_the_policy_asks_about():
+    """``governing_path`` must name the tool the rendered sharing leg calls.
+
+    The app layer asks this registry which tool governs a sub-resource — a
+    task's project, an event's calendar — and the DDL renderer asks the same
+    entry to build the policy. A table where those two answered differently
+    would be one where an endpoint authorized against one resource while the
+    database gated on another.
+    """
+    import re
+
+    from app.db.initiative_rls import INITIATIVE_PATHS, governing_path
+
+    mismatches = []
+    for table, path in sorted(INITIATIVE_PATHS.items()):
+        derived = governing_path(table)
+        leg = path.dac.predicate(table, "SELECT", False) if path.dac else None
+        asked = set(re.findall(r"resource_access\('([a-z_]+)'", leg or ""))
+        if derived is None:
+            if table not in _NO_SINGLE_PARENT:
+                mismatches.append(
+                    f"{table}: policy asks {sorted(asked) or 'nothing'}, app derives "
+                    "nothing and the table is not in _NO_SINGLE_PARENT"
+                )
+            continue
+        if asked != {derived[0].value}:
+            mismatches.append(
+                f"{table}: policy asks {sorted(asked)}, app derives {derived[0].value}"
+            )
+    assert mismatches == [], mismatches
+
+
+def test_no_single_parent_names_only_real_tables():
+    """The exemption list cannot outlive the tables it names."""
+    from app.db.initiative_rls import INITIATIVE_PATHS
+
+    stale = sorted(set(_NO_SINGLE_PARENT) - set(INITIATIVE_PATHS))
+    assert stale == [], stale
+
+
+def test_every_declared_hop_is_a_real_column():
+    """``via`` names the FK chain an endpoint walks to reach the parent.
+
+    It is used to load a row, so a stale column name would be an attribute
+    error at request time rather than at import. Checked against the mapped
+    models, which is where the policy's join gets its columns too.
+    """
+    from sqlmodel import SQLModel
+
+    from app.db.initiative_rls import INITIATIVE_PATHS, governing_path
+
+    tables = SQLModel.metadata.tables
+    missing = []
+    for table, path in sorted(INITIATIVE_PATHS.items()):
+        derived = governing_path(table)
+        if derived is None or not derived[1]:
+            continue
+        first_hop = derived[1][0]
+        mapped = tables.get(table)
+        if mapped is not None and first_hop not in mapped.columns:
+            missing.append(f"{table}.{first_hop}")
+    assert missing == [], missing

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -120,16 +120,27 @@ class DacPath:
     ``tool`` and ``via`` are the SAME declaration as data rather than SQL, so
     the app layer can answer "which tool governs a task, and how does a task
     reach it" from the registry the policies are rendered from instead of
-    restating it per endpoint. ``via`` is the foreign-key chain from this
-    table to the governing resource, outermost first — ``("project_id",)`` on
-    ``tasks``, ``("task_id", "project_id")`` on ``task_tags``, empty where the
-    row IS the resource. Both are None/empty for a polymorphic table, whose
-    governing tool is a property of the row rather than the table.
+    restating it per endpoint.
+
+    ``via`` is the join chain from this table to the governing resource,
+    outermost first, as ``(column, table_it_points_at)`` pairs — the column
+    belongs to the PREVIOUS table in the walk, starting with this one:
+
+    - ``tasks``      → ``(("project_id", "projects"),)``
+    - ``task_tags``  → ``(("task_id", "tasks"), ("project_id", "projects"))``
+    - ``projects``   → ``()`` — the row IS the resource
+
+    Naming the table at every hop and not just the column is what lets the
+    walk be checked end to end: a renamed intermediate is caught where it is
+    declared rather than where something later follows it.
+
+    Both are None/empty for a polymorphic table, whose governing tool is a
+    property of the row rather than of the table.
     """
 
     predicate: DacBuilder
     tool: Tool | None = None
-    via: tuple[str, ...] = ()
+    via: tuple[tuple[str, str], ...] = ()
 
 
 def _resource_call(tool: str, resource_id: str, initiative: str, write: bool) -> str:
@@ -234,7 +245,7 @@ def _dac_via(
 
     return DacPath(
         tool=tool,
-        via=(fk,),
+        via=((fk, parent),),
         predicate=lambda t, c, w: (
             f"EXISTS (SELECT 1 FROM {parent} {alias} "
             f"WHERE {alias}.{parent_pk} = {t}.{fk} AND "
@@ -257,7 +268,7 @@ def _dac_two_hop(mid: str, mid_fk: str, parent: str, fk: str) -> DacPath:
     tool = _TOOL_BY_TABLE[parent]
     return DacPath(
         tool=tool,
-        via=(fk, mid_fk),
+        via=((fk, mid), (mid_fk, parent)),
         predicate=lambda t, c, w: (
             f"EXISTS (SELECT 1 FROM {mid} dmid JOIN {parent} dpar "
             f"ON dpar.id = dmid.{mid_fk} WHERE dmid.id = {t}.{fk} AND "
@@ -1062,8 +1073,8 @@ assert all(
 ), "DAC_WRITE_COMMANDS names a command that does not write"
 
 
-def governing_path(table: str) -> tuple[Tool, tuple[str, ...]] | None:
-    """The tool that governs ``table``'s rows and the FK chain that reaches it.
+def governing_path(table: str) -> tuple[Tool, tuple[tuple[str, str], ...]] | None:
+    """The tool that governs ``table``'s rows and the join chain that reaches it.
 
     The app-layer half of the sharing leg the policies are rendered from — one
     declaration, read two ways, so an endpoint resolving "which project does

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -110,15 +110,26 @@ _TOOL_BY_TABLE: dict[str, Tool] = {tool.plural: tool for tool in Tool}
 
 @dataclass(frozen=True)
 class DacPath:
-    """How a row names the tool that governs it — gates 3 and 4, as SQL.
+    """How a row names the tool that governs it — gates 3 and 4.
 
     ``predicate`` renders the tool gate that the table's policies AND onto the
     membership one, or None where no tool governs the table. Both gates come
     from the same declaration and the same join, so a child table asks its
     parent about its role and its sharing once rather than twice.
+
+    ``tool`` and ``via`` are the SAME declaration as data rather than SQL, so
+    the app layer can answer "which tool governs a task, and how does a task
+    reach it" from the registry the policies are rendered from instead of
+    restating it per endpoint. ``via`` is the foreign-key chain from this
+    table to the governing resource, outermost first — ``("project_id",)`` on
+    ``tasks``, ``("task_id", "project_id")`` on ``task_tags``, empty where the
+    row IS the resource. Both are None/empty for a polymorphic table, whose
+    governing tool is a property of the row rather than the table.
     """
 
     predicate: DacBuilder
+    tool: Tool | None = None
+    via: tuple[str, ...] = ()
 
 
 def _resource_call(tool: str, resource_id: str, initiative: str, write: bool) -> str:
@@ -207,7 +218,10 @@ def _dac_self(tool: Tool | None = None) -> DacPath:
             creating=command == "INSERT" and tool is None,
         )
 
-    return DacPath(predicate=build)
+    # ``tool`` here is only the explicitly-named one: without it the governing
+    # tool is read off the table name at render time, and the caller asking
+    # this registry knows its own table.
+    return DacPath(predicate=build, tool=tool)
 
 
 def _dac_via(
@@ -219,6 +233,8 @@ def _dac_via(
         return DacPath(predicate=lambda t, c, w: None)
 
     return DacPath(
+        tool=tool,
+        via=(fk,),
         predicate=lambda t, c, w: (
             f"EXISTS (SELECT 1 FROM {parent} {alias} "
             f"WHERE {alias}.{parent_pk} = {t}.{fk} AND "
@@ -231,7 +247,7 @@ def _dac_via(
                 creating=False,
             )
             + ")"
-        )
+        ),
     )
 
 
@@ -240,12 +256,14 @@ def _dac_two_hop(mid: str, mid_fk: str, parent: str, fk: str) -> DacPath:
     task's tag link by its task's project, an attendee by its event's calendar."""
     tool = _TOOL_BY_TABLE[parent]
     return DacPath(
+        tool=tool,
+        via=(fk, mid_fk),
         predicate=lambda t, c, w: (
             f"EXISTS (SELECT 1 FROM {mid} dmid JOIN {parent} dpar "
             f"ON dpar.id = dmid.{mid_fk} WHERE dmid.id = {t}.{fk} AND "
             + _tool_gate(tool, "dpar.id", "dpar.initiative_id", c, w, creating=False)
             + ")"
-        )
+        ),
     )
 
 
@@ -1042,6 +1060,33 @@ assert DAC_WRITE_COMMANDS.keys() <= INITIATIVE_SCOPED_TABLES, (
 assert all(
     commands <= ALL_WRITE_COMMANDS for commands in DAC_WRITE_COMMANDS.values()
 ), "DAC_WRITE_COMMANDS names a command that does not write"
+
+
+def governing_path(table: str) -> tuple[Tool, tuple[str, ...]] | None:
+    """The tool that governs ``table``'s rows and the FK chain that reaches it.
+
+    The app-layer half of the sharing leg the policies are rendered from — one
+    declaration, read two ways, so an endpoint resolving "which project does
+    this task belong to, and is it shared with me" cannot answer differently
+    from the policy that already decided it.
+
+    ``()`` as the chain means the row IS the resource (``projects`` → project).
+    ``None`` means no single tool governs the table: a polymorphic one, where
+    the answer is a property of the row, or a configuration table that no
+    tool's sharing governs.
+    """
+    path = INITIATIVE_PATHS.get(table)
+    if path is None or path.dac is None:
+        return None
+    tool = path.dac.tool
+    if tool is None:
+        # _dac_self reads it off the table name at render time rather than
+        # storing it; a table that is no tool's own has no answer here.
+        tool = _TOOL_BY_TABLE.get(table)
+        if tool is None:
+            return None
+        return tool, ()
+    return tool, path.dac.via
 
 
 def dac_asks_at_write(table: str, command: str) -> bool:

--- a/backend/app/services/fields/spec.py
+++ b/backend/app/services/fields/spec.py
@@ -312,7 +312,7 @@ class Dataset:
 
     ``tool`` names the tool whose **sharing governs** these rows, which is not
     always the tool they are — a task is governed by its project, the same
-    answer ``dac_scope_clause`` reaches for. Naming it lets everything the enum
+    answer the sharing gate reaches for. Naming it lets everything the enum
     already derives be derived rather than restated: the default dataset name,
     and in turn the master switch and resource type the gates read off it. Only
     the field list is genuinely per-dataset.

--- a/backend/app/services/membership.py
+++ b/backend/app/services/membership.py
@@ -2,11 +2,15 @@
 
 Initiative scoping has **one** definition: the ``public.initiative_access`` SQL
 function (initiative member OR guild admin OR PAM grant, read from the request
-GUCs). The guild-schema RLS policies call it as the fail-closed DB backstop, and
-``initiative_scope_clause`` here calls the *same* function so app-built queries
-use the identical rule — no parallel re-implementation. This module also provides
-the guild/initiative-membership batch lookups (resolve membership for many users
-or initiatives in one round trip instead of a per-user loop).
+GUCs). The guild-schema RLS policies call it, and ``initiative_scope_clause``
+here calls the *same* function — for the tables the policies deliberately do
+not cover, which is the structural initiative set (``initiatives`` itself and
+its roster): those are guild-scoped by the schema boundary, so this clause is
+their only scope gate rather than a second opinion on one.
+
+This module also provides the guild/initiative-membership batch lookups
+(resolve membership for many users or initiatives in one round trip instead of
+a per-user loop).
 
 Routing contract:
   - ``guild_memberships`` is a shared/public table — the guild helpers work on
@@ -17,15 +21,12 @@ Routing contract:
     query.
 """
 
-from typing import Any, Collection, Iterable, Optional
+from typing import Collection, Iterable, Optional
 
 from sqlalchemy import ColumnElement, exists, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core.pam_context import has_active_grant
-from app.core.role_context import is_request_guild_admin
 from app.models.platform.guild import GuildMembership, GuildRole
-from app.models.platform.user import User
 from app.models.tenant.initiative import InitiativeMember
 
 
@@ -92,35 +93,6 @@ def initiative_scope_clause(
 #: Distinguishes "this row has no initiative_id column" from "its initiative_id
 #: is NULL". Only the second means guild scope.
 NO_SCOPE_COLUMN = object()
-
-
-def initiative_scope_ok(
-    entity: Any,
-    user: User,
-    *,
-    guild_role: GuildRole | str | None = None,
-) -> bool:
-    """Sync counterpart of :func:`initiative_scope_clause` for single entities
-    whose ``initiative.memberships`` are already eagerly loaded — gate 2, not
-    the per-resource sharing gate, which is ``permissions.dac_scope_clause``.
-
-    Resolves the same legs as ``public.initiative_access``, in the same order, so
-    the app-layer answer and the policy's agree.
-    """
-    # A row that names no initiative is guild-level, and this check has nothing
-    # to decide about it — the branch `public.initiative_access` takes too.
-    if getattr(entity, "initiative_id", NO_SCOPE_COLUMN) is None:
-        return True
-    initiative = getattr(entity, "initiative", None)
-    memberships = (
-        getattr(initiative, "memberships", None) if initiative is not None else None
-    ) or []
-    if any(m.user_id == user.id for m in memberships):
-        return True
-    guild_id = getattr(entity, "guild_id", None)
-    if guild_id is not None and has_active_grant(guild_id):
-        return True
-    return is_request_guild_admin(guild_id, guild_role=guild_role)
 
 
 def member_initiative_ids_select(user_id: int):

--- a/backend/app/services/permissions.py
+++ b/backend/app/services/permissions.py
@@ -4,16 +4,22 @@ The application-level permission layer for every tool. Unlike the mandatory RLS
 layer (see ``rls.py``), which PostgreSQL enforces, this resolves what a request
 may read, write or own from the ``resource_grants`` rows on a resource.
 
-The result is asked for in two shapes, and the second is defined in terms of the
-first:
+What is left here is what Postgres does not answer. The guild-schema policies
+apply this same sharing rule to every content table — gate 4, rendered from
+``app/db/initiative_rls.py`` and calling ``public.resource_access`` — so a
+statement confined to one initiative needs no sharing clause of its own. The
+app layer keeps the decisions the policies do not express:
 
-  - :func:`request_bypasses_dac` for a loaded row, behind
-    :func:`require_access` / :func:`compute_permission`
-  - :func:`dac_scope_clause` for a query, appended to a listing's WHERE
+  - :func:`require_access` — a *named* refusal on a loaded row, plus the
+    frozen-guild cap
+  - :func:`compute_permission` — what the client renders affordances from
+  - :func:`granted_scope_clause` — deliberately NARROWER than the policy for a
+    list spanning initiatives (no guild-admin leg)
+  - :func:`writable_scope_clause` — "which of these may I change", which a read
+    policy does not answer
 
 Guild isolation and initiative membership are separate layers, in ``rls.py`` and
-Postgres, with the sync initiative-scope check beside its SQL counterpart in
-``membership.py``.
+Postgres.
 """
 
 from dataclasses import dataclass
@@ -30,7 +36,7 @@ from app.core.role_context import (
     is_request_guild_admin,
     request_overrides_sharing,
 )
-from app.services.membership import NO_SCOPE_COLUMN, initiative_scope_ok
+from app.services.membership import NO_SCOPE_COLUMN
 from app.core.tools import Tool
 
 from app.models.platform.guild import GuildMembership, GuildRole
@@ -104,8 +110,9 @@ def _granted_resource_ids(
     ``levels`` narrows to grants issued at those levels; omitted, any grant
     counts, which is what a read listing wants.
 
-    Grant rows only. :func:`dac_scope_clause` is the public entry point and
-    composes this with the rest of the decision.
+    Grant rows only. :func:`granted_scope_clause` and
+    :func:`writable_scope_clause` are the public entry points and compose this
+    with the rest of the decision.
     """
     my_roles = select(InitiativeMember.role_id).where(
         InitiativeMember.user_id == user_id
@@ -186,55 +193,18 @@ def granted_scope_clause(
     initiatives shows is what reaches the reader, the same way their sidebar and
     the community front page list the initiatives they joined.
 
-    That is also why ``initiative_id`` is absent from this signature where
-    :func:`dac_scope_clause` has one: the initiative "Full access" override
-    answers for one initiative at a time, and a list spanning them has no single
-    initiative to ask about.
+    ``initiative_id`` is absent from this signature on purpose: the initiative
+    "Full access" override answers for one initiative at a time, and a list
+    spanning them has no single initiative to ask about.
 
     A PAM or break-glass grantee keeps their window. They hold no membership row
     and no grant, so the grant legs would answer nothing at all — the grant is
     what they navigate by, exactly as it is in the initiative listing.
 
-    Use :func:`dac_scope_clause` for a statement already confined to one
-    initiative, where the reader's standing in that initiative is the question.
+    A statement already confined to one initiative asks nothing here — see
+    :func:`listing_scope_clause`.
     """
     if grant_satisfies(guild_id, access=access):
-        return true()
-    return id_col.in_(_granted_resource_ids(tool, user_id))
-
-
-def dac_scope_clause(
-    tool: Tool,
-    id_col: ColumnElement[int],
-    user_id: int,
-    *,
-    guild_id: int | None,
-    initiative_id: int | None = None,
-    access: str = "read",
-) -> ColumnElement[bool]:
-    """The WHERE leg narrowing ``id_col`` to the ``tool`` rows this request may see.
-
-    The query-shaped form of :func:`request_bypasses_dac`: that one answers for a
-    loaded row, this one answers once for a whole statement, and both resolve
-    through the same call. It returns ``true()`` when the request already covers
-    the guild, so a caller appends it unconditionally rather than branching.
-
-    ``id_col`` is whichever column names the resource — its own id, or a foreign
-    key to it (``Task.project_id``). ``access`` is what the caller intends to do:
-    a listing wants the default ``read``, and a grant covers only the level it
-    was issued at.
-
-    ``initiative_id`` folds in the initiative "Full access" override, which
-    answers for one initiative at a time. Pass it only from a statement already
-    confined to that one initiative, which is the case in which the override and
-    the statement agree on scope. Omitting it matches the per-row check
-    (:func:`compute_permission`) for every other leg.
-
-    A listing that spans initiatives wants :func:`granted_scope_clause` instead:
-    guild-admin standing answers "may I reach it", which is the right question
-    for one initiative and the wrong one for a list across them.
-    """
-    if request_bypasses_dac(guild_id, initiative_id=initiative_id, access=access):
         return true()
     return id_col.in_(_granted_resource_ids(tool, user_id))
 
@@ -250,25 +220,25 @@ def listing_scope_clause(
 ) -> ColumnElement[bool]:
     """The WHERE leg for a tool listing, picking the rule its scope calls for.
 
-    Confined to one initiative, the question is the reader's standing there, and
-    a guild admin's reaches all of it — :func:`dac_scope_clause`.
+    **Confined to one initiative, there is nothing to add.** The question is the
+    reader's standing there, and the table's own policy already asked it: every
+    content table carries a sharing leg deferring to ``public.resource_access``
+    (guild admin OR PAM at the level OR the "Full access" override OR a grant
+    row), ANDed with initiative membership and the reader's initiative role.
+    Restating it here would narrow nothing and consult ``resource_grants`` a
+    second time per row.
 
-    Spanning initiatives — the community front page's table, the sidebar's tool
-    lists, the cross-guild ``/me/*`` views — the question is what has been
-    granted to the reader, so :func:`granted_scope_clause` answers it. This is
-    the listing-shaped form of the same rule the initiative listing follows: an
-    admin navigates what reaches them, and reaches everything else the moment
-    they ask for one initiative by name.
-
-    The initiative "Full access" override stays out of the confined branch, as
-    it already was at every call site here; folding it into listings is a
-    separate decision from choosing between these two rules.
+    **Spanning initiatives** — the community front page's table, the sidebar's
+    tool lists, the cross-guild ``/me/*`` views — the question is what has been
+    granted to the reader, which is NARROWER than the policy: it drops the
+    guild-admin leg. An admin navigates what reaches them, and reaches
+    everything else the moment they ask for one initiative by name. That is a
+    product rule, not an enforcement one, so :func:`granted_scope_clause`
+    carries it.
     """
-    if initiative_id is None:
-        return granted_scope_clause(
-            tool, id_col, user_id, guild_id=guild_id, access=access
-        )
-    return dac_scope_clause(tool, id_col, user_id, guild_id=guild_id, access=access)
+    if initiative_id is not None:
+        return true()
+    return granted_scope_clause(tool, id_col, user_id, guild_id=guild_id, access=access)
 
 
 def writable_scope_clause(
@@ -279,16 +249,16 @@ def writable_scope_clause(
     guild_id: int | None,
     initiative_id: int | None = None,
 ) -> ColumnElement[bool]:
-    """:func:`listing_scope_clause` narrowed to what the reader may CHANGE.
+    """The listing rule narrowed to what the reader may CHANGE.
 
-    The scope clauses above answer at ``read``, and their grant leg deliberately
-    ignores the level — every grant reaches a listing. A caller asking "which of
-    these may this person edit" needs the level to count, so this one filters
-    the grant rows to :data:`WRITE_LEVELS`.
+    This one does NOT collapse the way :func:`listing_scope_clause` does. A read
+    policy admits a row shared at any level, so "may I see it" is already
+    answered and "may I edit it" is strictly narrower — the grant rows have to
+    be filtered to :data:`WRITE_LEVELS` here, whatever the statement's scope.
 
-    The two branches are the same choice :func:`listing_scope_clause` makes:
-    confined to one initiative, a guild admin's authority answers; spanning
-    them, only what has been granted does.
+    The two branches are the scope choice made elsewhere: confined to one
+    initiative, a guild admin's authority answers; spanning them, only what has
+    been granted does.
     """
     if initiative_id is not None:
         if request_bypasses_dac(guild_id, initiative_id=initiative_id, access="write"):
@@ -306,7 +276,6 @@ def writable_scope_clause(
 @dataclass(frozen=True)
 class DacResource:
     name: Tool
-    scope_gate: bool  # gate on initiative_scope_ok? (project/document yes)
     denied_msg: str
     owner_msg: str
     write_msg: str
@@ -315,56 +284,48 @@ class DacResource:
 DAC_RESOURCES: dict[Tool, DacResource] = {
     Tool.project: DacResource(
         Tool.project,
-        True,
         ProjectMessages.NO_ACCESS,
         ProjectMessages.OWNER_REQUIRED,
         ProjectMessages.WRITE_ACCESS_REQUIRED,
     ),
     Tool.document: DacResource(
         Tool.document,
-        True,
         DocumentMessages.NO_ACCESS,
         DocumentMessages.OWNER_REQUIRED,
         DocumentMessages.WRITE_ACCESS_REQUIRED,
     ),
     Tool.queue: DacResource(
         Tool.queue,
-        False,
         QueueMessages.PERMISSION_REQUIRED,
         QueueMessages.OWNER_REQUIRED,
         QueueMessages.WRITE_ACCESS_REQUIRED,
     ),
     Tool.counter_group: DacResource(
         Tool.counter_group,
-        False,
         CounterMessages.PERMISSION_REQUIRED,
         CounterMessages.OWNER_REQUIRED,
         CounterMessages.WRITE_ACCESS_REQUIRED,
     ),
     Tool.calendar: DacResource(
         Tool.calendar,
-        True,
         CalendarMessages.PERMISSION_REQUIRED,
         CalendarMessages.OWNER_REQUIRED,
         CalendarMessages.WRITE_ACCESS_REQUIRED,
     ),
     Tool.dashboard: DacResource(
         Tool.dashboard,
-        True,
         DashboardMessages.PERMISSION_REQUIRED,
         DashboardMessages.OWNER_REQUIRED,
         DashboardMessages.WRITE_ACCESS_REQUIRED,
     ),
     Tool.post: DacResource(
         Tool.post,
-        True,
         PostMessages.PERMISSION_REQUIRED,
         PostMessages.OWNER_REQUIRED,
         PostMessages.WRITE_ACCESS_REQUIRED,
     ),
     Tool.gallery: DacResource(
         Tool.gallery,
-        True,
         GalleryMessages.PERMISSION_REQUIRED,
         GalleryMessages.OWNER_REQUIRED,
         GalleryMessages.WRITE_ACCESS_REQUIRED,
@@ -715,8 +676,13 @@ def require_access(
     guild_role: GuildRole | str | None = None,
 ) -> None:
     """Raise 403 unless ``user`` may act on ``row``: frozen-guild read cap →
-    bypass (admin/PAM/Full access) → (scope_gate) initiative scope → effective
-    DAC level vs requested access."""
+    bypass (admin/PAM/Full access) → effective DAC level vs requested access.
+
+    No initiative-scope step. The row was loaded through a routed session, and
+    every content table's policy defers to ``public.initiative_access`` before
+    anything here runs — a row belonging to an initiative the caller is not in
+    does not arrive to be checked. What is left is the part the policies do not
+    do: saying which refusal it is."""
     guild_id = getattr(row, "guild_id", None)
     initiative_id = getattr(row, "initiative_id", None)
     # A frozen guild (read_only lifecycle status) caps EVERY real member at
@@ -737,12 +703,6 @@ def require_access(
         guild_role=guild_role,
     ):
         return
-    if resource.scope_gate and not initiative_scope_ok(
-        row, user, guild_role=guild_role
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail=resource.denied_msg
-        )
     effective = effective_level(resource, row, user.id)
 
     if require_owner:

--- a/backend/app/services/permissions_test.py
+++ b/backend/app/services/permissions_test.py
@@ -11,7 +11,7 @@ import pathlib
 
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import ColumnElement
+from sqlalchemy import ColumnElement, text
 from sqlmodel import delete, select
 
 from app.api import resource_access
@@ -25,24 +25,23 @@ from app.core.tools import Tool
 from app.models.platform.guild import GuildRole
 from app.models.platform.user import UserRole
 from app.models.tenant.document import Document
+from app.db.session import set_rls_context
 from app.models.tenant.initiative import InitiativeMember
 from app.models.tenant.project import Project
-from app.models.tenant.queue import Queue
 from app.models.tenant.resource_grant import ResourceGrant
 from app.services.permissions import (
     DAC_RESOURCES,
     audience_user_ids,
     compute_permission,
-    dac_scope_clause,
     effective_level,
+    granted_scope_clause,
     has_project_write_access,
+    listing_scope_clause,
     require_access,
+    writable_scope_clause,
 )
 from app.testing.factories import TOOL_FACTORIES
 
-# The tools whose rows are gated on initiative membership as well as on grants
-# (``scope_gate``); the rest are guild-level and skip that leg.
-SCOPE_GATED = [t for t, r in DAC_RESOURCES.items() if r.scope_gate]
 ALL_TOOLS = list(DAC_RESOURCES)
 
 # The canonical per-tool factory registry rather than a copy of it: that one
@@ -300,21 +299,43 @@ async def test_membership_alone_grants_nothing(session, acting_user, clean_conte
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("tool", SCOPE_GATED, ids=lambda t: t.value)
-async def test_a_grant_left_behind_after_removal_is_denied(
+@pytest.mark.parametrize("tool", ALL_TOOLS, ids=lambda t: t.value)
+async def test_a_grant_left_behind_after_removal_reaches_nothing(
     session, acting_user, clean_context, tool: Tool
 ):
-    """A grant row outliving the user's initiative membership must not carry
-    access — the scope gate is checked before the grant is read."""
+    """A grant row outliving the user's initiative membership carries no access.
+
+    Leaving an initiative does not sweep the grants written for you, so the row
+    is still there naming you at owner. What answers it is the table's own
+    policy: every content table ANDs ``public.initiative_access`` onto its
+    sharing leg, so the resource stops being visible the moment the membership
+    goes — asserted here as the guild role, against the database, because that
+    is where the answer comes from.
+    """
     w = await build_world(session, acting_user, tool)
-    set_active_role(w.guild.id, GuildRole.member.value)
-    loaded = await w.grant("owner", user=w.co_member.user)
-    require_access(w.resource, loaded, w.co_member.user, access="read")
+    await w.grant("owner", user=w.co_member.user)
+    model = type(w.row)
+
+    async def visible() -> bool:
+        await set_rls_context(
+            session,
+            user_id=w.co_member.user.id,
+            guild_id=w.guild.id,
+            guild_role=GuildRole.member.value,
+        )
+        try:
+            rows = (
+                await session.exec(select(model.id).where(model.id == w.row.id))
+            ).all()
+            return bool(rows)
+        finally:
+            await session.exec(text("RESET ROLE"))
+
+    assert await visible(), "the grant should reach it while the membership stands"
 
     await _remove_from_initiative(session, w.initiative, w.co_member.user)
-    loaded = await w.load()
-    assert refused(w.resource, loaded, w.co_member.user, access="read").detail == (
-        w.resource.denied_msg
+    assert not await visible(), (
+        "a grant that outlived the membership must reach nothing"
     )
 
 
@@ -447,49 +468,86 @@ async def test_a_frozen_guild_caps_everyone_at_read(
     refused(w.resource, loaded, w.admin.user, access="write")
 
 
-# ── dac_scope_clause: the query-shaped half of the DAC decision ──────────────
+# ── The clauses that survive the policies ───────────────────────────────────
+#
+# A statement confined to one initiative asks nothing: the table's own policy
+# already applied the sharing gate. What is left here is the listing rule for a
+# statement that SPANS initiatives, which is narrower than the policy on
+# purpose, and the writable rule, which is narrower than any read policy.
 
 
 def _compiled(clause: ColumnElement[bool]) -> str:
     return str(clause.compile(compile_kwargs={"literal_binds": True}))
 
 
-def test_dac_scope_clause_is_a_no_op_for_a_guild_wide_request():
-    """A guild admin, or a live PAM grant, reaches the whole guild — so the
-    clause adds nothing and the caller needs no branch around it."""
+def test_a_confined_listing_adds_nothing():
+    """Named an initiative, the clause is a no-op whoever is asking.
+
+    The rows come from a table whose policy has already asked gate 4, so a
+    second copy of the question could only cost a query.
+    """
     set_active_grant(None, None)
     set_override_sharing_initiatives(None)
     try:
-        set_active_role(7, GuildRole.admin.value)
-        assert _compiled(dac_scope_clause(Tool.project, Project.id, 1, guild_id=7)) == (
-            "true"
-        )
-
-        set_active_role(None, None)
-        set_active_grant(7, "read")
-        assert (
-            _compiled(dac_scope_clause(Tool.document, Document.id, 1, guild_id=7))
-            == "true"
-        )
+        for role in (None, GuildRole.member.value, GuildRole.admin.value):
+            set_active_role(7 if role else None, role)
+            assert (
+                _compiled(
+                    listing_scope_clause(
+                        Tool.project, Project.id, 1, guild_id=7, initiative_id=3
+                    )
+                )
+                == "true"
+            )
     finally:
         set_active_role(None, None)
-        set_active_grant(None, None)
 
 
-def test_dac_scope_clause_respects_the_grant_level():
-    """A grant opens the guild only at the level it was issued at, so a read
-    grant is a no-op for a read but not for a write."""
+def test_a_listing_across_initiatives_still_narrows_a_guild_admin():
+    """Spanning initiatives, the question is what reaches the reader.
+
+    A guild admin's authority is not a leg here — their sidebar lists what was
+    shared with them, and they reach the rest by naming an initiative.
+    """
+    set_active_grant(None, None)
+    set_override_sharing_initiatives(None)
+    set_active_role(7, GuildRole.admin.value)
+    try:
+        sql = _compiled(listing_scope_clause(Tool.project, Project.id, 1, guild_id=7))
+        assert sql != "true"
+        assert "resource_grants" in sql
+    finally:
+        set_active_role(None, None)
+
+
+def test_a_pam_window_is_a_no_op_across_initiatives():
+    """A grantee holds no membership and no grant row, so the grant legs would
+    answer nothing at all — the window is what they navigate by."""
     set_active_role(None, None)
     set_override_sharing_initiatives(None)
     set_active_grant(7, "read")
     try:
         assert (
-            _compiled(dac_scope_clause(Tool.project, Project.id, 1, guild_id=7))
+            _compiled(granted_scope_clause(Tool.document, Document.id, 1, guild_id=7))
+            == "true"
+        )
+    finally:
+        set_active_grant(None, None)
+
+
+def test_the_window_opens_only_at_the_level_it_was_issued_at():
+    """A read grant is a no-op for a read and not for a write."""
+    set_active_role(None, None)
+    set_override_sharing_initiatives(None)
+    set_active_grant(7, "read")
+    try:
+        assert (
+            _compiled(granted_scope_clause(Tool.project, Project.id, 1, guild_id=7))
             == "true"
         )
         assert (
             _compiled(
-                dac_scope_clause(
+                granted_scope_clause(
                     Tool.project, Project.id, 1, guild_id=7, access="write"
                 )
             )
@@ -498,7 +556,7 @@ def test_dac_scope_clause_respects_the_grant_level():
         set_active_grant(7, "read_write")
         assert (
             _compiled(
-                dac_scope_clause(
+                granted_scope_clause(
                     Tool.project, Project.id, 1, guild_id=7, access="write"
                 )
             )
@@ -508,37 +566,42 @@ def test_dac_scope_clause_respects_the_grant_level():
         set_active_grant(None, None)
 
 
-def test_dac_scope_clause_narrows_an_ordinary_member():
-    """A member is scoped to the resources granted to them, and the clause names
-    the tool it was asked about."""
-    set_active_grant(None, None)
+def test_a_window_on_another_guild_opens_nothing_here():
+    """PAM is keyed by guild, and no guild at all narrows rather than opens."""
+    set_active_role(None, None)
     set_override_sharing_initiatives(None)
-    set_active_role(7, GuildRole.member.value)
+    set_active_grant(8, "read_write")
     try:
-        sql = _compiled(dac_scope_clause(Tool.queue, Queue.id, 1, guild_id=7))
-        assert "resource_grants" in sql
-        assert "queue" in sql
-        assert sql != "true"
+        assert (
+            _compiled(granted_scope_clause(Tool.project, Project.id, 1, guild_id=7))
+            != "true"
+        )
+        assert (
+            _compiled(granted_scope_clause(Tool.project, Project.id, 1, guild_id=None))
+            != "true"
+        )
     finally:
-        set_active_role(None, None)
+        set_active_grant(None, None)
 
 
-def test_dac_scope_clause_narrows_when_the_role_is_for_another_guild():
-    """Role context is keyed by guild, so being an admin of guild 8 grants
-    nothing in guild 7."""
+def test_the_writable_clause_does_not_collapse_when_confined():
+    """Unlike the read listing, this one still has something to ask.
+
+    A read policy admits a row shared at any level, so "which of these may I
+    change" is a narrower question than the one already answered — the grant
+    rows have to be filtered by level whatever the scope.
+    """
+    set_active_role(7, GuildRole.member.value)
     set_active_grant(None, None)
     set_override_sharing_initiatives(None)
-    set_active_role(8, GuildRole.admin.value)
     try:
-        assert (
-            _compiled(dac_scope_clause(Tool.project, Project.id, 1, guild_id=7))
-            != "true"
+        sql = _compiled(
+            writable_scope_clause(
+                Tool.project, Project.id, 1, guild_id=7, initiative_id=3
+            )
         )
-        # ...and no guild at all narrows too, rather than opening up.
-        assert (
-            _compiled(dac_scope_clause(Tool.project, Project.id, 1, guild_id=None))
-            != "true"
-        )
+        assert sql != "true"
+        assert "resource_grants" in sql
     finally:
         set_active_role(None, None)
 
@@ -550,17 +613,14 @@ def test_every_tool_can_be_scoped(tool):
     set_active_role(None, None)
     set_active_grant(None, None)
     set_override_sharing_initiatives(None)
-    sql = _compiled(dac_scope_clause(tool, Project.id, 1, guild_id=7))
+    sql = _compiled(granted_scope_clause(tool, Project.id, 1, guild_id=7))
     assert "resource_grants" in sql
     assert tool.value in sql
 
 
-def test_the_grants_subquery_has_one_caller():
-    """``dac_scope_clause`` is the single entry point for narrowing a listing.
-
-    ``_granted_resource_ids`` is one part of what it composes, and is private so
-    that composition happens in one place.
-    """
+def test_the_grants_subquery_has_one_home():
+    """``_granted_resource_ids`` is private so the composition happens in one
+    place — the clause builders in ``permissions.py`` and nowhere else."""
     root = pathlib.Path(__file__).resolve().parents[1]
     offenders = [
         str(path.relative_to(root))
@@ -569,8 +629,8 @@ def test_the_grants_subquery_has_one_caller():
         and "_granted_resource_ids" in path.read_text()
     ]
     assert offenders == [], (
-        "these modules reach for the grants subquery directly instead of "
-        f"permissions.dac_scope_clause: {offenders}"
+        "these modules reach for the grants subquery directly instead of the "
+        f"clause builders in permissions.py: {offenders}"
     )
 
 

--- a/backend/app/services/tenant/comments.py
+++ b/backend/app/services/tenant/comments.py
@@ -317,26 +317,26 @@ async def _load_parent(
 
 async def _shares_resource(
     session: AsyncSession,
-    tool: Tool,
     id_col: ColumnElement[int],
     *,
     resource_id: int,
-    user_id: int,
-    guild_id: int,
-    access: str,
 ) -> bool:
-    """Whether the sharing gate lets this request reach one resource by id.
+    """Whether this request can reach one resource by id.
 
-    The id is already known, so this asks the gate directly rather than loading
-    the row and its grants to run the engine over them.
+    Selecting the id IS the question. The resource's own table carries the
+    sharing gate, so a row the request may not reach does not come back, and
+    the id is already known — loading the row with its grants to run the engine
+    over them would ask what the lookup has just answered.
+
+    Asked at read whatever the caller is doing, which is what the comment
+    tables themselves ask: ``DAC_WRITE_COMMANDS`` puts ``comments`` in the
+    responding set, so every command on a thread is gated by whether the
+    parent is reachable, not by whether it is editable. You may answer a notice
+    you cannot rewrite.
     """
-    stmt = select(id_col).where(
-        id_col == resource_id,
-        permissions_service.dac_scope_clause(
-            tool, id_col, user_id, guild_id=guild_id, access=access
-        ),
-    )
-    return (await session.exec(stmt)).first() is not None
+    return (
+        await session.exec(select(id_col).where(id_col == resource_id))
+    ).first() is not None
 
 
 async def _ensure_parent_access(
@@ -358,7 +358,7 @@ async def _ensure_parent_access(
     belongs to the task, so a project with comments off still has task threads.
     """
     if ctx.task is not None:
-        anchor_tool, anchor_model, anchor_row = Tool.project, Project, ctx.project
+        anchor_model, anchor_row = Project, ctx.project
     else:
         target = TOOL_COMMENT_TARGETS[cast(Tool, ctx.tool)]
         initiative = getattr(ctx.resource, "initiative", None)
@@ -370,7 +370,7 @@ async def _ensure_parent_access(
             raise CommentPermissionError(target.feature_disabled)
         if not getattr(ctx.resource, "comments_enabled", True):
             raise CommentPermissionError(CommentMessages.COMMENTS_DISABLED)
-        anchor_tool, anchor_model, anchor_row = target.tool, target.model, ctx.resource
+        anchor_model, anchor_row = target.model, ctx.resource
         # A parent that has not gone up yet has no thread to join: a scheduled
         # post is a draft, and reading or writing its comments would say it
         # exists. Asked before the sharing decision below, because the answer
@@ -385,12 +385,8 @@ async def _ensure_parent_access(
         return
     if await _shares_resource(
         session,
-        anchor_tool,
         anchor_model.id,  # type: ignore[attr-defined]
         resource_id=cast(int, anchor_row.id),
-        user_id=cast(int, user.id),
-        guild_id=guild_id,
-        access=access,
     ):
         return
     raise CommentPermissionError(CommentMessages.PERMISSION_DENIED)

--- a/backend/app/services/tenant/outbox_poller.py
+++ b/backend/app/services/tenant/outbox_poller.py
@@ -2,12 +2,18 @@
 
 The authorization decision is a query, not a check. For every subscription the
 poller routes a session **as that subscription's owner** and reads the outbox
-through it — so ``event_outbox``'s own initiative-member RLS returns exactly the
-events that owner may currently see, and nothing here re-implements the six
-gates. A guild-wide subscription therefore means "everything in this guild I can
-reach", and it stays true as membership changes: leaving an initiative, losing a
-PAM grant, or being deactivated all stop the matching deliveries on the next
-pass with no subscription edit and no cache to invalidate.
+through it, so ``event_outbox``'s own RLS decides the batch and nothing here
+re-implements it. A guild-wide subscription therefore means "everything in this
+guild I belong to", and it stays true as membership changes: leaving an
+initiative, losing a PAM grant, or being deactivated all stop the matching
+deliveries on the next pass with no subscription edit and no cache to
+invalidate.
+
+What the log is scoped by is the initiative, not per-resource sharing: the
+change log is no tool's own table, so it carries the membership gate and not
+the sharing one. An envelope is identifiers and changed column names, and a
+consumer reads current state back through the REST path, where sharing decides
+the read.
 
 ``initiative_id`` on the subscription is a narrowing filter on top of that, never
 a widening one.
@@ -267,10 +273,11 @@ async def _drain_subscription(
     """Deliver one subscription's pending transactions, as its owner.
 
     The session is routed to the subscription's guild with the OWNER's user id,
-    so every outbox read is gated by that owner's access. ``satisfied_providers``
-    is the system sentinel: a background pass has no login to satisfy a guild's
-    auth policy with, and that leg is about how a person authenticated, not about
-    what this owner may reach. Every other gate applies unchanged.
+    so the outbox read is gated by that owner's membership (see the module
+    docstring for what that covers). ``satisfied_providers`` is the system
+    sentinel: a background pass has no login to satisfy a guild's auth policy
+    with, and that leg is about how a person authenticated, not about what this
+    owner may reach.
     """
     await set_rls_context(
         session,

--- a/backend/app/services/tenant/search_test.py
+++ b/backend/app/services/tenant/search_test.py
@@ -76,7 +76,7 @@ async def test_the_owner_does_get_the_hit(session, acting_user):
 
 async def test_a_guild_admin_is_not_narrowed_by_sharing(session, acting_user):
     """A guild admin reaches every aspect of their guild, so the clause is the
-    one ``dac_scope_clause`` already collapses to true."""
+    one the sharing gate already collapses to true."""
     a = await acting_user(guild_role=GuildRole.admin, initiative=True, project=True)
     b = await acting_user(
         guild_role=GuildRole.admin,

--- a/backend/app/services/tenant/task_statuses.py
+++ b/backend/app/services/tenant/task_statuses.py
@@ -159,7 +159,7 @@ async def list_initiative_statuses(
 ) -> list[InitiativeTaskStatusRead]:
     """The distinct status columns across an initiative's readable projects.
 
-    Visibility is the project listing's own rule — ``dac_scope_clause`` narrows
+    Visibility is the project listing's own rule — the sharing gate narrows
     the scan to the projects this request may read — so both the columns and
     the counts describe the caller's view of the initiative. The scan is
     confined to one initiative, so it also passes ``initiative_id`` and picks up


### PR DESCRIPTION
## Problem

Gates 1–4 are decided in Postgres now. Every content table's policy ANDs the membership gate, the initiative-role gate and a call to `public.resource_access` onto one predicate, rendered from `INITIATIVE_PATHS`:

```sql
CREATE POLICY initiative_member_select ON tasks AS PERMISSIVE FOR SELECT
  USING (EXISTS (… initiative_access(projects.initiative_id, uid, false))
     AND EXISTS (SELECT 1 FROM projects dac WHERE dac.id = tasks.project_id
                 AND initiative_role_permits(dac.initiative_id, uid, 'projects_enabled', true)
                 AND resource_access('project', dac.id, uid, dac.initiative_id, false)));
```

The app layer was still stating gate 4 a second time, in about a dozen places. A second statement of a rule can only agree with the first or drift from it, and the drift is silent because the duplicate is an AND of something that already held.

## Notable changes

**A confined listing adds nothing.** `listing_scope_clause(initiative_id=…)` returns `true()` and `dac_scope_clause` is gone. The policy on the table being listed had already applied the same legs, level for level — `resource_access` expands to `guild-admin OR PAM-at-level OR full-access-override OR a grant row at the level`, which is `request_bypasses_dac() OR granted()` leg for leg — so the clause narrowed nothing and read `resource_grants` a second time per row. Nine listings: projects, documents, queues, counters, calendars, dashboards, posts, galleries, calendar events.

**`comments._shares_resource`** asked the same question by selecting an id it already had, under a clause the table's own policy applies. The select is the answer.

**`DacResource.scope_gate` / `membership.initiative_scope_ok`** were gate 2 restated on a row a routed session could not have loaded without passing it. Already inconsistent — set for six tools, unset for two, with no behavioural difference.

**`DacPath` carries the governing tool and FK chain as data**, not only as rendered SQL, so the app can read a sub-resource's parent out of the registry the policy comes from. `governing_path("tasks")` → `(Tool.project, ("project_id",))`. Tasks and calendar events took their tool from a literal; they take it from there now.

**Six byte-identical create gates became one** (`resource_access.require_create`), keyed on the tool — the permission key from `Tool.create_permission`, the message from the registry. Documents, projects and the import engine keep their own shapes; folding those would change behaviour, not just structure.

## What stays, and why

Deliberately not removed — these answer things no policy expresses:

- `require_access` — the **named 403**. Without it a refused write is "no rows matched", which surfaces as an ORM row-count error.
- the frozen-guild read cap, the feature gates, the manage-via-grant block
- `compute_permission` / `my_permission_level` — the database decides, it does not report
- the draft rule (`READ_VISIBLE`, `posts.visibility_clause`)
- `granted_scope_clause` — **deliberately narrower** than the policy: it drops the guild-admin leg, so a list spanning initiatives shows what reaches the reader. Product rule, not enforcement.
- `writable_scope_clause` — "which of these may I change" is narrower than any read policy, so it does not collapse.

## Schema / env

None. No migration, no new table, no config.

## Testing

```
pytest app/services/permissions_test.py app/db/guild_rls_test.py \
       app/api/v1/tenant_endpoints/{tasks,calendar_events,comments}_test.py     # 212 passed
pytest app/api/v1/tenant_endpoints/{queues,counters,calendars,dashboards,galleries,posts,projects,documents_scope}_test.py \
       app/services/tenant/outbox_poller_test.py                                # 263 passed
ruff check app && ruff format app && ty check app                               # clean
```

Two new drift tests in `guild_rls_test.py`: the tool the app derives must be the one the rendered policy asks about, and every declared hop must be a real column. The first caught `document_links` on its first run (one tool, two parents — both endpoints must clear the gate), which is now an explicit exemption with a reason rather than a silent pass.

The stale-grant guarantee moved with the check that used to make it. `test_a_grant_left_behind_after_removal_is_denied` asserted it through the app helper on a superuser session; it now routes as the guild role and asserts the row is invisible, across all eight tools instead of six.

No changelog entry — internal refactor, no user-visible change.

## Note on one thing deliberately left

`event_outbox` carries no sharing leg, so the webhook poller — which routes as the subscription's owner — reads change events for resources that owner holds no grant on. Envelopes are identifiers and changed column names only, and the same metadata already reaches that person through their own initiative-room socket, so this was decided as intended rather than fixed. `outbox_poller`'s docstrings claimed all six gates applied to that read; they now say which one does.