### PR TITLE
Resolve a draft whose sheet stops being visible

### DIFF
--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -88,6 +88,7 @@ import {
   referenceInsertTarget,
 } from "@/lib/spreadsheet/formula-refs";
 import {
+  draftResolution,
   formatSheetPrefix,
   MAX_SHEETS,
   type SheetId,
@@ -895,6 +896,17 @@ export const SpreadsheetDocumentEditor = ({
     setEditing(null);
     pointRefRef.current = null;
   }, []);
+
+  // Hiding a sheet from the menu commits the draft on it first (see
+  // ``handleSetSheetHidden``). Undo, redo and a peer reach the same state
+  // without passing through there, so the rule is applied to the sheets
+  // themselves rather than to the one action that used to change them.
+  useEffect(() => {
+    if (!editing) return;
+    const resolution = draftResolution(sheets, editing.sheetId);
+    if (resolution === "commit") commitEdit();
+    else if (resolution === "cancel") cancelEdit();
+  }, [editing, sheets, commitEdit, cancelEdit]);
 
   // Blur handler shared by the in-cell input and the formula-bar input. A blur
   // that hands focus to the *other* editing surface is a surface switch, not

--- a/frontend/src/components/documents/spreadsheet/useSpreadsheetHistory.test.ts
+++ b/frontend/src/components/documents/spreadsheet/useSpreadsheetHistory.test.ts
@@ -116,30 +116,63 @@ describe("spreadsheet undo", () => {
 
 // ── the registry is the only list ────────────────────────────────────────────
 
-const SOURCE_DIRS = [
-  __dirname, // the spreadsheet hooks
-  join(__dirname, ".."), // components/documents, for the editor itself
+/** Every tree a spreadsheet transaction can be written from. */
+const SOURCE_ROOTS = [
+  join(__dirname, ".."), // components/documents, spreadsheet/ included
+  join(__dirname, "..", "..", "..", "lib", "spreadsheet"),
 ];
 
-/** Every `"spreadsheet-…"` string literal written in the spreadsheet source. */
-const originLiteralsInSource = (): Set<string> => {
-  const found = new Set<string>();
-  for (const dir of SOURCE_DIRS) {
+/** Every source file under those trees, at any depth. */
+const sourceFiles = (): string[] => {
+  const out: string[] = [];
+  const walk = (dir: string) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (!entry.isFile()) continue;
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
       if (!/\.tsx?$/.test(entry.name)) continue;
       if (entry.name.includes(".test.")) continue;
       if (entry.name === "origins.ts") continue;
-      const text = readFileSync(join(dir, entry.name), "utf8");
-      for (const [, literal] of text.matchAll(/"(spreadsheet-[a-z-]+)"/g)) {
-        found.add(literal);
-      }
+      out.push(path);
+    }
+  };
+  for (const root of SOURCE_ROOTS) walk(root);
+  return out;
+};
+
+/** Every `"spreadsheet-…"` string literal written outside the registry. */
+const originLiteralsInSource = (): Set<string> => {
+  const found = new Set<string>();
+  for (const file of sourceFiles()) {
+    for (const [, literal] of readFileSync(file, "utf8").matchAll(/"(spreadsheet-[a-z-]+)"/g)) {
+      found.add(literal);
     }
   }
   return found;
 };
 
+/** Every registry key the source actually writes under. */
+const originKeysUsed = (): Set<string> => {
+  const used = new Set<string>();
+  for (const file of sourceFiles()) {
+    for (const [, key] of readFileSync(file, "utf8").matchAll(
+      /SPREADSHEET_(?:SEED_)?ORIGINS\.([A-Z_]+)/g
+    )) {
+      used.add(key);
+    }
+  }
+  return used;
+};
+
 describe("spreadsheet transaction origins", () => {
+  it("finds the source it is meant to be guarding", () => {
+    // A guard that reads nothing passes forever.
+    expect(sourceFiles().length).toBeGreaterThan(10);
+    expect(originKeysUsed().size).toBeGreaterThan(10);
+  });
+
   it("are written as constants, never as bare strings", () => {
     // A bare literal is how an origin comes into being without anyone deciding
     // whether undo should reach it — which is the way paste arrived.
@@ -147,22 +180,12 @@ describe("spreadsheet transaction origins", () => {
   });
 
   it("hold no entry that nothing writes under", () => {
-    const used = new Set<string>();
-    for (const dir of SOURCE_DIRS) {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (!entry.isFile() || !/\.tsx?$/.test(entry.name)) continue;
-        if (entry.name.includes(".test.") || entry.name === "origins.ts") continue;
-        const text = readFileSync(join(dir, entry.name), "utf8");
-        for (const [, key] of text.matchAll(/SPREADSHEET_(?:SEED_)?ORIGINS\.([A-Z_]+)/g)) {
-          used.add(key);
-        }
-      }
-    }
+    const used = originKeysUsed();
     const declared = [
       ...Object.keys(SPREADSHEET_ORIGINS),
       ...Object.keys(SPREADSHEET_SEED_ORIGINS),
     ];
-    expect([...declared].filter((k) => !used.has(k))).toEqual([]);
+    expect(declared.filter((key) => !used.has(key))).toEqual([]);
   });
 
   it("are undoable unless they seed a document", () => {

--- a/frontend/src/lib/spreadsheet/sheets.test.ts
+++ b/frontend/src/lib/spreadsheet/sheets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  draftResolution,
   formatSheetPrefix,
   MAX_SHEET_NAME_LENGTH,
   needsSheetQuoting,
@@ -101,5 +102,28 @@ describe("newSheetId", () => {
     const ids = new Set(Array.from({ length: 50 }, () => newSheetId()));
     expect(ids.size).toBe(50);
     for (const id of ids) expect(id).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});
+
+describe("draftResolution", () => {
+  const visible = [{ id: "s1", name: "Sheet1" }];
+  const hidden = [{ id: "s1", name: "Sheet1", hidden: true }];
+
+  it("leaves an edit alone while its sheet is on screen", () => {
+    expect(draftResolution(visible, "s1")).toBe("keep");
+  });
+
+  it("commits an edit whose sheet has been hidden", () => {
+    // The sheet still holds the value, so the edit belongs in it — the same
+    // rule the hide menu applies before it hides anything.
+    expect(draftResolution(hidden, "s1")).toBe("commit");
+  });
+
+  it("drops an edit whose sheet has gone", () => {
+    expect(draftResolution(visible, "s2")).toBe("cancel");
+  });
+
+  it("has nothing to say when nothing is being edited", () => {
+    expect(draftResolution(visible, null)).toBe("keep");
   });
 });

--- a/frontend/src/lib/spreadsheet/sheets.ts
+++ b/frontend/src/lib/spreadsheet/sheets.ts
@@ -144,3 +144,23 @@ export const newSheetId = (): SheetId => {
   if (uuid) return `s${uuid.replace(/-/g, "").slice(0, 12)}`;
   return `s${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36).slice(-4)}`;
 };
+
+/**
+ * What to do with an in-progress cell edit, given the sheets that now exist.
+ *
+ * A draft belongs to the sheet it was started on, and that sheet can stop
+ * being available without going through the menu that hides it — an undo, a
+ * redo, or a peer doing either. The rule is the same wherever it happens:
+ * a sheet that is merely hidden still holds the value, so the edit is
+ * committed into it; a sheet that is gone has nowhere to put one, so the
+ * draft is dropped.
+ */
+export const draftResolution = (
+  sheets: readonly SheetMeta[],
+  editingSheetId: SheetId | null
+): "keep" | "commit" | "cancel" => {
+  if (!editingSheetId) return "keep";
+  const sheet = sheets.find((s) => s.id === editingSheetId);
+  if (!sheet) return "cancel";
+  return sheet.hidden ? "commit" : "keep";
+};


### PR DESCRIPTION
Review follow-up to #1539, which merged before these two findings were addressed.

## 1. A draft stranded on a hidden sheet

`handleSetSheetHidden` deliberately commits the edit in progress before hiding:

```ts
// Hiding the sheet being edited would leave the draft with nowhere
// visible to land, so the edit is committed first.
if (hidden && editing?.sheetId === id) commitEdit();
```

#1539 made `SHEET_HIDDEN` undoable, which added two more ways to reach that state — undo and redo — neither of which passes through the menu. (A peer hiding the sheet was always a third, so this was partly pre-existing.) The grid falls back to a visible sheet, `editing` keeps pointing at the hidden one, and `commitEdit` writes into a sheet nobody can see.

Rather than add the same guard to each new route, the rule now belongs to the sheets rather than to the one action that used to change them. [`draftResolution(sheets, editingSheetId)`](frontend/src/lib/spreadsheet/sheets.ts) answers `keep` / `commit` / `cancel`, and the editor applies it wherever the sheet list changes:

- **hidden** → commit. The sheet still holds the value, so the edit belongs in it — the same answer the menu gives.
- **gone** → cancel. There is nowhere to put it.
- **visible** → keep.

This covers undo, redo and a peer with one rule, and it is a pure function, so the behaviour is tested directly rather than through the editor.

## 2. The drift guards read only two directories

The origin guards added in #1539 scanned the top level of `spreadsheet/` and `components/documents/` — not recursively, and not `lib/spreadsheet/`. A bare origin in a nested file would have slipped past the very guards meant to stop it.

They now walk both trees to any depth, `lib/spreadsheet/` included. A third test asserts the walk is finding files and constants at all, because **a guard that reads nothing passes forever** — which is exactly the failure mode that made the first version weak.

## Testing

```
cd frontend && pnpm vitest run src/lib/spreadsheet/ src/components/documents/spreadsheet/   # 338 passed (17 files)
cd frontend && pnpm lint && pnpm exec tsc --noEmit                                          # clean
```

New: four `draftResolution` cases (on screen / hidden / gone / nothing being edited), and the guard-reaches-the-source assertion.

No changelog entry — #1539's Unreleased entry already describes this behaviour, and this is that behaviour working correctly rather than a separate user-visible change.
