### PR TITLE
Green the checks dev is failing

### DIFF
--- a/backend/alembic/versions/20260909_0239_guild_base_read_role.py
+++ b/backend/alembic/versions/20260909_0239_guild_base_read_role.py
@@ -91,13 +91,18 @@ def downgrade() -> None:
             EXECUTE format(
                 'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA public '
                 'REVOKE SELECT ON TABLES FROM {ROLE}', current_user);
+            -- The member's name, from pg_roles, rather than its oid cast to
+            -- regrole: a membership whose role is already gone renders as a
+            -- bare number, which is not an identifier REVOKE can take. Joining
+            -- pg_roles drops those rows, and %I quotes what is left.
             FOR holder IN
-                SELECT m.member::regrole AS who
+                SELECT r.rolname AS who
                 FROM pg_auth_members m
                 JOIN pg_roles g ON g.oid = m.roleid
+                JOIN pg_roles r ON r.oid = m.member
                 WHERE g.rolname = '{ROLE}'
             LOOP
-                EXECUTE format('REVOKE {ROLE} FROM %s', holder.who);
+                EXECUTE format('REVOKE {ROLE} FROM %I', holder.who);
             END LOOP;
             REVOKE ALL ON ALL TABLES IN SCHEMA public FROM {ROLE};
             -- Sequences are not granted on the way up. Revoked anyway, so a

--- a/backend/app/core/webhook_events.py
+++ b/backend/app/core/webhook_events.py
@@ -43,9 +43,12 @@ def _vocabulary() -> dict[str, frozenset[str]]:
     for spec in build_specs():
         if spec.facet is not None:
             # A polymorphic facet reports against any of several parents, and
-            # every one of them can name the label.
+            # every one of them can name the label. A facet the ROW decides
+            # brings its whole vocabulary: an edge says ``tags`` or
+            # ``attachments`` depending on what it is, and both are nameable.
+            labels = spec.facet_values or {spec.facet}
             for resource in spec.resource_types:
-                fields.setdefault(resource, set()).add(spec.facet)
+                fields.setdefault(resource, set()).update(labels)
             continue
         bucket = fields.setdefault(spec.static_resource_type, set())
         table = SQLModel.metadata.tables[spec.table]

--- a/backend/app/db/event_capture.py
+++ b/backend/app/db/event_capture.py
@@ -125,6 +125,9 @@ class CaptureSpec:
     #: the row holds. ``None`` everywhere else, and then ``facet`` is the whole
     #: answer and no per-row lookup is paid for.
     facet_expr: str | None = None
+    #: Every label ``facet_expr`` can yield, for the vocabularies that have to
+    #: know the names before a row exists. Empty where ``facet`` is the answer.
+    facet_values: frozenset[str] = frozenset()
     #: Row expression yielding the initiative this trigger's events are scoped
     #: to, where the table's own answer is not this report's. ``None`` leaves
     #: the table's registry entry to answer, which is the ordinary case.
@@ -326,6 +329,7 @@ def build_specs() -> list[CaptureSpec]:
                             if report.facet_expr is not None
                             else None
                         ),
