### PR TITLE
Name guilds to billing by reference

### DIFF
--- a/backend/app/api/v1/platform_endpoints/billing.py
+++ b/backend/app/api/v1/platform_endpoints/billing.py
@@ -6,6 +6,10 @@ before parsing, run under the ``initiative_billing`` database role scoped to
 the request's guild, and share one transaction (jti redemption, event-log
 claim, and write commit or roll back together). Not part of the OpenAPI
 schema; no user is ever resolved.
+
+Every verb names its guild by the **reference** billing holds for it, never by
+a row id of ours. ``_resolve_guild`` is the one place that becomes a guild id,
+and everything past it works on the id as before.
 """
 
 from __future__ import annotations
@@ -26,6 +30,7 @@ from app.schemas.platform.billing import (
     BillingUsageRequest,
 )
 from app.services.platform import billing as billing_service
+from app.services.platform import identity_refs
 from app.services.platform.billing import (
     BillingEnvelopeError,
     BillingGuildNotFoundError,
@@ -88,6 +93,23 @@ async def _verify_and_parse(request: Request, model):
     return claims, payload
 
 
+async def _resolve_guild(guild_ref: str) -> int:
+    """The guild billing's reference names.
+
+    Billing names a guild by the reference it was given and never by a row id
+    of ours, so this is the edge every verb below crosses first. An unknown
+    reference answers 404 with nothing consumed, which is the same retryable
+    shape as a guild that does not exist yet.
+    """
+    guild_id = await identity_refs.resolve_billing_guild(ref=guild_ref)
+    if guild_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=BillingMessages.GUILD_NOT_FOUND,
+        )
+    return guild_id
+
+
 async def _burn_jti(session, claims) -> None:
     try:
         await billing_service.record_jti(
@@ -105,10 +127,13 @@ async def apply_guild_tier(
     request: Request, session: SessionDep
 ) -> BillingGuildTierRead:
     claims, payload = await _verify_and_parse(request, BillingGuildTierApply)
-    await set_billing_context(session, guild_id=payload.guild_id)
+    guild_id = await _resolve_guild(payload.guild_ref)
+    await set_billing_context(session, guild_id=guild_id)
     await _burn_jti(session, claims)
     try:
-        result = await billing_service.apply_guild_tier(session, payload)
+        result = await billing_service.apply_guild_tier(
+            session, payload, guild_id=guild_id
+        )
     except BillingGuildNotFoundError as exc:
         # Rolls back with the jti unredeemed and the event id unconsumed, so
         # the delivery can be retried once the guild exists.
@@ -142,16 +167,15 @@ async def guild_usage(
     guild 404s with the jti unredeemed (retryable).
     """
     claims, payload = await _verify_and_parse(request, BillingUsageRequest)
-    await set_billing_context(session, guild_id=payload.guild_id)
+    guild_id = await _resolve_guild(payload.guild_ref)
+    await set_billing_context(session, guild_id=guild_id)
     await _burn_jti(session, claims)
     try:
-        usage_bytes = await billing_service.guild_storage_usage(
-            admin_session, payload.guild_id
-        )
+        usage_bytes = await billing_service.guild_storage_usage(admin_session, guild_id)
     except BillingGuildNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=BillingMessages.GUILD_NOT_FOUND,
         ) from exc
     await session.commit()  # persist the one-shot jti redemption
-    return BillingUsageRead(guild_id=payload.guild_id, usage_bytes=usage_bytes)
+    return BillingUsageRead(guild_ref=payload.guild_ref, usage_bytes=usage_bytes)

--- a/backend/app/api/v1/platform_endpoints/billing_test.py
+++ b/backend/app/api/v1/platform_endpoints/billing_test.py
@@ -32,13 +32,17 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core import config as config_module
 from app.db.jti_blocklist import purge_expired_jtis
+from app.db.session import AdminSessionLocal
 from app.models.platform.billing import BillingEventLog, BillingJti
