### PR TITLE
Undo a paste as the one thing it was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Work written with no connection is not lost when it returns** — a document held its editing session open for about half a minute of lost connection and then gave up on it for good, with nothing to bring it back when the network returned. Anything written in the meantime lived only in that window, and the attempt to save it on reconnect was the one kind of save a document being edited by somebody else refuses. The session now waits out an outage of any length, comes back the moment the network does, and hands over everything written while it was away — merged with whatever everyone else did in the meantime, rather than written over it. Being refused access still ends the session; losing the connection no longer does.
 
+- **Undo takes a paste back whole** — pasting a block of cells, or cutting one and putting it somewhere else, left nothing on the undo stack at all: the next undo reached past it and took back the edit made before, so it looked as though one stray cell had changed its mind. A paste is a single action again, and one press returns every cell it wrote — and, for a cut, returns the block it came from. Hiding a sheet can be undone now too, which it could not be while every other thing done to a sheet could.
+
 ## [0.67.1] - 2026-09-09
 
 ### Added

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import * as Y from "yjs";
 
 import { FormulaCellInput } from "@/components/documents/spreadsheet/FormulaCellInput";
+import { SPREADSHEET_ORIGINS } from "@/components/documents/spreadsheet/origins";
 import { SpreadsheetFindBar } from "@/components/documents/spreadsheet/SpreadsheetFindBar";
 import { SpreadsheetFormulaBar } from "@/components/documents/spreadsheet/SpreadsheetFormulaBar";
 import { SpreadsheetSheetTabs } from "@/components/documents/spreadsheet/SpreadsheetSheetTabs";
@@ -1285,7 +1286,7 @@ export const SpreadsheetDocumentEditor = ({
             formatting.updateCell(at[0], at[1], { style: fmt.style, format: fmt.format ?? null });
           }
         }
-      }, "spreadsheet-paste");
+      }, SPREADSHEET_ORIGINS.PASTE);
       if (dropped > 0) toast.info(t("documents:spreadsheet.pasteClipped", { count: dropped }));
     },
     [docForData, bulkUpdate, bulkUpdateOn, formatting, grid, t]
@@ -1372,7 +1373,7 @@ export const SpreadsheetDocumentEditor = ({
           cellStyles: result.cellStyles,
           frozen: formatting.frozen,
         });
-      }, "spreadsheet-sort");
+      }, SPREADSHEET_ORIGINS.SORT);
     },
     [readOnly, cells, formatting, bulkUpdate, docForData]
   );
@@ -1438,7 +1439,7 @@ export const SpreadsheetDocumentEditor = ({
             for (const [key, value] of Object.entries(rewritten)) draft.set(key, value);
           });
         }
-      }, "spreadsheet-structure");
+      }, SPREADSHEET_ORIGINS.STRUCTURE);
 
       // Remap the selection along the shifted axis so it tracks the same
       // content — otherwise an insert-above leaves the stale band straddling