+                        facet_values=report.facet_values,
                         initiative_expr=(
                             report.initiative_expr(ROW)
                             if report.initiative_expr is not None

--- a/backend/app/db/initiative_rls.py
+++ b/backend/app/db/initiative_rls.py
@@ -1331,6 +1331,11 @@ class ReportsAs:
     #: depends on the row rather than on the table. ``facet`` stays the constant
     #: the rest of the registry reads; this is what the trigger evaluates.
     facet_expr: RowLocator | None = None
+    #: Every label ``facet_expr`` can yield. The static counterpart to the
+    #: expression, the way ``resource_types`` is to ``type_expr`` — a subscriber
+    #: names a field before any row exists, so the vocabulary has to be known without
+    #: evaluating anything. Empty where ``facet`` is the whole answer.
+    facet_values: frozenset[str] = frozenset()
     #: Row expression yielding the initiative THIS report is scoped to, where
     #: the table's own answer is not the one this report wants. A table
     #: reporting against two different resources answers this twice. The parent
@@ -1453,6 +1458,7 @@ def relationships_report_on_both_ends() -> tuple[ReportsAs, ...]:
             # table; what the trigger evaluates is the expression below.
             facet=FACETS[RelationshipType.related_to],
             facet_expr=lambda r: f"(CASE {r}.relationship_type {facet_arms} END)",
+            facet_values=frozenset(FACETS.values()),
             type_expr=lambda r: f"(CASE {r}.{side}_type {type_arms} END)",
             initiative_expr=lambda r: _relationship_end(r, side, init),
             label=side,

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -257,26 +257,6 @@ OWN_ROW_TABLES: dict[str, str] = {
 # table is in neither bucket, so a new table forces the decision.
 CREATED_BY_EXEMPT_TABLES: frozenset[str] = frozenset(
     {
-        # Junctions and link rows. Each already carries its own matched pair
-        # naming the relation rather than a row author — ``attached_by_id`` /
-        # ``attached_at`` on the document links, ``created_at`` on the tag
-        # links — and the thing that was authored is the entity at either end.
-        "calendar_event_documents",
-        "calendar_event_tags",
-        "calendar_tags",
-        "counter_group_tags",
-        "dashboard_tags",
-        "document_tags",
-        "post_tags",
-        "gallery_tags",
-        "gallery_image_tags",
-        "project_documents",
-        "project_tags",
-        "queue_item_documents",
-        "queue_item_tags",
-        "queue_item_tasks",
-        "queue_tags",
-        "task_tags",
         # Roster rows: the membership IS the fact, and ``user_id`` already names
         # whose it is.
         "calendar_event_attendees",

--- a/backend/app/services/tenant/comments_test.py
+++ b/backend/app/services/tenant/comments_test.py
@@ -32,7 +32,7 @@ from app.testing import (
 
 
 @pytest.mark.integration
-async def test_task_comment_access_honors_grant(session: AsyncSession):
+async def test_task_comment_access_honors_grant(session: AsyncSession, role_session):
     owner = await create_user(session, email="owner-cmt@example.com")
     grantee = await create_user(session, email="grantee-cmt@example.com")
     guild = await create_guild(session, creator=owner)
@@ -45,32 +45,41 @@ async def test_task_comment_access_honors_grant(session: AsyncSession):
     )
     assert ctx is not None
 
+    # Asked on a session that reaches Postgres as the app does. The sharing
+    # decision is the parent table's own policy now — selecting the id IS the
+    # question — so a session that bypasses row-level security cannot answer it,
+    # and would say yes to everything below.
+    reader = await role_session("app_user")
+    await set_rls_context(reader, user_id=grantee.id, guild_id=guild.id)
+
     try:
         # No grant: a non-member is denied.
         set_active_grant(None, None)
         with pytest.raises(CommentPermissionError):
-            await _ensure_parent_access(session, ctx, user=grantee, access="read")
+            await _ensure_parent_access(reader, ctx, user=grantee, access="read")
 
-        # Read grant: may read comments, but not post.
+        # Read grant: may read comments.
         set_active_grant(guild.id, "read")
-        await _ensure_parent_access(session, ctx, user=grantee, access="read")
-        with pytest.raises(CommentPermissionError):
-            await _ensure_parent_access(session, ctx, user=grantee, access="write")
+        await _ensure_parent_access(reader, ctx, user=grantee, access="read")
 
         # Read-write grant: may post.
         set_active_grant(guild.id, "read_write")
-        await _ensure_parent_access(session, ctx, user=grantee, access="write")
+        await _ensure_parent_access(reader, ctx, user=grantee, access="write")
 
         # A grant for a different guild doesn't apply.
         set_active_grant(guild.id + 999, "read_write")
         with pytest.raises(CommentPermissionError):
-            await _ensure_parent_access(session, ctx, user=grantee, access="read")
+            await _ensure_parent_access(reader, ctx, user=grantee, access="read")
     finally:
         set_active_grant(None, None)
 
 
 @pytest.mark.integration
-async def test_document_comment_access_honors_grant(session: AsyncSession):
+async def test_document_comment_access_honors_grant(
+    session: AsyncSession, role_session
+):
+    """The other branch of the parent check: a tool entity answers for itself,
+    where a task answers through its project."""
     owner = await create_user(session, email="owner-cmt2@example.com")
     grantee = await create_user(session, email="grantee-cmt2@example.com")
     guild = await create_guild(session, creator=owner)
@@ -91,16 +100,79 @@ async def test_document_comment_access_honors_grant(session: AsyncSession):
     )
     assert ctx is not None
 
+    reader = await role_session("app_user")
+    await set_rls_context(reader, user_id=grantee.id, guild_id=guild.id)
+
     try:
-        set_active_grant(guild.id, "read")
-        await _ensure_parent_access(session, ctx, user=grantee, access="read")
+        set_active_grant(None, None)
         with pytest.raises(CommentPermissionError):
-            await _ensure_parent_access(session, ctx, user=grantee, access="write")
+            await _ensure_parent_access(reader, ctx, user=grantee, access="read")
+
+        set_active_grant(guild.id, "read")
+        await _ensure_parent_access(reader, ctx, user=grantee, access="read")
 
         set_active_grant(guild.id, "read_write")
-        await _ensure_parent_access(session, ctx, user=grantee, access="write")
+        await _ensure_parent_access(reader, ctx, user=grantee, access="write")
     finally:
         set_active_grant(None, None)
+
+
+@pytest.mark.integration
+async def test_a_read_only_grant_cannot_post(session: AsyncSession, role_session):
+    """The half of the rule the parent check no longer answers.
+
+    Reaching a thread and adding to it are different questions, and only the
+    first is "can this request see the parent". Posting is a write, and a
+    read-only window is routed into the SELECT-only guild role — so the refusal
+    is the insert's, and this is where it has to be asked.
+
+    Under the real ``app_user`` login, like the RLS legs below: a session that
+    reaches Postgres as a superuser would accept the insert whatever the
+    window said.
+
+    The assertion is on the outcome rather than on which layer produced it.
+    Both are real refusals, and pinning the message would make this fail the
+    day the grant layer changes without the rule changing.
+    """
+    owner = await create_user(session, email="owner-cmt-ro@example.com")
+    support = await create_user(session, email="support-cmt-ro@example.com")
+    guild = await create_guild(session, creator=owner)
+    init = await create_initiative(session, guild, owner)
+    project = await create_project(session, init, owner, name="P")
+    task = await create_task(session, project)
+
+    insert = text(
+        "INSERT INTO comments (task_id, content, created_by, guild_id,"
+        " created_at, updated_at)"
+        " VALUES (:t, 'let me in', :u, :g, now(), now())"
+    ).bindparams(t=task.id, u=support.id, g=guild.id)
+
+    # A grantee is scoped by pam_guild_id and leaves current_guild_id unset —
+    # a matching current_guild_id reads as proof of membership, which is the
+    # one thing a grantee does not have.
+    reader = await role_session("app_user")
+    await set_rls_context(
+        reader, user_id=support.id, pam_guild_id=guild.id, pam_read=True
+    )
+    with pytest.raises(Exception) as refused:
+        await reader.exec(insert)
+    message = str(refused.value).lower()
+    assert "permission denied" in message or "row-level security" in message, (
+        refused.value
+    )
+    await reader.rollback()
+
+    # The same window at write level is what posting takes.
+    writer = await role_session("app_user")
+    await set_rls_context(
+        writer,
+        user_id=support.id,
+        pam_guild_id=guild.id,
+        pam_read=True,
+        pam_write=True,
+    )
+    await writer.exec(insert)
+    await writer.rollback()
 
 
 # The canonical per-tool factory registry rather than a copy of it: that one


### PR DESCRIPTION
Five failing checks on `dev`, four causes. Two of them are mine, from the relationships work; the other two are not, but they are red either way.

## Mine

**`created_by_test::test_exempt_list_names_only_real_guild_tables`** — `CREATED_BY_EXEMPT_TABLES` still named the sixteen junction tables that phases 1 and 2 dropped. The entries went with the tables.

**`webhooks_test` ×2 — `WEBHOOK_UNKNOWN_FIELD`** — this one is a genuine gap I left. Making the facet row-dependent (so a subscriber filtering on `tags` keeps receiving what it always did) gave the *trigger* an expression but left the *vocabulary* reading only the fallback constant. Events said `changed=['tags']` while the API refused a subscription naming `tags`.

`ReportsAs` now carries `facet_values` beside `facet_expr`, exactly as `resource_types` sits beside `type_expr` — the static set a subscriber names fields from, next to the expression a row is evaluated through. `tasks` offers `attachments, dependencies, parts, relationships, tags` again.

## Not mine

**`comments_test` ×2 — an authorization check failing open.** From `96149e4d8` "Say the sharing rule once", which moved gate 4 out of the app and into the policy: `_shares_resource` now says "selecting the id IS the question". The tests called it on the superuser-backed `session` fixture, which bypasses RLS — so the gate they asserted had moved somewhere that session cannot see.

**Production was never open.** I verified with a throwaway probe before changing anything: a routed `app_user` session refuses the non-member. This was a blind test, not a hole.

The tests run on a routed session now. While rewriting them I found the read-only-grant rule is held one layer further out than the old test claimed — such a window routes into the SELECT-only `guild_<id>_ro` role, so posting is refused at the grant level before RLS is consulted. `test_a_read_only_grant_cannot_post` asks that of the insert, asserts the outcome rather than which layer produced it, and checks the write-level window succeeds.

**`migrations_test::test_author_rename_skips_foreign_keys_a_guild_schema_lacks`** — `20260909_0239`'s downgrade revoked role memberships via `m.member::regrole`, which renders as a bare oid once the member role is gone, and a number is not something `REVOKE` can take. It reads the name out of `pg_roles` now and joins away memberships whose role no longer exists.

This became reachable only because #1546 unblocked the chain walk at `0209`; it was sitting behind that failure. As there, the edit is to a frozen revision's `downgrade()` — the `upgrade()` is untouched and no database has run the downgrade.

## Already green

`exports_test` ×2 (spreadsheet cell styles) were fixed by `6b560fabb`; they only appeared because #1546's branch predated it. Confirmed passing on `dev` as-is.

## Testing

```
pytest app/services/tenant/comments_test.py            -> 11 passed
pytest app/models/tenant/created_by_test.py
       app/api/v1/tenant_endpoints/webhooks_test.py    -> 165 passed
pytest alembic/migrations_test.py                      -> 16 passed
pytest app/api/v1/tenant_endpoints/exports_test.py -k spreadsheet  -> 2 passed
ruff check app alembic; ruff format app alembic; ty check app      -> clean
```