+from app.models.platform.identity_ref import IdentityEntity, IdentityPurpose
+from app.services.platform.identity_refs import ensure_ref
 from app.services.tenant.attachments import (
     StorageQuotaExceededError,
     enforce_storage_quota,
 )
 from app.testing.schema_harness import route_session_to_guild
 from app.testing import (
+    billing_guild_ref,
     guild_administration,
     create_guild,
     create_upload,
@@ -132,9 +136,10 @@ async def _post(client: AsyncClient, endpoint: str, payload: dict, **overrides):
     return await client.post(path, content=body, headers=headers)
 
 
-def _tier_payload(guild_id: int, **fields) -> dict:
+async def _tier_payload(guild_id: int, **fields) -> dict:
+    """A write the way billing sends one: the guild named by its reference."""
     return {
-        "guild_id": guild_id,
+        "guild_ref": await billing_guild_ref(guild_id),
         "event_id": fields.pop("event_id", f"evt-{secrets.token_hex(6)}"),
         "source": fields.pop("source", "paddle_webhook"),
         **fields,
@@ -149,7 +154,7 @@ async def test_unconfigured_boundary_refuses_everything(
 ):
     monkeypatch.setattr(config_module.settings, "BILLING_PUBLIC_KEY_PEM", None)
     guild = await create_guild(session)
-    response = await _post(client, "guild-tier", _tier_payload(guild.id))
+    response = await _post(client, "guild-tier", await _tier_payload(guild.id))
     # 503, not 403: billing absent is the self-host default, not a caller
     # fault (see billing_foss_test.py for the full unconfigured surface).
     assert response.status_code == 503
@@ -160,7 +165,7 @@ async def test_missing_envelope_headers_rejected(
     client: AsyncClient, session: AsyncSession
 ):
     guild = await create_guild(session)
-    body = json.dumps(_tier_payload(guild.id)).encode()
+    body = json.dumps(await _tier_payload(guild.id)).encode()
     response = await client.post(
         "/api/v1/billing/guild-tier",
         content=body,
@@ -174,7 +179,7 @@ async def test_stale_timestamp_rejected(client: AsyncClient, session: AsyncSessi
     guild = await create_guild(session)
     stale = str(int(time.time()) - 3600)
     response = await _post(
-        client, "guild-tier", _tier_payload(guild.id), timestamp=stale
+        client, "guild-tier", await _tier_payload(guild.id), timestamp=stale
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_STALE_TIMESTAMP"
@@ -183,7 +188,7 @@ async def test_stale_timestamp_rejected(client: AsyncClient, session: AsyncSessi
 async def test_wrong_hmac_secret_rejected(client: AsyncClient, session: AsyncSession):
     guild = await create_guild(session)
     response = await _post(
-        client, "guild-tier", _tier_payload(guild.id), secret="wrong-secret"
+        client, "guild-tier", await _tier_payload(guild.id), secret="wrong-secret"
     )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_SIGNATURE"
@@ -193,9 +198,9 @@ async def test_tampered_body_rejected(client: AsyncClient, session: AsyncSession
     """A signature minted for one body must not authorize a different one."""
     guild = await create_guild(session)
     path = "/api/v1/billing/guild-tier"
-    signed_body = json.dumps(_tier_payload(guild.id, tier_name="silver")).encode()
+    signed_body = json.dumps(await _tier_payload(guild.id, tier_name="silver")).encode()
     headers = _signed_headers(path, signed_body)
-    tampered = json.dumps(_tier_payload(guild.id, tier_name="platinum")).encode()
+    tampered = json.dumps(await _tier_payload(guild.id, tier_name="platinum")).encode()
     response = await client.post(path, content=tampered, headers=headers)
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_SIGNATURE"
@@ -204,7 +209,9 @@ async def test_tampered_body_rejected(client: AsyncClient, session: AsyncSession
 async def test_wrong_jwt_key_rejected(client: AsyncClient, session: AsyncSession):
     guild = await create_guild(session)
     token = _mint_token(private_pem=_OTHER_PRIVATE_PEM)
-    response = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    response = await _post(
+        client, "guild-tier", await _tier_payload(guild.id), token=token
+    )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
 
@@ -218,7 +225,9 @@ async def test_wrong_audience_or_issuer_rejected(
 ):
     guild = await create_guild(session)
     token = _mint_token(**claim_overrides)
-    response = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    response = await _post(
+        client, "guild-tier", await _tier_payload(guild.id), token=token
+    )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
 
@@ -229,10 +238,14 @@ async def test_jti_is_one_shot(client: AsyncClient, session: AsyncSession):
     guild = await create_guild(session)
     token = _mint_token(jti="billing-replay-001")
 
-    first = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    first = await _post(
+        client, "guild-tier", await _tier_payload(guild.id), token=token
+    )
     assert first.status_code == 200, first.text
 
-    second = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    second = await _post(
+        client, "guild-tier", await _tier_payload(guild.id), token=token
+    )
     assert second.status_code == 403
     assert second.json()["detail"] == "BILLING_REPLAYED_TOKEN"
 
@@ -242,7 +255,9 @@ async def test_oversized_jti_rejected(client: AsyncClient, session: AsyncSession
     verification, not surface as a database error at redemption."""
     guild = await create_guild(session)
     token = _mint_token(jti="x" * 65)
-    response = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    response = await _post(
+        client, "guild-tier", await _tier_payload(guild.id), token=token
+    )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
 
@@ -275,7 +290,9 @@ async def test_purged_jti_still_unreplayable(
     assert remaining is None
 
     # Fresh HMAC, purged blocklist row — the token's own exp still refuses it.
-    response = await _post(client, "guild-tier", _tier_payload(guild.id), token=token)
+    response = await _post(
+        client, "guild-tier", await _tier_payload(guild.id), token=token
+    )
     assert response.status_code == 403
     assert response.json()["detail"] == "BILLING_INVALID_TOKEN"
 
@@ -288,7 +305,7 @@ async def test_apply_guild_tier_happy_path(client: AsyncClient, session: AsyncSe
     response = await _post(
         client,
         "guild-tier",
-        _tier_payload(
+        await _tier_payload(
             guild.id,
             event_id="evt-happy-1",
             tier_name="gold",
@@ -329,14 +346,14 @@ async def test_replayed_event_id_is_noop(client: AsyncClient, session: AsyncSess
     first = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id, event_id="evt-dup", tier_name="gold"),
+        await _tier_payload(guild.id, event_id="evt-dup", tier_name="gold"),
     )
     assert first.status_code == 200 and first.json()["applied"] is True
 
     second = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id, event_id="evt-dup", tier_name="platinum"),
+        await _tier_payload(guild.id, event_id="evt-dup", tier_name="platinum"),
     )
     assert second.status_code == 200
     data = second.json()
@@ -355,7 +372,9 @@ async def test_sentinel_semantics_omit_vs_null(
     setup = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id, tier_name="gold", max_storage_bytes=1024, max_users=10),
+        await _tier_payload(
+            guild.id, tier_name="gold", max_storage_bytes=1024, max_users=10
+        ),
     )
     assert setup.status_code == 200
 
@@ -363,7 +382,7 @@ async def test_sentinel_semantics_omit_vs_null(
     response = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id, max_storage_bytes=None),
+        await _tier_payload(guild.id, max_storage_bytes=None),
     )
     assert response.status_code == 200
     data = response.json()
@@ -388,7 +407,7 @@ async def test_the_pushed_ceiling_is_the_one_uploads_are_held_to(
     # Cleared: no ceiling to hit.
     assert (
         await _post(
-            client, "guild-tier", _tier_payload(guild.id, max_storage_bytes=None)
+            client, "guild-tier", await _tier_payload(guild.id, max_storage_bytes=None)
         )
     ).status_code == 200
     await route_session_to_guild(session, guild.id)
@@ -397,7 +416,7 @@ async def test_the_pushed_ceiling_is_the_one_uploads_are_held_to(
     # Same upload, against a cap billing pushed after it.
     assert (
         await _post(
-            client, "guild-tier", _tier_payload(guild.id, max_storage_bytes=1000)
+            client, "guild-tier", await _tier_payload(guild.id, max_storage_bytes=1000)
         )
     ).status_code == 200
     await route_session_to_guild(session, guild.id)
@@ -411,7 +430,7 @@ async def test_status_change_stamps_status_changed_at(
     guild = await create_guild(session)
     assert guild.status_changed_at is None
     response = await _post(
-        client, "guild-tier", _tier_payload(guild.id, status="read_only")
+        client, "guild-tier", await _tier_payload(guild.id, status="read_only")
     )
     assert response.status_code == 200
     assert response.json()["status"] == "read_only"
@@ -431,7 +450,7 @@ async def test_support_source_may_only_raise_storage(
     allowed = await _post(
         client,
         "guild-tier",
-        _tier_payload(
+        await _tier_payload(
             guild.id,
             source="support_manual",
             actor="support:42",
@@ -444,7 +463,7 @@ async def test_support_source_may_only_raise_storage(
     tier_change = await _post(
         client,
         "guild-tier",
-        _tier_payload(
+        await _tier_payload(
             guild.id, source="support_manual", actor="support:42", tier_name="gold"
         ),
     )
@@ -454,7 +473,7 @@ async def test_support_source_may_only_raise_storage(
     anonymous = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id, source="support_manual", max_storage_bytes=4096),
+        await _tier_payload(guild.id, source="support_manual", max_storage_bytes=4096),
     )
     assert anonymous.status_code == 422
     assert anonymous.json()["detail"] == "BILLING_ACTOR_REQUIRED"
@@ -472,7 +491,7 @@ async def test_support_source_cannot_lower_storage(
     cap_unlimited = await _post(
         client,
         "guild-tier",
-        _tier_payload(
+        await _tier_payload(
             guild.id,
             source="support_manual",
             actor="support:42",
@@ -484,14 +503,14 @@ async def test_support_source_cannot_lower_storage(
 
     # Give the guild a finite cap via the automated path.
     setup = await _post(
-        client, "guild-tier", _tier_payload(guild.id, max_storage_bytes=4096)
+        client, "guild-tier", await _tier_payload(guild.id, max_storage_bytes=4096)
     )
     assert setup.status_code == 200
 
     lowered = await _post(
         client,
         "guild-tier",
-        _tier_payload(
+        await _tier_payload(
             guild.id,
             source="support_manual",
             actor="support:42",
@@ -511,7 +530,7 @@ async def test_support_source_cannot_lower_storage(
     equal = await _post(
         client,
         "guild-tier",
-        _tier_payload(
+        await _tier_payload(
             guild.id,
             source="support_manual",
             actor="support:42",
@@ -524,7 +543,7 @@ async def test_support_source_cannot_lower_storage(
 
     # paddle_webhook (the automated recompute path) may lower freely.
     automated = await _post(
-        client, "guild-tier", _tier_payload(guild.id, max_storage_bytes=512)
+        client, "guild-tier", await _tier_payload(guild.id, max_storage_bytes=512)
     )
     assert automated.status_code == 200
     assert automated.json()["max_storage_bytes"] == 512
@@ -537,7 +556,7 @@ async def test_unknown_guild_404_does_not_consume_event_id(
     missing = await _post(
         client,
         "guild-tier",
-        _tier_payload(999_999_999, event_id="evt-preserved", tier_name="gold"),
+        await _tier_payload(999_999_999, event_id="evt-preserved", tier_name="gold"),
     )
     assert missing.status_code == 404
     assert missing.json()["detail"] == "BILLING_GUILD_NOT_FOUND"
@@ -545,17 +564,63 @@ async def test_unknown_guild_404_does_not_consume_event_id(
     retry = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id, event_id="evt-preserved", tier_name="gold"),
+        await _tier_payload(guild.id, event_id="evt-preserved", tier_name="gold"),
     )
     assert retry.status_code == 200, retry.text
     assert retry.json()["applied"] is True
+
+
+async def test_a_reference_this_deployment_never_minted_is_404(
+    client: AsyncClient, session: AsyncSession
+):
+    """Billing names the guild, and only a reference this deployment issued
+    for billing is a name it answers to."""
+    response = await _post(
+        client,
+        "guild-tier",
+        {
+            "guild_ref": "gbil_notoneweminted",
+            "event_id": "evt-unknown-ref",
+            "source": "paddle_webhook",
+        },
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "BILLING_GUILD_NOT_FOUND"
+
+
+async def test_a_reference_minted_for_something_else_is_404(
+    client: AsyncClient, session: AsyncSession
+):
+    """A user's reference resolves, and is still not an answer to which guild
+    this is."""
+    user = await create_user(session)
+    async with AdminSessionLocal() as admin:
+        user_ref = await ensure_ref(
+            admin,
+            entity_type=IdentityEntity.user,
+            entity_id=user.id,
+            purpose=IdentityPurpose.billing,
+        )
+        await admin.commit()
+
+    response = await _post(
+        client,
+        "guild-tier",
+        {
+            "guild_ref": user_ref,
+            "event_id": "evt-wrong-entity",
+            "source": "paddle_webhook",
+        },
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "BILLING_GUILD_NOT_FOUND"
 
 
 async def test_malformed_payload_rejected_after_verification(
     client: AsyncClient, session: AsyncSession
 ):
     path = "/api/v1/billing/guild-tier"
-    body = b'{"guild_id": "not-a-number"}'
+    body = b'{"guild_ref": 17}'
     headers = _signed_headers(path, body)
     response = await client.post(path, content=body, headers=headers)
     assert response.status_code == 422
@@ -570,9 +635,13 @@ async def test_a_read_burns_its_jti(client: AsyncClient, session: AsyncSession):
     replayable inside the window."""
     guild = await create_guild(session)
     token = _mint_token(jti="billing-read-replay")
-    first = await _post(client, "usage", {"guild_id": guild.id}, token=token)
+    first = await _post(
+        client, "usage", {"guild_ref": await billing_guild_ref(guild.id)}, token=token
+    )
     assert first.status_code == 200
-    second = await _post(client, "usage", {"guild_id": guild.id}, token=token)
+    second = await _post(
+        client, "usage", {"guild_ref": await billing_guild_ref(guild.id)}, token=token
+    )
     assert second.status_code == 403
     assert second.json()["detail"] == "BILLING_REPLAYED_TOKEN"
 
@@ -585,20 +654,32 @@ async def test_usage_sums_guild_bytes(client: AsyncClient, session: AsyncSession
     await create_upload(session, guild, uploader, size_bytes=1000)
     await create_upload(session, guild, uploader, size_bytes=234)
 
-    response = await _post(client, "usage", {"guild_id": guild.id})
+    response = await _post(
+        client, "usage", {"guild_ref": await billing_guild_ref(guild.id)}
+    )
     assert response.status_code == 200, response.text
-    assert response.json() == {"guild_id": guild.id, "usage_bytes": 1234}
+    assert response.json() == {
+        "guild_ref": await billing_guild_ref(guild.id),
+        "usage_bytes": 1234,
+    }
 
 
 async def test_usage_zero_for_empty_guild(client: AsyncClient, session: AsyncSession):
     guild = await create_guild(session)
-    response = await _post(client, "usage", {"guild_id": guild.id})
+    response = await _post(
+        client, "usage", {"guild_ref": await billing_guild_ref(guild.id)}
+    )
     assert response.status_code == 200, response.text
-    assert response.json() == {"guild_id": guild.id, "usage_bytes": 0}
+    assert response.json() == {
+        "guild_ref": await billing_guild_ref(guild.id),
+        "usage_bytes": 0,
+    }
 
 
 async def test_usage_unknown_guild_404(client: AsyncClient, session: AsyncSession):
-    response = await _post(client, "usage", {"guild_id": 999_999_999})
+    response = await _post(
+        client, "usage", {"guild_ref": await billing_guild_ref(999_999_999)}
+    )
     assert response.status_code == 404
     assert response.json()["detail"] == "BILLING_GUILD_NOT_FOUND"
 
@@ -606,9 +687,13 @@ async def test_usage_unknown_guild_404(client: AsyncClient, session: AsyncSessio
 async def test_usage_burns_jti(client: AsyncClient, session: AsyncSession):
     guild = await create_guild(session)
     token = _mint_token(jti="billing-usage-replay")
-    first = await _post(client, "usage", {"guild_id": guild.id}, token=token)
+    first = await _post(
+        client, "usage", {"guild_ref": await billing_guild_ref(guild.id)}, token=token
+    )
     assert first.status_code == 200
-    second = await _post(client, "usage", {"guild_id": guild.id}, token=token)
+    second = await _post(
+        client, "usage", {"guild_ref": await billing_guild_ref(guild.id)}, token=token
+    )
     assert second.status_code == 403
     assert second.json()["detail"] == "BILLING_REPLAYED_TOKEN"
 
@@ -633,7 +718,7 @@ async def test_both_keys_verify_while_billing_rotates(
         response = await _post(
             client,
             "guild-tier",
-            _tier_payload(guild.id),
+            await _tier_payload(guild.id),
             token=_mint_token(private_pem=private_pem),
         )
         assert response.status_code == 200, response.text
@@ -652,7 +737,7 @@ async def test_dropping_the_old_block_ends_its_access(
     response = await _post(
         client,
         "guild-tier",
-        _tier_payload(guild.id),
+        await _tier_payload(guild.id),
         token=_mint_token(private_pem=_PRIVATE_PEM),
     )
     assert response.status_code == 403
@@ -672,6 +757,6 @@ async def test_unreadable_key_answers_503_not_403(
     )
     guild = await create_guild(session)
 
-    response = await _post(client, "guild-tier", _tier_payload(guild.id))
+    response = await _post(client, "guild-tier", await _tier_payload(guild.id))
     assert response.status_code == 503
     assert response.json()["detail"] == "BILLING_KEY_UNREADABLE"

--- a/backend/app/api/v1/platform_endpoints/guilds.py
+++ b/backend/app/api/v1/platform_endpoints/guilds.py
@@ -915,8 +915,6 @@ async def create_guild_billing_handoff(
             user_id=current_user.id, guild_id=guild_id
         )
         token, expires_in_seconds = create_billing_portal_handoff_token(
-            user_id=current_user.id,
-            guild_id=guild_id,
             guild_role=GuildRole.admin.value,
             user_ref=user_ref,
             guild_ref=guild_ref,

--- a/backend/app/api/v1/platform_endpoints/guilds_test.py
+++ b/backend/app/api/v1/platform_endpoints/guilds_test.py
@@ -1113,9 +1113,12 @@ async def test_guild_billing_handoff_succeeds_for_admin(
     payload = jwt.decode(body["handoff_token"], options={"verify_signature": False})
     assert payload["aud"] == BILLING_PORTAL_AUDIENCE
     assert payload["iss"] == "initiative"
-    assert payload["sub"] == str(admin.id)
-    assert payload["guild_id"] == guild.id
     assert payload["guild_role"] == "admin"
+    # The pair is named by reference and by nothing else, `sub` included.
+    assert payload["sub"] == payload["user_ref"]
+    assert payload["user_ref"].startswith("ubil_")
+    assert payload["guild_ref"].startswith("gbil_")
+    assert "guild_id" not in payload
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/platform_endpoints/settings.py
+++ b/backend/app/api/v1/platform_endpoints/settings.py
@@ -63,7 +63,7 @@ from app.core.security import (
     BillingSupportHandoffNotConfiguredError,
     create_billing_support_handoff_token,
 )
-from app.services.platform.identity_refs import billing_refs
+from app.services.platform.identity_refs import billing_refs, billing_user_ref
 from app.services.platform import access_grants as access_grants_service
 from app.services.auth import platform_provider as platform_provider_service
 from app.services.platform import app_settings as app_settings_service
@@ -657,12 +657,14 @@ async def create_platform_guild_billing_service_handoff(
     try:
         user_ref, guild_ref = await billing_refs(user_id=admin.id, guild_id=guild_id)
         token, expires_in_seconds = create_billing_support_handoff_token(
-            user_id=admin.id,
-            guild_id=guild_id,
             grant_id=grant.id,
             user_ref=user_ref,
             guild_ref=guild_ref,
-            approver_id=grant.approved_by_id,
+            approver_ref=(
+                await billing_user_ref(user_id=grant.approved_by_id)
+                if grant.approved_by_id is not None
+                else None
+            ),
         )
     except BillingSupportHandoffNotConfiguredError as exc:
         raise HTTPException(

--- a/backend/app/api/v1/platform_endpoints/settings_test.py
+++ b/backend/app/api/v1/platform_endpoints/settings_test.py
@@ -1349,8 +1349,12 @@ async def test_billing_handoff_self_issues_a_grant_and_names_it(
         audience=BILLING_SUPPORT_HANDOFF_AUDIENCE,
         issuer=BILLING_SUPPORT_HANDOFF_ISSUER,
     )
-    assert payload["sub"] == str(owner.id)
-    assert payload["guild_id"] == guild.id
+    # Everyone on the token is named by reference, `sub` included; no row id
+    # of ours is in the claims at all.
+    assert payload["sub"] == payload["user_ref"]
+    assert payload["user_ref"].startswith("ubil_")
+    assert payload["guild_ref"].startswith("gbil_")
+    assert "guild_id" not in payload
     assert payload["jti"]
     # Lifetime stays inside the receiver's ceiling.
     assert payload["exp"] - payload["iat"] <= 300
@@ -1363,7 +1367,8 @@ async def test_billing_handoff_self_issues_a_grant_and_names_it(
         )
     ).one()
     assert payload["grant_id"] == str(grant.id)
-    assert payload["approver"] == str(owner.id)
+    # The approver too — it names a person, so it is a reference like the rest.
+    assert payload["approver"] == payload["user_ref"]
     assert grant.access_level == "read"
     assert grant.status == "approved"
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -358,8 +358,6 @@ BILLING_PORTAL_HANDOFF_LIFETIME = timedelta(seconds=60)
 
 def create_billing_portal_handoff_token(
     *,
-    user_id: int,
-    guild_id: int,
     guild_role: str,
     user_ref: str,
     guild_ref: str,
@@ -367,19 +365,20 @@ def create_billing_portal_handoff_token(
 ) -> tuple[str, int]:
     """Mint the billing-portal handoff token (RS256; raises if unconfigured).
 
-    ``user_ref`` / ``guild_ref`` are what the receiver names the pair by — see
-    ``services.platform.identity_refs.billing_refs``. The row ids travel
-    alongside them until the receiver reads the references instead.
+    ``user_ref`` / ``guild_ref`` are the only names for the pair that cross —
+    see ``services.platform.identity_refs.billing_refs``. ``sub`` carries the
+    user's, which is what a pairwise pseudonymous identifier is for (OpenID
+    Connect Core §8.1); no row id of ours is a parameter here, so none can
+    reach the claims.
     """
     now = datetime.now(timezone.utc)
     payload: dict[str, Any] = {
         "jti": str(uuid.uuid4()),
-        "sub": str(user_id),
+        "sub": user_ref,
         "aud": BILLING_PORTAL_AUDIENCE,
         "iss": "initiative",
         "iat": int(now.timestamp()),
         "exp": now + expires_in,
-        "guild_id": guild_id,
         "guild_role": guild_role,
         "user_ref": user_ref,
         "guild_ref": guild_ref,
@@ -444,20 +443,20 @@ def billing_support_handoff_enabled() -> bool:
 
 def create_billing_support_handoff_token(
     *,
-    user_id: int,
-    guild_id: int,
     grant_id: int | str,
     user_ref: str,
     guild_ref: str,
-    approver_id: int | str | None = None,
+    approver_ref: str | None = None,
     expires_in: timedelta = BILLING_SUPPORT_HANDOFF_LIFETIME,
 ) -> tuple[str, int]:
     """Mint the billing-support handoff token.
 
     ``grant_id`` names the ``access_grants`` row that authorises the visit, so
-    both sides log the same grant. ``user_ref`` / ``guild_ref`` are what the
-    receiver names the pair by — see
-    ``services.platform.identity_refs.billing_refs``.
+    both sides log the same grant. Everyone else on it is named by reference —
+    the operator visiting, the guild visited, and whoever approved the visit —
+    see ``services.platform.identity_refs.billing_refs``. ``sub`` carries the
+    operator's, which is what a pairwise pseudonymous identifier is for
+    (OpenID Connect Core §8.1).
     """
     if not billing_support_handoff_enabled():
         raise BillingSupportHandoffNotConfiguredError(
@@ -468,18 +467,17 @@ def create_billing_support_handoff_token(
     now = datetime.now(timezone.utc)
     payload: dict[str, Any] = {
         "jti": str(uuid.uuid4()),
-        "sub": str(user_id),
+        "sub": user_ref,
         "aud": BILLING_SUPPORT_HANDOFF_AUDIENCE,
         "iss": BILLING_SUPPORT_HANDOFF_ISSUER,
         "iat": int(now.timestamp()),
         "exp": int((now + lifetime).timestamp()),
-        "guild_id": int(guild_id),
         "grant_id": str(grant_id),
         "user_ref": user_ref,
         "guild_ref": guild_ref,
     }
-    if approver_id is not None:
-        payload["approver"] = str(approver_id)
+    if approver_ref is not None:
+        payload["approver"] = approver_ref
     token = jwt.encode(
         payload,
         settings.BILLING_SUPPORT_HANDOFF_SECRET,

--- a/backend/app/core/security_test.py
+++ b/backend/app/core/security_test.py
@@ -58,8 +58,6 @@ def _b64url_encode(raw: bytes) -> str:
 def test_billing_portal_handoff_carries_admin_claims_and_distinct_audience():
     """Claims present, and the audience is the portal's own."""
     token, seconds = security.create_billing_portal_handoff_token(
-        user_id=42,
-        guild_id=7,
         guild_role="admin",
         user_ref="ubil_test42",
         guild_ref="gbil_test7",
@@ -70,13 +68,14 @@ def test_billing_portal_handoff_carries_admin_claims_and_distinct_audience():
     payload = _decode_unverified(token)
     assert payload["aud"] == security.BILLING_PORTAL_AUDIENCE
     assert payload["iss"] == "initiative"
-    assert payload["sub"] == "42"
-    assert payload["guild_id"] == 7
     assert payload["guild_role"] == "admin"
     assert payload["jti"] and isinstance(payload["jti"], str)
-    # What the receiver names the pair by, beside the row ids.
+    # The two are named by reference and by nothing else — `sub` carries the
+    # user's, and no row id of ours appears anywhere in the claims.
+    assert payload["sub"] == "ubil_test42"
     assert payload["user_ref"] == "ubil_test42"
     assert payload["guild_ref"] == "gbil_test7"
+    assert "guild_id" not in payload
 
 
 @pytest.mark.unit
@@ -85,8 +84,6 @@ def test_billing_portal_handoff_refuses_to_mint_without_private_key(monkeypatch)
     monkeypatch.setattr(security.settings, "HANDOFF_SIGNING_PRIVATE_KEY_PEM", None)
     with pytest.raises(HandoffSigningNotConfiguredError):
         security.create_billing_portal_handoff_token(
-            user_id=1,
-            guild_id=2,
             guild_role="admin",
             user_ref="ubil_test1",
             guild_ref="gbil_test2",
@@ -184,8 +181,6 @@ def test_verify_upload_token_rejects_wrong_audience():
     """A token signed with our secret but carrying a foreign audience (e.g. a
     handoff into another service) must not be honored as an upload token."""
     handoff, _ = security.create_billing_portal_handoff_token(
-        user_id=1,
-        guild_id=2,
         guild_role="admin",
         user_ref="ubil_test1",
         guild_ref="gbil_test2",
@@ -306,8 +301,6 @@ def test_decode_session_token_rejects_scoped_upload_token():
 @pytest.mark.unit
 def test_decode_session_token_rejects_handoff_token():
     handoff, _ = security.create_billing_portal_handoff_token(
-        user_id=7,
-        guild_id=1,
         guild_role="admin",
         user_ref="ubil_test7",
         guild_ref="gbil_test1",

--- a/backend/app/schemas/platform/billing.py
+++ b/backend/app/schemas/platform/billing.py
@@ -13,6 +13,7 @@ from pydantic import Field, model_validator
 
 from app.core.messages import BillingMessages
 from app.models.platform.billing import BillingSource
+from app.models.platform.identity_ref import REF_MAX_LENGTH
 from app.models.platform.guild import GuildStatus
 from app.schemas.base import SanitizedBaseModel
 
@@ -33,7 +34,7 @@ class BillingGuildTierApply(SanitizedBaseModel):
     same id is a safe no-op.
     """
 
-    guild_id: int = Field(ge=1)
+    guild_ref: str = Field(min_length=1, max_length=REF_MAX_LENGTH)
     event_id: str = Field(min_length=1, max_length=128)
     source: BillingSource
     # Acting human for manual ops (support grant id / staff id); NULL for
@@ -65,9 +66,12 @@ class BillingGuildTierRead(SanitizedBaseModel):
 
     ``applied`` is False when the event id had already been claimed — the
     values shown are the current state, untouched by the replayed delivery.
+
+    The guild is echoed by the reference the caller sent, which is the only
+    name for it the two services share.
     """
 
-    guild_id: int
+    guild_ref: str
     tier_name: Optional[str] = None
     max_storage_bytes: Optional[int] = None
     max_users: Optional[int] = None
@@ -83,7 +87,7 @@ class BillingUsageRequest(SanitizedBaseModel):
     HMAC covers it, like every other verb on this boundary.
     """
 
-    guild_id: int = Field(ge=1)
+    guild_ref: str = Field(min_length=1, max_length=REF_MAX_LENGTH)
 
 
 class BillingUsageRead(SanitizedBaseModel):
@@ -91,7 +95,7 @@ class BillingUsageRead(SanitizedBaseModel):
     ``enforce_storage_quota`` reads. Read-only; the app never pushes usage
     anywhere."""
 
-    guild_id: int
+    guild_ref: str
     usage_bytes: int
 
 

--- a/backend/app/services/platform/billing.py
+++ b/backend/app/services/platform/billing.py
@@ -235,9 +235,13 @@ async def _member_count(session: AsyncSession, guild_id: int) -> int:
 
 
 async def apply_guild_tier(
-    session: AsyncSession, payload: BillingGuildTierApply
+    session: AsyncSession, payload: BillingGuildTierApply, *, guild_id: int
 ) -> BillingGuildTierRead:
     """Apply a tier-metadata write, exactly once per ``event_id``.
+
+    The payload names its guild by the reference billing holds; ``guild_id`` is
+    what that resolved to at the edge, and is the only name for the guild used
+    from here in.
 
     Sequence: existence check (404 before consuming the event id), then the
     source/state restriction (a refused write consumes nothing — the whole
@@ -247,9 +251,9 @@ async def apply_guild_tier(
     ``model_fields_set`` sentinel semantics (omit = leave, null = unlimited).
     """
     provided = payload.model_fields_set
-    row = await _select_tier_row(session, payload.guild_id)
+    row = await _select_tier_row(session, guild_id)
     if row is None:
-        raise BillingGuildNotFoundError(payload.guild_id)
+        raise BillingGuildNotFoundError(guild_id)
 
     # support_manual may only RAISE the storage cap. The payload validator
     # already forbids it every other field; the lower-vs-raise half needs the
@@ -274,7 +278,7 @@ async def apply_guild_tier(
     # transaction survive.
     claim = insert(BillingEventLog.__table__).values(
         event_id=payload.event_id,
-        guild_id=payload.guild_id,
+        guild_id=guild_id,
         op=BillingOp.guild_tier.value,
         source=payload.source.value,
         actor=payload.actor,
@@ -301,7 +305,7 @@ async def apply_guild_tier(
             guild_values["status_changed_at"] = now
             logger.info(
                 "billing: guild %s status %s -> %s (source=%s actor=%s event=%s)",
-                payload.guild_id,
+                guild_id,
                 row.status,
                 payload.status.value,
                 payload.source.value,
@@ -312,24 +316,24 @@ async def apply_guild_tier(
             if administration_values:
                 await session.exec(
                     update(GuildAdministration)
-                    .where(GuildAdministration.guild_id == payload.guild_id)
+                    .where(GuildAdministration.guild_id == guild_id)
                     .values(**administration_values)
                 )
             # Stamp the guild whichever row moved: "when did this guild last
             # change" stays a fact about the guild.
             guild_values["updated_at"] = now
             await session.exec(
-                update(Guild).where(Guild.id == payload.guild_id).values(**guild_values)
+                update(Guild).where(Guild.id == guild_id).values(**guild_values)
             )
-            row = await _select_tier_row(session, payload.guild_id)
+            row = await _select_tier_row(session, guild_id)
 
     return BillingGuildTierRead(
-        guild_id=row.id,
+        guild_ref=payload.guild_ref,
         tier_name=row.tier_name,
         max_storage_bytes=row.max_storage_bytes,
         max_users=row.max_users,
         status=GuildStatus(row.status),
-        member_count=await _member_count(session, payload.guild_id),
+        member_count=await _member_count(session, guild_id),
         applied=applied,
     )
 

--- a/backend/app/services/platform/billing_claim.py
+++ b/backend/app/services/platform/billing_claim.py
@@ -62,8 +62,6 @@ async def _send_claim(user_id: int, guild_id: int) -> None:
     try:
         user_ref, guild_ref = await billing_refs(user_id=user_id, guild_id=guild_id)
         token, _ = create_billing_portal_handoff_token(
-            user_id=user_id,
-            guild_id=guild_id,
             guild_role="admin",
             user_ref=user_ref,
             guild_ref=guild_ref,

--- a/backend/app/services/platform/billing_claim_test.py
+++ b/backend/app/services/platform/billing_claim_test.py
@@ -117,10 +117,13 @@ async def test_the_request_carries_a_signed_handoff_and_no_bare_identity(
         algorithms=["RS256"],
         audience=BILLING_PORTAL_AUDIENCE,
     )
-    assert claims["sub"] == "9"
-    assert claims["guild_id"] == 77
     assert claims["guild_role"] == "admin"
     assert claims["iss"] == "initiative"
+    # The pair is named by reference and by nothing else, `sub` included.
+    assert claims["sub"] == claims["user_ref"]
+    assert claims["user_ref"].startswith("ubil_")
+    assert claims["guild_ref"].startswith("gbil_")
+    assert "guild_id" not in claims
 
 
 async def test_send_failure_never_raises(billing_configured, monkeypatch):

--- a/backend/app/services/platform/billing_ping.py
+++ b/backend/app/services/platform/billing_ping.py
@@ -3,8 +3,8 @@
 A nudge that a guild's membership changed. What the service does with it is
 its own business; this side only sends it.
 
-* the payload is the guild id and a fresh event id, and nothing else — no
-  member data, no PII, no count;
+* the payload is the guild's reference and a fresh event id, and nothing
+  else — no member data, no PII, no count;
 * no retry queue and no delivery guarantee;
 * the join/leave transaction must never fail or slow because the service is
   down: the send runs as a detached task with a tight timeout and swallows
@@ -33,6 +33,7 @@ from uuid import uuid4
 import httpx
 
 from app.core.config import settings
+from app.services.platform.identity_refs import billing_guild_ref
 
 logger = logging.getLogger(__name__)
 
@@ -52,17 +53,19 @@ def billing_ping_enabled() -> bool:
     return bool(settings.BILLING_SERVICE_URL and settings.BILLING_HMAC_SECRET)
 
 
-def build_membership_ping(guild_id: int) -> tuple[str, bytes, dict[str, str]]:
+def build_membership_ping(guild_ref: str) -> tuple[str, bytes, dict[str, str]]:
     """Assemble (url, body, headers) for one ping. Pure — no I/O.
 
-    The HMAC is bound to the path component billing's verifier will see,
-    so a base URL with a path prefix still signs correctly.
+    The guild is named by the reference billing holds for it, which is the only
+    name for it the two share. The HMAC is bound to the path component
+    billing's verifier will see, so a base URL with a path prefix still signs
+    correctly.
     """
     base = settings.BILLING_SERVICE_URL.rstrip("/")
     url = base + MEMBERSHIP_PING_PATH
     path = urlsplit(url).path
     body = json.dumps(
-        {"guild_id": int(guild_id), "event_id": uuid4().hex},
+        {"guild_ref": guild_ref, "event_id": uuid4().hex},
         separators=(",", ":"),
     ).encode()
     ts = str(int(time.time()))
@@ -82,7 +85,8 @@ async def _send_membership_ping(guild_id: int) -> None:
     """One attempt, no retry; never raises (task exceptions would only spam
     the loop's never-retrieved handler)."""
     try:
-        url, body, headers = build_membership_ping(guild_id)
+        guild_ref = await billing_guild_ref(guild_id=guild_id)
+        url, body, headers = build_membership_ping(guild_ref)
         async with httpx.AsyncClient(timeout=_PING_TIMEOUT) as client:
             await client.post(url, content=body, headers=headers)
     except Exception:

--- a/backend/app/services/platform/billing_ping_test.py
+++ b/backend/app/services/platform/billing_ping_test.py
@@ -75,13 +75,14 @@ async def test_configured_dispatches_one_ping(billing_configured, sent_pings):
 
 
 def test_payload_has_no_pii_and_verifiable_signature(billing_configured):
-    url, body, headers = billing_ping.build_membership_ping(42)
+    url, body, headers = billing_ping.build_membership_ping("gbil_test42")
     assert url == "https://billing.internal/api/v1/pings/membership"
 
     payload = json.loads(body)
-    # guild id + event id ONLY: no emails, names, user ids, or member counts.
-    assert set(payload) == {"guild_id", "event_id"}
-    assert payload["guild_id"] == 42
+    # The guild's reference + an event id ONLY: no emails, names, user ids or
+    # member counts, and no row id of ours either.
+    assert set(payload) == {"guild_ref", "event_id"}
+    assert payload["guild_ref"] == "gbil_test42"
     assert payload["event_id"]
 
     message = "\n".join(
@@ -98,7 +99,7 @@ def test_payload_has_no_pii_and_verifiable_signature(billing_configured):
 
 def test_event_ids_are_unique_per_ping(billing_configured):
     ids = {
-        json.loads(billing_ping.build_membership_ping(1)[1])["event_id"]
+        json.loads(billing_ping.build_membership_ping("gbil_test1")[1])["event_id"]
         for _ in range(5)
     }
     assert len(ids) == 5

--- a/backend/app/services/platform/identity_refs.py
+++ b/backend/app/services/platform/identity_refs.py
@@ -34,7 +34,9 @@ from app.models.platform.identity_ref import (
 
 __all__ = [
     "REF_GRACE_PERIOD",
+    "billing_guild_ref",
     "billing_refs",
+    "billing_user_ref",
     "drop_entity_refs",
     "drop_sector_refs",
     "ensure_ref",
@@ -43,6 +45,7 @@ __all__ = [
     "purge_retired_refs",
     "reissue_all_refs",
     "reissue_ref",
+    "resolve_billing_guild",
     "resolve_ref",
 ]
 
@@ -124,6 +127,44 @@ async def ensure_ref(
     return stored.ref
 
 
+async def billing_user_ref(*, user_id: int) -> str:
+    """The reference billing knows one user by, minting on first use.
+
+    For the people a handoff names besides the one presenting it — the
+    approver of a support visit — who need the same treatment and no more.
+    """
+    from app.db.session import AdminSessionLocal
+
+    async with AdminSessionLocal() as session:
+        ref = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.user,
+            entity_id=user_id,
+            purpose=IdentityPurpose.billing,
+        )
+        await session.commit()
+    return ref
+
+
+async def billing_guild_ref(*, guild_id: int) -> str:
+    """The reference billing knows one guild by, minting on first use.
+
+    For the paths that name a guild to billing without a person attached — the
+    membership nudge, and the tests that post what billing would.
+    """
+    from app.db.session import AdminSessionLocal
+
+    async with AdminSessionLocal() as session:
+        ref = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.guild,
+            entity_id=guild_id,
+            purpose=IdentityPurpose.billing,
+        )
+        await session.commit()
+    return ref
+
+
 async def billing_refs(*, user_id: int, guild_id: int) -> tuple[str, str]:
     """The references billing knows one user and one guild by.
 
@@ -150,6 +191,32 @@ async def billing_refs(*, user_id: int, guild_id: int) -> tuple[str, str]:
         )
         await session.commit()
     return user_ref, guild_ref
+
+
+async def resolve_billing_guild(*, ref: str) -> int | None:
+    """Which guild one billing reference names, or None.
+
+    The inverse of ``billing_refs``, for the endpoints billing calls: it names
+    the guild by the reference it was given, and this is where that becomes the
+    row id everything inside works on. Opens a system-engine session of its own
+    for the same reason ``billing_refs`` does — the callers are request
+    handlers routed to other roles.
+
+    Narrower than ``resolve_ref``: a reference minted for a user, or for
+    another purpose, is not an answer to this question.
+    """
+    from app.db.session import AdminSessionLocal
+
+    async with AdminSessionLocal() as session:
+        row = await resolve_ref(session, ref=ref)
+    if row is None:
+        return None
+    if (
+        row.entity_type != IdentityEntity.guild
+        or row.purpose != IdentityPurpose.billing
+    ):
+        return None
+    return row.entity_id
 
 
 async def resolve_ref(

--- a/backend/app/testing/__init__.py
+++ b/backend/app/testing/__init__.py
@@ -20,6 +20,7 @@ from app.testing.app_channel import (
 from app.testing.factories import (
     grant_role_permission,
     TOOL_FACTORIES,
+    billing_guild_ref,
     enable_all_tools,
     create_tool_entity,
     create_app_delegation,
@@ -77,6 +78,7 @@ __all__ = [
     "encode_body",
     "register_app_service",
     "TOOL_FACTORIES",
+    "billing_guild_ref",
     "enable_all_tools",
     "create_tool_entity",
     "Actor",

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -2189,3 +2189,15 @@ async def enable_all_tools(session: AsyncSession, initiative: Initiative) -> Ini
     await session.commit()
     await session.refresh(fresh)
     return fresh
+
+
+async def billing_guild_ref(guild_id: int) -> str:
+    """The reference the billing service knows one guild by, minted on demand.
+
+    Billing names a guild by its reference and never by a row id, so a test
+    that posts to the billing boundary needs the value that boundary would
+    actually receive — which is the one the service itself would mint.
+    """
+    from app.services.platform import identity_refs
+
+    return await identity_refs.billing_guild_ref(guild_id=guild_id)


### PR DESCRIPTION
## Problem

Billing keys on an id of its own now, so a row id of ours means nothing to it. Every verb across that boundary still named its guild with one.

The handoff tokens were the other half: #1528 added `user_ref`/`guild_ref` alongside the raw `sub` and `guild_id` so billing could switch over. Billing has (Morelitea/initiative_billing#52, #53), so the raw pair can go.

## Changes

**The endpoints billing calls**
- `POST /billing/guild-tier` and `POST /billing/usage` take `guild_ref` and echo it back — no row id of ours travels outward at all.
- `_resolve_guild` is the one edge that turns a reference into a guild id; everything past it works on the id as before, so `set_billing_context`, `apply_guild_tier` and the RLS routing are untouched.
- A reference minted for a **user**, or for another **purpose**, is not an answer to which guild this is: both 404, as does one this deployment never issued. All three with nothing consumed, which is the same retryable shape as a guild that does not exist yet.

**The membership ping** carries the reference too.

**Both handoff tokens** drop the raw `sub` and `guild_id`:
- `sub` now carries the user's reference. That is what a pairwise pseudonymous identifier is *for* — OpenID Connect Core §8.1 defines it as the subject claim — so this is the standards-correct reading rather than a workaround. Billing requires `sub` to be present and reads identity from `user_ref`; both agree.
- The support token's `approver` is a reference like everyone else named on it.
- Neither minter takes a row id as a **parameter** any more, so none can reach the claims by accident later.

`identity_refs` gains `billing_guild_ref` / `billing_user_ref` beside the existing `billing_refs`, for the paths that need one of the pair rather than both.

## Notes

`test_reorder_guilds` and `test_reorder_memberships` fail on clean `dev` as well — unrelated to this branch, verified by stashing.

## Testing

```
pytest app/core/security_test.py app/services/platform/ \
       app/api/v1/platform_endpoints/billing_test.py \
       app/api/v1/platform_endpoints/billing_foss_test.py
# 399 passed (+ the pre-existing reorder failure above)

pytest app/api/v1/platform_endpoints/guilds_test.py \
       app/api/v1/platform_endpoints/settings_test.py -k billing
ruff check app && ruff format app && ty check
```