--- a/frontend/src/components/documents/spreadsheet/origins.ts
+++ b/frontend/src/components/documents/spreadsheet/origins.ts
@@ -1,0 +1,55 @@
+/**
+ * Every Yjs transaction origin the spreadsheet writes under, in one place.
+ *
+ * An origin is how a write says what it was. `Y.UndoManager` tracks a
+ * transaction only when its origin is one it was told about, so an origin and
+ * its undoability are the same decision — and they are made here, together,
+ * rather than in a list kept alongside the call sites.
+ *
+ * **Nesting.** Yjs flattens nested `transact` calls and keeps only the
+ * *outermost* origin. An action that wraps several store mutations in an outer
+ * `doc.transact(fn, origin)` is therefore seen as that outer origin alone; the
+ * inner ones never surface. Pasting a block is the case to remember: it writes
+ * cells, clears a cut's source and replaces formatting through three different
+ * stores, and the whole thing reaches the undo stack as {@link PASTE}.
+ */
+
+/**
+ * Origins that record something a person did. Every one of these is undoable,
+ * and one press of undo reverses exactly one of them.
+ */
+export const SPREADSHEET_ORIGINS = {
+  EDIT: "spreadsheet-edit",
+  BULK: "spreadsheet-bulk",
+  REPLACE_ALL: "spreadsheet-replace-all",
+  PASTE: "spreadsheet-paste",
+  FMT_EDIT: "spreadsheet-fmt-edit",
+  FMT_BATCH: "spreadsheet-fmt-batch",
+  FMT_REPLACE_ALL: "spreadsheet-fmt-replace-all",
+  SORT: "spreadsheet-sort",
+  STRUCTURE: "spreadsheet-structure",
+  SHEET_ADD: "spreadsheet-sheet-add",
+  SHEET_RENAME: "spreadsheet-sheet-rename",
+  SHEET_DELETE: "spreadsheet-sheet-delete",
+  SHEET_MOVE: "spreadsheet-sheet-move",
+  SHEET_DUPLICATE: "spreadsheet-sheet-duplicate",
+  SHEET_HIDDEN: "spreadsheet-sheet-hidden",
+} as const;
+
+/**
+ * Origins that bring a document into being rather than change one. Undo never
+ * reaches these: hydrating a doc is not an edit a reader made, and rolling it
+ * back would empty the sheet.
+ */
+export const SPREADSHEET_SEED_ORIGINS = {
+  BOOTSTRAP: "spreadsheet-bootstrap",
+} as const;
+
+/** What `Y.UndoManager` is told to track — the registry above, entire. */
+export const UNDOABLE_SPREADSHEET_ORIGINS: readonly string[] = Object.values(SPREADSHEET_ORIGINS);
+
+/** Every origin the spreadsheet may write under, undoable or not. */
+export const ALL_SPREADSHEET_ORIGINS: readonly string[] = [
+  ...Object.values(SPREADSHEET_ORIGINS),
+  ...Object.values(SPREADSHEET_SEED_ORIGINS),
+];

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetCells.ts
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetCells.ts
@@ -13,6 +13,8 @@ import { DEFAULT_COLS, DEFAULT_ROWS } from "@/lib/spreadsheet/bounds";
 import { type CellValue, keyOf } from "@/lib/spreadsheet/coords";
 import type { SheetId } from "@/lib/spreadsheet/sheets";
 
