### PR TITLE
Fix the fixtures that hid the cell-style bug

### DIFF
--- a/backend/app/api/v1/tenant_endpoints/exports_test.py
+++ b/backend/app/api/v1/tenant_endpoints/exports_test.py
@@ -583,7 +583,7 @@ async def test_document_export_spreadsheet_formats(
                 "1:0": "+not-a-formula",
                 "1:1": 42,
             },
-            "cellStyles": {"0:0": {"bold": True, "fill": "#ff0000"}},
+            "cellStyles": {"0:0": {"style": {"bold": True, "fill": "#ff0000"}}},
             "columns": {"0": {"width": 140}},
             "rows": {},
             "frozen": {"rows": 1, "cols": 0},
@@ -660,7 +660,7 @@ async def test_document_export_spreadsheet_survives_corrupt_snapshot(
             "dimensions": {"rows": 1, "cols": 1},
             "cells": {"0:0": "ok", "corrupt": "x", "1:2:3": "y", ":": "z"},
             "cellStyles": {
-                "0:0": {"fill": "#fff", "color": "not-a-color"},
+                "0:0": {"style": {"fill": "#fff", "color": "not-a-color"}},
             },
         },
     )

--- a/backend/app/services/export/spreadsheet_test.py
+++ b/backend/app/services/export/spreadsheet_test.py
@@ -163,3 +163,57 @@ def test_hidden_rows_and_columns_export_hidden() -> None:
     sheet = book.worksheets[0]
     assert sheet.column_dimensions["C"].hidden is True
     assert sheet.row_dimensions[5].hidden is True
+
+
+# ── per-cell formatting, in both shapes a document has had ───────────────────
+
+
+def _rendered(content: dict):
+    return load_workbook(io.BytesIO(render_xlsx(content, title="B"))).active
+
+
+@pytest.mark.unit
+def test_a_cells_own_look_reaches_the_workbook() -> None:
+    """A cell entry keeps its look under ``style``, beside its ``format`` —
+    the same wrapper the column and row layers use. Reading the entry as
+    though it were the look finds neither."""
+    sheet = _rendered(
+        {
+            "schema_version": 3,
+            "kind": "spreadsheet",
+            "sheets": [
+                _sheet(
+                    "S",
+                    {"0:0": 1},
+                    cellStyles={
+                        "0:0": {
+                            "style": {"bold": True, "fill": "#ff0000"},
+                            "format": {"type": "percent", "decimals": 1},
+                        }
+                    },
+                )
+            ],
+        }
+    )
+
+    cell = sheet.cell(row=1, column=1)
+    assert cell.font.bold is True
+    assert cell.fill.start_color.rgb == "FFFF0000"
+    assert cell.number_format == "0.0%"
+
+
+@pytest.mark.unit
+def test_a_column_look_still_reaches_the_workbook() -> None:
+    """Column and row layers have always used the wrapper; a cell layer that
+    does must not cost them theirs."""
+    sheet = _rendered(
+        {
+            "schema_version": 3,
+            "kind": "spreadsheet",
+            "sheets": [
+                _sheet("S", {"0:0": 1}, columns={"0": {"style": {"italic": True}}})
+            ],
+        }
+    )
+
+    assert sheet.cell(row=1, column=1).font.italic is True

--- a/backend/app/services/tenant/documents_spreadsheet_test.py
+++ b/backend/app/services/tenant/documents_spreadsheet_test.py
@@ -144,3 +144,23 @@ def test_hidden_sheet_is_kept_when_another_is_shown() -> None:
         }
     )
     assert [sheet.get("hidden") for sheet in normalized["sheets"]] == [None, True]
+
+
+@pytest.mark.unit
+def test_a_cell_entry_keeps_its_wrapper() -> None:
+    content = normalize_spreadsheet_content(
+        {
+            "schema_version": 3,
+            "kind": "spreadsheet",
+            "sheets": [
+                {
+                    "id": "s1",
+                    "name": "S",
+                    "cells": {"0:0": 1},
+                    "cellStyles": {"0:0": {"style": {"italic": True}}},
+                }
+            ],
+        }
+    )
+
+    assert content["sheets"][0]["cellStyles"]["0:0"] == {"style": {"italic": True}}


### PR DESCRIPTION
Fixes the two `exports_test.py` failures on `dev` after #1543.

## What happened

#1543 changed the renderer to read a cell's formatting entry the way the column and row layers are read — out of `style`. That is where `CellFmt` has kept it since `167ac72a5`, the commit that introduced cell formatting at all:

```ts
export interface CellFmt {
  style?: CellStyle;
  format?: NumberFormat;
}
```

Two export tests then failed, because they build their content through `create_document`, which does **not** normalize, and put the look at the entry's top level:

```python
"cellStyles": {"0:0": {"bold": True, "fill": "#ff0000"}},
```

No client produces that, and `_normalize_cellstyles` has always read `entry.get("style")` — a flat entry normalizes to nothing. The shape exists only in these two fixtures.

Reading the entry as though it were the look is what made them pass. It is also what dropped per-cell bold, fill, colour, alignment and borders from **every real export**, because a real document holds the wrapper. The tests were green on the bug and red on the fix.

## The change

The fixtures now use the shape a document actually holds. The renderer is unchanged from #1543.

My first attempt at this added a fallback so the renderer accepted both shapes, and an upcast in the normalizer to match. Both are reverted — they add support for something that never shipped, and the flat shape has no source to come from.

Worth separating, since it tripped me up: `schema_version` (1 → 2 → 3) tracks the **workbook layout** — a single sheet at the top level became a `sheets` array in `1b9d35241`. It says nothing about the `cellStyles` entry shape, which has been the `{style, format}` wrapper throughout.

## Testing

```
cd backend && pytest -n 0 app/services/export/spreadsheet_test.py \
                          app/services/tenant/documents_spreadsheet_test.py \
                          app/services/tenant/spreadsheet_import_test.py   # 42 passed
cd backend && ruff check app && ruff format app && ty check                # clean
```

New unit coverage pins both sides without a database: the renderer carries a cell's `style` and `format` through to the workbook, a column's `style` still reaches it, and the normalizer keeps the wrapper intact.

`exports_test.py` is DB-backed, so I did not run it — but I rendered both corrected fixtures directly through `render_xlsx` and checked the exact assertions: `font.bold is True`, `freeze_panes == "A2"`, and `fill.start_color.rgb == "FFFFFFFF"` for the `#fff` shorthand.
