### PR TITLE
Send a member to connect under the guild's reference

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_app_connections_test.py
@@ -36,6 +36,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.messages import GuildAppMessages, MarketplaceMessages
 from app.models.platform.guild import GuildRole
 from app.models.tenant.guild_app_user_connection import GuildAppUserConnection
+from app.services.marketplace.app_refs import ensure_app_guild_ref
 from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.services.tenant import app_revocation
 from app.testing import (
@@ -414,7 +415,9 @@ class TestConnect:
         )
         query = parse_qs(connect.query)
         assert query["connection_ref"] == [body["connection_ref"]]
-        assert query["guild_id"] == [str(a.guild.id)]
+        assert query["guild_ref"] == [
+            await ensure_app_guild_ref(guild_id=a.guild.id, app_install_id=app.id)
+        ]
 
     async def test_the_handle_is_opaque_and_carries_nothing_about_the_person(
         self, client: AsyncClient, acting_user, session: AsyncSession
@@ -509,7 +512,9 @@ class TestConnect:
         )
         query = parse_qs(connect.query)
         assert query["connection_ref"] == [body["connection_ref"]]
-        assert query["guild_id"] == [str(a.guild.id)]
+        assert query["guild_ref"] == [
+            await ensure_app_guild_ref(guild_id=a.guild.id, app_install_id=app.id)
+        ]
 
         # On the install row, because that is where a guild-wide credential
         # lives — and no member row was minted for it.

--- a/backend/app/api/v1/tenant_endpoints/guild_apps.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps.py
@@ -874,7 +874,9 @@ async def connect_guild_app(
 
     return await _connect_start(
         registration,
-        guild_id=app.guild_id,
+        guild_ref=await app_refs.ensure_app_guild_ref(
+            guild_id=app.guild_id, app_install_id=app.id
+        ),
         connection_id=row.connection_id,
         connection_ref=row.connection_ref,
         connect_path=connect_path,
@@ -926,7 +928,9 @@ async def _start_guild_connect(
     )
     return await _connect_start(
         registration,
-        guild_id=app.guild_id,
+        guild_ref=await app_refs.ensure_app_guild_ref(
+            guild_id=app.guild_id, app_install_id=app.id
+        ),
         connection_id=connection_id,
         connection_ref=connection_ref,
         connect_path=connect_path,
@@ -937,7 +941,7 @@ async def _start_guild_connect(
 async def _connect_start(
     registration: Any,
     *,
-    guild_id: int,
+    guild_ref: str,
     connection_id: str,
     connection_ref: str,
     connect_path: str,
@@ -950,12 +954,13 @@ async def _connect_start(
 
     The guild travels with the ref because the channel addresses every install
     by guild: the app writes its result back to
-    ``/installs/{guild_id}/connections/{ref}``, and a ref on its own names
-    nothing it can look up.
+    ``/installs/{guild_ref}/connections/{ref}``, and a ref on its own names
+    nothing it can look up. It is the reference minted for this install — the
+    same name the app is given everywhere else — and not a row id.
     """
     query = [
         ("connection_ref", connection_ref),
-        ("guild_id", str(guild_id)),
+        ("guild_ref", guild_ref),
     ]
     query += await _return_address(registration.public_id, connection_id)
 

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -929,7 +929,7 @@ class TestConnectLaunch:
         # URL, which is why it travels here and the secret does not.
         assert set(parse_qs(query)) == {
             "connection_ref",
-            "guild_id",
+            "guild_ref",
             "return_url",
             "return_sig",
         }

--- a/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
+++ b/backend/app/api/v1/tenant_endpoints/guild_apps_platform_test.py
@@ -43,7 +43,7 @@ from app.core.messages import (
 )
 from app.models.platform.app_service_registration import AppServiceStatus
 from app.models.platform.guild import GuildRole
-from app.services.marketplace.app_refs import ensure_app_ref
+from app.services.marketplace.app_refs import ensure_app_guild_ref, ensure_app_ref
 from app.services.marketplace.registration_lookup import invalidate_registrations
 from app.testing import (
     create_app_service_registration,
@@ -881,7 +881,9 @@ class TestConnectLaunch:
         )
         query = parse_qs(urlsplit(body["connect_url"]).query)
         assert query["connection_ref"] == [body["connection_ref"]]
-        assert query["guild_id"] == [str(a.guild.id)]
+        assert query["guild_ref"] == [
+            await ensure_app_guild_ref(guild_id=a.guild.id, app_install_id=app.id)
+        ]
 
     async def test_the_url_uses_the_browser_address(
         self, client: AsyncClient, acting_user, session: AsyncSession, registration


### PR DESCRIPTION
## Problem

#1542 moved `/installs/{guild_ref}/connections/{ref}` onto the reference, but left the URL that feeds it behind.

The connect URL Initiative builds for a vendor flow still carried `guild_id`, and the app uses exactly what it finds there to write the result back. So the two halves of one flow disagreed: the app is handed a row id and asked to address a route that now expects a reference.

Found by following `guildFrom(params)` in the GitHub app, which reads that query parameter.

## Changes

- `_connect_start` takes and emits `guild_ref` — the reference minted for the install, the same name the app is given on every other channel and the only one it can address us with.
- Both call sites (a member's own connection and a guild-wide one) resolve it through `app_refs.ensure_app_guild_ref`.
- The three tests that pinned `query["guild_id"]` now pin the reference.

## Note

The app-kit needs nothing for this. `landing.ts` never parsed `guild_id` — it only mentions it in a sentence — so there is no functional change on that side; a fixture tidy is going up separately.

## Testing

`ruff check app`, `ruff format app`. Leaving the suite to CI.