+import { SPREADSHEET_ORIGINS } from "./origins";
+
 /**
  * Write access to one sheet's cell map, plus its grid dimensions.
  *
@@ -149,7 +151,7 @@ export const useSpreadsheetCells = ({
       yDoc.transact(() => {
         if (value === null || value === "") cells.delete(key);
         else cells.set(key, value);
-      }, "spreadsheet-edit");
+      }, SPREADSHEET_ORIGINS.EDIT);
     },
     [yDoc, partsFor]
   );
@@ -181,7 +183,7 @@ export const useSpreadsheetCells = ({
         for (const key of prev.keys()) {
           if (!next.has(key)) cells.delete(key);
         }
-      }, "spreadsheet-bulk");
+      }, SPREADSHEET_ORIGINS.BULK);
     },
     [yDoc, partsFor]
   );
@@ -203,7 +205,7 @@ export const useSpreadsheetCells = ({
         // transiently see (new cells, old dimensions).
         yMeta.set(META_ROWS, nextDimensions.rows);
         yMeta.set(META_COLS, nextDimensions.cols);
-      }, "spreadsheet-replace-all");
+      }, SPREADSHEET_ORIGINS.REPLACE_ALL);
       // A structural change is the authority on canvas size; drop the local
       // growth so deleting a band actually shrinks the grid.
       setGrown(null);

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetFormatting.ts
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetFormatting.ts
@@ -25,6 +25,8 @@ import {
   sanitizeRowFmt,
 } from "@/lib/spreadsheet/styles";
 
+import { SPREADSHEET_ORIGINS } from "./origins";
+
 /**
  * Collaborative store for one sheet's formatting structures (schema v2's
  * model, now per sheet): per-column, per-row, and per-cell style/format
@@ -242,7 +244,7 @@ export const useSpreadsheetFormatting = ({
         const next = applyColumnPatch(yColumns.get(key) as ColumnFmt, patch);
         if (next) yColumns.set(key, next);
         else yColumns.delete(key);
-      }, "spreadsheet-fmt-edit");
+      }, SPREADSHEET_ORIGINS.FMT_EDIT);
     },
     [yDoc, yColumns]
   );
@@ -259,7 +261,7 @@ export const useSpreadsheetFormatting = ({
         const next = applyRowPatch(yRows.get(key) as RowFmt, patch);
         if (next) yRows.set(key, next);
         else yRows.delete(key);
-      }, "spreadsheet-fmt-edit");
+      }, SPREADSHEET_ORIGINS.FMT_EDIT);
     },
     [yDoc, yRows]
   );
@@ -276,7 +278,7 @@ export const useSpreadsheetFormatting = ({
         const next = applyCellPatch(yCellStyles.get(key) as CellFmt, patch);
         if (next) yCellStyles.set(key, next);
         else yCellStyles.delete(key);
-      }, "spreadsheet-fmt-edit");
+      }, SPREADSHEET_ORIGINS.FMT_EDIT);
     },
     [yDoc, yCellStyles]
   );
@@ -287,14 +289,14 @@ export const useSpreadsheetFormatting = ({
       yDoc.transact(() => {
         yMeta.set(META_FROZEN_ROWS, clampFrozen(next.rows));
         yMeta.set(META_FROZEN_COLS, clampFrozen(next.cols));
-      }, "spreadsheet-fmt-edit");
+      }, SPREADSHEET_ORIGINS.FMT_EDIT);
     },
     [yDoc, yMeta]
   );
 
   const batch = useCallback(
     (fn: () => void) => {
-      if (yDoc) yDoc.transact(fn, "spreadsheet-fmt-batch");
+      if (yDoc) yDoc.transact(fn, SPREADSHEET_ORIGINS.FMT_BATCH);
       else fn();
     },
     [yDoc]
@@ -315,7 +317,7 @@ export const useSpreadsheetFormatting = ({
         for (const [k, v] of Object.entries(next.cellStyles)) yCellStyles.set(k, v);
         yMeta.set(META_FROZEN_ROWS, clampFrozen(next.frozen.rows));
         yMeta.set(META_FROZEN_COLS, clampFrozen(next.frozen.cols));
-      }, "spreadsheet-fmt-replace-all");
+      }, SPREADSHEET_ORIGINS.FMT_REPLACE_ALL);
     },
     [yDoc, yColumns, yRows, yCellStyles, yMeta]
   );

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetHistory.test.ts
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetHistory.test.ts
@@ -1,0 +1,173 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+
+import { createYjsUndoManager } from "@/hooks/useYjsHistory";
+import { DEFAULT_SHEET_ID } from "@/lib/spreadsheet/sheets";
+
+import {
+  ALL_SPREADSHEET_ORIGINS,
+  SPREADSHEET_ORIGINS,
+  SPREADSHEET_SEED_ORIGINS,
+  UNDOABLE_SPREADSHEET_ORIGINS,
+} from "./origins";
+import {
+  ensureSheetContainer,
+  SHEET_CELLS,
+  sheetContainer,
+  sheetPart,
+  Y_SHEETS_KEY,
+} from "./workbookDoc";
+
+/** The scope `useSpreadsheetHistory` uses, so these exercise the real wiring. */
+const scope = (doc: Y.Doc) => [doc.getMap(Y_SHEETS_KEY)];
+
+const undoManagerFor = (doc: Y.Doc) =>
+  createYjsUndoManager(doc, {
+    getScope: scope,
+    trackedOrigins: UNDOABLE_SPREADSHEET_ORIGINS,
+  })!;
+
+/** A workbook with one sheet, seeded the way the editor seeds it. */
+const workbook = () => {
+  const doc = new Y.Doc();
+  doc.transact(() => {
+    ensureSheetContainer(doc, DEFAULT_SHEET_ID);
+  }, SPREADSHEET_SEED_ORIGINS.BOOTSTRAP);
+  return doc;
+};
+
+const cellsOf = (doc: Y.Doc) =>
+  sheetPart(sheetContainer(doc, DEFAULT_SHEET_ID), SHEET_CELLS) as Y.Map<unknown>;
+
+describe("spreadsheet undo", () => {
+  it("takes a pasted block back in one press", () => {
+    const doc = workbook();
+    const um = undoManagerFor(doc);
+    const cells = cellsOf(doc);
+    doc.transact(() => cells.set("0:0", "kept"), SPREADSHEET_ORIGINS.EDIT);
+
+    // A paste writes every cell of the block inside one outer transaction.
+    doc.transact(() => {
+      cells.set("1:0", "a");
+      cells.set("1:1", "b");
+      cells.set("2:0", "c");
+      cells.set("2:1", "d");
+    }, SPREADSHEET_ORIGINS.PASTE);
+
+    expect(um.undoStack.length).toBe(2);
+
+    um.undo();
+
+    // The whole block goes, and only the block.
+    expect(cells.has("1:0")).toBe(false);
+    expect(cells.has("1:1")).toBe(false);
+    expect(cells.has("2:0")).toBe(false);
+    expect(cells.has("2:1")).toBe(false);
+    expect(cells.get("0:0")).toBe("kept");
+  });
+
+  it("takes a cut's move back in one press, source and destination", () => {
+    const doc = workbook();
+    const cells = cellsOf(doc);
+    doc.transact(() => {
+      cells.set("0:0", "moving");
+    }, SPREADSHEET_ORIGINS.EDIT);
+    const um = undoManagerFor(doc);
+
+    // A cut clears its source in the same transaction as the write.
+    doc.transact(() => {
+      cells.delete("0:0");
+      cells.set("5:5", "moving");
+    }, SPREADSHEET_ORIGINS.PASTE);
+
+    um.undo();
+
+    expect(cells.get("0:0")).toBe("moving");
+    expect(cells.has("5:5")).toBe(false);
+  });
+
+  it("makes hiding a sheet undoable, like every other sheet action", () => {
+    const doc = workbook();
+    const um = undoManagerFor(doc);
+    const container = sheetContainer(doc, DEFAULT_SHEET_ID)!;
+
+    doc.transact(() => {
+      (container.get("meta") as Y.Map<unknown>).set("hidden", true);
+    }, SPREADSHEET_ORIGINS.SHEET_HIDDEN);
+
+    expect(um.undoStack.length).toBe(1);
+    um.undo();
+    expect((container.get("meta") as Y.Map<unknown>).get("hidden")).toBeUndefined();
+  });
+
+  it("never undoes the seeding of a document", () => {
+    const doc = new Y.Doc();
+    const um = undoManagerFor(doc);
+    doc.transact(() => {
+      ensureSheetContainer(doc, DEFAULT_SHEET_ID);
+    }, SPREADSHEET_SEED_ORIGINS.BOOTSTRAP);
+
+    expect(um.undoStack.length).toBe(0);
+  });
+});
+
+// ── the registry is the only list ────────────────────────────────────────────
+
+const SOURCE_DIRS = [
+  __dirname, // the spreadsheet hooks
+  join(__dirname, ".."), // components/documents, for the editor itself
+];
+
+/** Every `"spreadsheet-…"` string literal written in the spreadsheet source. */
+const originLiteralsInSource = (): Set<string> => {
+  const found = new Set<string>();
+  for (const dir of SOURCE_DIRS) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      if (!/\.tsx?$/.test(entry.name)) continue;
+      if (entry.name.includes(".test.")) continue;
+      if (entry.name === "origins.ts") continue;
+      const text = readFileSync(join(dir, entry.name), "utf8");
+      for (const [, literal] of text.matchAll(/"(spreadsheet-[a-z-]+)"/g)) {
+        found.add(literal);
+      }
+    }
+  }
+  return found;
+};
+
+describe("spreadsheet transaction origins", () => {
+  it("are written as constants, never as bare strings", () => {
+    // A bare literal is how an origin comes into being without anyone deciding
+    // whether undo should reach it — which is the way paste arrived.
+    expect([...originLiteralsInSource()]).toEqual([]);
+  });
+
+  it("hold no entry that nothing writes under", () => {
+    const used = new Set<string>();
+    for (const dir of SOURCE_DIRS) {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isFile() || !/\.tsx?$/.test(entry.name)) continue;
+        if (entry.name.includes(".test.") || entry.name === "origins.ts") continue;
+        const text = readFileSync(join(dir, entry.name), "utf8");
+        for (const [, key] of text.matchAll(/SPREADSHEET_(?:SEED_)?ORIGINS\.([A-Z_]+)/g)) {
+          used.add(key);
+        }
+      }
+    }
+    const declared = [
+      ...Object.keys(SPREADSHEET_ORIGINS),
+      ...Object.keys(SPREADSHEET_SEED_ORIGINS),
+    ];
+    expect([...declared].filter((k) => !used.has(k))).toEqual([]);
+  });
+
+  it("are undoable unless they seed a document", () => {
+    expect(UNDOABLE_SPREADSHEET_ORIGINS).toContain(SPREADSHEET_ORIGINS.PASTE);
+    expect(UNDOABLE_SPREADSHEET_ORIGINS).not.toContain(SPREADSHEET_SEED_ORIGINS.BOOTSTRAP);
+    expect(ALL_SPREADSHEET_ORIGINS).toContain(SPREADSHEET_SEED_ORIGINS.BOOTSTRAP);
+  });
+});

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetHistory.ts
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetHistory.ts
@@ -1,5 +1,6 @@
 import type * as Y from "yjs";
 
+import { UNDOABLE_SPREADSHEET_ORIGINS } from "@/components/documents/spreadsheet/origins";
 import { Y_SHEETS_KEY } from "@/components/documents/spreadsheet/workbookDoc";
 import { useYjsHistory, type YjsHistory } from "@/hooks/useYjsHistory";
 
@@ -7,40 +8,10 @@ import { useYjsHistory, type YjsHistory } from "@/hooks/useYjsHistory";
  * Per-session undo/redo for the spreadsheet — a thin adapter over the
  * generic {@link useYjsHistory} primitive. The data hooks
  * (`useSpreadsheetCells` / `useSpreadsheetFormatting`) already funnel
- * every mutation through `doc.transact(fn, origin)`; this just tells
- * the shared `Y.UndoManager` which shared types and which origins
- * represent undoable user actions.
+ * every mutation through `doc.transact(fn, origin)`; this tells the
+ * shared `Y.UndoManager` which shared types to watch, and takes which
+ * origins are undoable from the one registry that defines them.
  */
-
-// Every spreadsheet transaction origin that represents a user action.
-// Bootstrap/seed origins ("spreadsheet-bootstrap",
-// "spreadsheet-fmt-bootstrap") are intentionally excluded so hydrating
-// a fresh doc is never undoable. CSV/XLSX import IS included so a
-// fat-fingered import is a single undo step.
-//
-// IMPORTANT: an action that wraps several store mutations in an *outer*
-// `doc.transact(fn, origin)` must list that OUTER origin here, not the
-// inner store origins. Yjs flattens nested transacts and keeps only the
-// outermost origin, so "spreadsheet-sort" / "spreadsheet-structure" (the
-// sort and row/column insert/delete wrappers) are what the UndoManager
-// actually sees — the inner "spreadsheet-bulk" / "spreadsheet-fmt-*"
-// origins never surface for those ops.
-const SPREADSHEET_UNDO_ORIGINS = [
-  "spreadsheet-edit",
-  "spreadsheet-bulk",
-  "spreadsheet-replace-all",
-  "spreadsheet-fmt-edit",
-  "spreadsheet-fmt-batch",
-  "spreadsheet-fmt-replace-all",
-  "spreadsheet-import",
-  "spreadsheet-sort",
-  "spreadsheet-structure",
-  "spreadsheet-sheet-add",
-  "spreadsheet-sheet-rename",
-  "spreadsheet-sheet-delete",
-  "spreadsheet-sheet-move",
-  "spreadsheet-sheet-duplicate",
-] as const;
 
 // Everything a spreadsheet owns hangs off the single `sheets` map (see
 // `workbookDoc.ts`), and a `Y.UndoManager` tracks any type whose parent
@@ -52,5 +23,5 @@ export const useSpreadsheetHistory = (doc: Y.Doc | null): YjsHistory =>
   useYjsHistory({
     doc,
     getScope: spreadsheetScope,
-    trackedOrigins: SPREADSHEET_UNDO_ORIGINS,
+    trackedOrigins: UNDOABLE_SPREADSHEET_ORIGINS,
   });

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.ts
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetSheets.ts
@@ -42,6 +42,8 @@ import {
 } from "@/lib/spreadsheet/sheets";
 import type { CellFmt, ColumnFmt, RowFmt } from "@/lib/spreadsheet/styles";
 
+import { SPREADSHEET_ORIGINS } from "./origins";
+
 /**
  * The workbook level of a spreadsheet document: which sheets exist, what
  * they're called, what order the tabs sit in — and, because a formula can
@@ -244,7 +246,7 @@ export const useSpreadsheetSheets = ({
         meta?.set(META_FROZEN_ROWS, 0);
         meta?.set(META_FROZEN_COLS, 0);
         renumber(yDoc, ids);
-      }, "spreadsheet-sheet-add");
+      }, SPREADSHEET_ORIGINS.SHEET_ADD);
       return id;
     },
     [yDoc, initialContent]
@@ -276,7 +278,7 @@ export const useSpreadsheetSheets = ({
           });
           for (const [key, value] of rewrites) cells.set(key, value);
         }
-      }, "spreadsheet-sheet-rename");
+      }, SPREADSHEET_ORIGINS.SHEET_RENAME);
       return name;
     },
     [yDoc]
@@ -293,7 +295,7 @@ export const useSpreadsheetSheets = ({
           yDoc,
           current.filter((s) => s.id !== id).map((s) => s.id)
         );
-      }, "spreadsheet-sheet-delete");
+      }, SPREADSHEET_ORIGINS.SHEET_DELETE);
       return true;
     },
     [yDoc]
@@ -312,7 +314,7 @@ export const useSpreadsheetSheets = ({
         // instead of storing a negative in every saved workbook.
         if (hidden) meta?.set(META_HIDDEN, true);
         else meta?.delete(META_HIDDEN);
-      }, "spreadsheet-sheet-hidden");
+      }, SPREADSHEET_ORIGINS.SHEET_HIDDEN);
       return true;
     },
     [yDoc]
@@ -327,7 +329,7 @@ export const useSpreadsheetSheets = ({
       const to = Math.max(0, Math.min(ids.length - 1, from + delta));
       if (to === from) return;
       ids.splice(to, 0, ...ids.splice(from, 1));
-      yDoc.transact(() => renumber(yDoc, ids), "spreadsheet-sheet-move");
+      yDoc.transact(() => renumber(yDoc, ids), SPREADSHEET_ORIGINS.SHEET_MOVE);
     },
     [yDoc]
   );
@@ -363,7 +365,7 @@ export const useSpreadsheetSheets = ({
         meta?.set(META_FROZEN_ROWS, readInt(sourceMeta, META_FROZEN_ROWS, 0));
         meta?.set(META_FROZEN_COLS, readInt(sourceMeta, META_FROZEN_COLS, 0));
         renumber(yDoc, ids);
-      }, "spreadsheet-sheet-duplicate");
+      }, SPREADSHEET_ORIGINS.SHEET_DUPLICATE);
       return copyId;
     },
     [yDoc]

--- a/frontend/src/components/documents/spreadsheet/workbookDoc.ts
+++ b/frontend/src/components/documents/spreadsheet/workbookDoc.ts
@@ -31,6 +31,8 @@ import * as Y from "yjs";
 import type { SpreadsheetContent, SpreadsheetSheetContent } from "@/lib/spreadsheet/content";
 import { DEFAULT_SHEET_ID, type SheetId, type SheetMeta } from "@/lib/spreadsheet/sheets";
 
+import { SPREADSHEET_SEED_ORIGINS } from "./origins";
+
 export const Y_SHEETS_KEY = "sheets";
 
 /** Keys of a sheet container. */
@@ -194,5 +196,5 @@ export const ensureWorkbook = (doc: Y.Doc | null, content: SpreadsheetContent): 
     content.sheets.forEach((sheet, index) => {
       seedSheet(doc, sheet, index);
     });
-  }, "spreadsheet-bootstrap");
+  }, SPREADSHEET_SEED_ORIGINS.BOOTSTRAP);
 };


### PR DESCRIPTION
## Problem

Paste several cells into a sheet, press Ctrl+Z, and one unrelated cell changes instead of the paste coming back.

`writeBlock` already does the right thing — it wraps the cell writes, the cut's source clear and the formatting replace in a single outer `docForData.transact(fn, "spreadsheet-paste")`, and its comment says so. But `"spreadsheet-paste"` was never added to `SPREADSHEET_UNDO_ORIGINS`, and Yjs flattens nested transacts down to the **outermost** origin. So the undo manager saw an origin it wasn't tracking and recorded **nothing** — a paste produced zero undo entries, and the next Ctrl+Z reached past it to the single-cell edit before, which is the "one stray cell" people see.

`useSpreadsheetHistory.ts` carries a long comment warning about exactly this trap. The list it warns you to update is the one that was out of date.

It had drifted in both directions:

| Origin | In source | In tracked list |
|---|---|---|
| `spreadsheet-paste` | ✅ | ❌ — this bug |
| `spreadsheet-sheet-hidden` | ✅ | ❌ — hiding a sheet was not undoable |
| `spreadsheet-import` | ❌ | ✅ — nothing writes under it |
| `spreadsheet-fmt-bootstrap` | ❌ (a comment only) | ✅ |

## Changes

Appending two strings would fix today's symptom and leave the mechanism that produced it. Instead, [origins.ts](frontend/src/components/documents/spreadsheet/origins.ts) is now the one place an origin exists, split by the question that matters:

- `SPREADSHEET_ORIGINS` — things a person did. Undoable, one press each.
- `SPREADSHEET_SEED_ORIGINS` — bringing a document into being. Undo never reaches these.
- `UNDOABLE_SPREADSHEET_ORIGINS` is derived, so registering an origin and deciding its undoability are one act.

All 16 call sites across five files use the constants, and `useSpreadsheetHistory` takes its tracked list from the registry — the parallel list is gone. The two stale entries are dropped.

## Testing

```
cd frontend && pnpm vitest run src/components/documents/spreadsheet/ \
                               src/hooks/useYjsHistory.test.ts \
                               src/lib/spreadsheet/          # 340 passed (18 files)
cd frontend && pnpm lint && pnpm exec tsc --noEmit           # clean
```

New coverage in `useSpreadsheetHistory.test.ts`, against a real `Y.UndoManager` with the real scope and origins:

- a pasted block goes back in one press, and only the block
- a cut's move goes back in one press — destination cleared, source restored
- hiding a sheet is undoable
- seeding a document is not

Plus two guards so the list cannot drift again: no bare `"spreadsheet-…"` literal anywhere in the spreadsheet source, and no registry entry nothing writes under. **Both were verified to fail** by reintroducing a bare literal — they caught the literal *and* the constant it orphaned.
