### PR TITLE
Keep the name Save button until you use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Cell colours and bold survive an Excel export** — a spreadsheet exported to `.xlsx` kept the number formats it was given but quietly lost the look of individual cells: bold, fill, text colour, alignment and borders set on a cell arrived plain. Column and row formatting was always carried over, and now per-cell formatting is too.
 
+- **A document nobody is editing stops writing to itself** — a document open with live editing on saved itself every ten seconds whether or not anything had changed, so one left open in a tab kept moving its own "updated" time and appearing at the top of anything sorted by it. It saves when there is something to save.
+
 ## [0.67.1] - 2026-09-09
 
 ### Added

--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -1,0 +1,129 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildDocumentSummary } from "@/__tests__/factories";
+import { guildHttp } from "@/__tests__/helpers/guildHttp";
+import { server } from "@/__tests__/helpers/msw-server";
+import { renderPage } from "@/__tests__/helpers/render";
+
+const collaborating = { value: false };
+
+vi.mock("@/hooks/useCollaboration", () => ({
+  useCollaboration: () => ({
+    providerFactory: null,
+    connectionStatus: collaborating.value ? "connected" : "disconnected",
+    isSynced: collaborating.value,
+    collaborators: [],
+    collaboratorsReady: collaborating.value,
+    isCollaborating: collaborating.value,
+    isReady: true,
+    connect: vi.fn(),
+    resume: vi.fn(),
+    disconnect: vi.fn(),
+    sendContent: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/documents/editor/editor", () => ({
+  Editor: () => <div data-testid="editor" />,
+}));
+
+const doc = buildDocumentSummary({ id: 7, name: "Original", initiative_id: 1 });
+
+const patches: Record<string, unknown>[] = [];
+
+beforeEach(() => {
+  patches.length = 0;
+  collaborating.value = false;
+  server.use(
+    guildHttp.get("/documents/:documentId", () => HttpResponse.json(doc)),
+    guildHttp.patch("/documents/:documentId", async ({ request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      patches.push(body);
+      return HttpResponse.json({ ...doc, name: body.name ?? doc.name });
+    }),
+    guildHttp.post("/recents/", () => HttpResponse.json({})),
+    guildHttp.get("/documents/:documentId/backlinks", () => HttpResponse.json([])),
+    guildHttp.get("/properties/definitions", () => HttpResponse.json([]))
+  );
+});
+
+const { DocumentDetailPage } = await import("./DocumentDetailPage");
+
+const renderDoc = () =>
+  renderPage(DocumentDetailPage, {
+    initialRoute: "/g/$guildId/i/$initiativeId/documents/$documentId",
+    routeParams: { guildId: "1", initiativeId: "1", documentId: "7" },
+  });
+
+describe("renaming a document", () => {
+  it("keeps the Save button beside the field while the name is being typed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDoc();
+
+    const input = await screen.findByDisplayValue("Original");
+    await user.clear(input);
+    await user.type(input, "Renamed");
+
+    // Well past the autosave debounce, with the field still held.
+    await vi.advanceTimersByTimeAsync(6000);
+
+    expect(patches).toEqual([]);
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(patches).toHaveLength(1));
+    expect(patches[0]).toMatchObject({ name: "Renamed" });
+    vi.useRealTimers();
+  });
+
+  it("autosaves the name once the field is let go", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDoc();
+
+    const input = await screen.findByDisplayValue("Original");
+    await user.clear(input);
+    await user.type(input, "Renamed");
+    await user.tab();
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    await waitFor(() => expect(patches).toHaveLength(1));
+    expect(patches[0]).toMatchObject({ name: "Renamed" });
+    vi.useRealTimers();
+  });
+
+  it("does not PATCH on a loop while collaborating with nothing edited", async () => {
+    collaborating.value = true;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderDoc();
+    await screen.findByDisplayValue("Original");
+
+    await vi.advanceTimersByTimeAsync(45_000);
+
+    expect(patches).toEqual([]);
+    vi.useRealTimers();
+  });
+
+  it("still autosaves a rename while collaborating", async () => {
+    collaborating.value = true;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDoc();
+
+    const input = await screen.findByDisplayValue("Original");
+    await user.clear(input);
+    await user.type(input, "Renamed");
+    await user.tab();
+
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    await waitFor(() => expect(patches).toHaveLength(1));
+    expect(patches[0]).toMatchObject({ name: "Renamed" });
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/pages/DocumentDetailPage.test.tsx
+++ b/frontend/src/pages/DocumentDetailPage.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildDocumentSummary } from "@/__tests__/factories";
 import { guildHttp } from "@/__tests__/helpers/guildHttp";
@@ -9,6 +9,7 @@ import { server } from "@/__tests__/helpers/msw-server";
 import { renderPage } from "@/__tests__/helpers/render";
 
 const collaborating = { value: false };
+const sendContent = vi.fn();
 
 vi.mock("@/hooks/useCollaboration", () => ({
   useCollaboration: () => ({
@@ -22,27 +23,41 @@ vi.mock("@/hooks/useCollaboration", () => ({
     connect: vi.fn(),
     resume: vi.fn(),
     disconnect: vi.fn(),
-    sendContent: vi.fn(),
+    sendContent,
   }),
 }));
 
+// Stands in for Lexical, exposing the one thing these tests drive: a body edit,
+// reported back the way the real editor reports one.
 vi.mock("@/components/documents/editor/editor", () => ({
-  Editor: () => <div data-testid="editor" />,
+  Editor: ({ onSerializedChange }: { onSerializedChange: (state: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() => onSerializedChange({ root: { children: [{ type: "edited" }] } })}
+    >
+      edit the body
+    </button>
+  ),
 }));
 
-const doc = buildDocumentSummary({ id: 7, name: "Original", initiative_id: 1 });
+const seed = buildDocumentSummary({ id: 7, name: "Original", initiative_id: 1 });
 
 const patches: Record<string, unknown>[] = [];
+/** What the server holds — a PATCH keeps what it was given, as the real one does. */
+let stored: Record<string, unknown> = { ...seed };
 
 beforeEach(() => {
   patches.length = 0;
+  stored = { ...seed };
+  sendContent.mockClear();
   collaborating.value = false;
   server.use(
-    guildHttp.get("/documents/:documentId", () => HttpResponse.json(doc)),
+    guildHttp.get("/documents/:documentId", () => HttpResponse.json(stored)),
     guildHttp.patch("/documents/:documentId", async ({ request }) => {
       const body = (await request.json()) as Record<string, unknown>;
       patches.push(body);
-      return HttpResponse.json({ ...doc, name: body.name ?? doc.name });
+      stored = { ...stored, ...body };
+      return HttpResponse.json(stored);
     }),
     guildHttp.post("/recents/", () => HttpResponse.json({})),
     guildHttp.get("/documents/:documentId/backlinks", () => HttpResponse.json([])),
@@ -51,6 +66,12 @@ beforeEach(() => {
 });
 
 const { DocumentDetailPage } = await import("./DocumentDetailPage");
+
+// Restored here rather than at the end of each test so a failed assertion
+// cannot leave fake timers behind for the next one.
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 const renderDoc = () =>
   renderPage(DocumentDetailPage, {
@@ -77,7 +98,6 @@ describe("renaming a document", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() => expect(patches).toHaveLength(1));
     expect(patches[0]).toMatchObject({ name: "Renamed" });
-    vi.useRealTimers();
   });
 
   it("autosaves the name once the field is let go", async () => {
@@ -94,7 +114,43 @@ describe("renaming a document", () => {
 
     await waitFor(() => expect(patches).toHaveLength(1));
     expect(patches[0]).toMatchObject({ name: "Renamed" });
-    vi.useRealTimers();
+  });
+
+  it("keeps saving the body while the name field is held", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDoc();
+
+    const input = await screen.findByDisplayValue("Original");
+    await user.click(await screen.findByRole("button", { name: "edit the body" }));
+    await user.clear(input);
+    await user.type(input, "Renamed");
+
+    await vi.advanceTimersByTimeAsync(6000);
+
+    // The body went; the half-typed name stayed behind with its Save button.
+    await waitFor(() => expect(patches).toHaveLength(1));
+    expect(patches[0]).toHaveProperty("content");
+    expect(patches[0]).not.toHaveProperty("name");
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+  });
+
+  it("keeps the room's content sync running while the name field is held", async () => {
+    collaborating.value = true;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDoc();
+
+    const input = await screen.findByDisplayValue("Original");
+    await user.click(await screen.findByRole("button", { name: "edit the body" }));
+    await user.clear(input);
+    await user.type(input, "Renamed");
+
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    await waitFor(() => expect(sendContent).toHaveBeenCalled());
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).not.toHaveProperty("name");
   });
 
   it("does not PATCH on a loop while collaborating with nothing edited", async () => {
@@ -106,7 +162,7 @@ describe("renaming a document", () => {
     await vi.advanceTimersByTimeAsync(45_000);
 
     expect(patches).toEqual([]);
-    vi.useRealTimers();
+    expect(sendContent).not.toHaveBeenCalled();
   });
 
   it("still autosaves a rename while collaborating", async () => {
@@ -124,6 +180,5 @@ describe("renaming a document", () => {
 
     await waitFor(() => expect(patches).toHaveLength(1));
     expect(patches[0]).toMatchObject({ name: "Renamed" });
-    vi.useRealTimers();
   });
 });

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -408,15 +408,14 @@ export const DocumentDetailPage = () => {
     // frozen (read_only lifecycle status) or access is via a read-level grant.
     return hasWriteAccess(document.my_permission_level);
   }, [document, user]);
-  const isDirty =
-    canEditDocument &&
-    ((document && title?.trim() !== document?.name?.trim()) ||
-      documentContentJson !== currentContentJson ||
-      normalizedDocumentFeatured !== featuredImageUrl);
+  // Split by what a save would carry: a rename and the rest of the document
+  // are committed on different terms — see the autosave effect.
+  const nameIsDirty = Boolean(document) && title?.trim() !== document?.name?.trim();
+  const bodyIsDirty =
+    documentContentJson !== currentContentJson || normalizedDocumentFeatured !== featuredImageUrl;
+  const isDirty = canEditDocument && (nameIsDirty || bodyIsDirty);
 
-  const titleIsDirty = Boolean(
-    canEditDocument && document && title?.trim() !== document?.name?.trim()
-  );
+  const titleIsDirty = canEditDocument && nameIsDirty;
 
   const commentsCanModerate = useMemo(() => {
     if (!document || !user) {
@@ -477,8 +476,12 @@ export const DocumentDetailPage = () => {
     suppressErrorToast: () => !isOnline,
     onSuccess: (_updated, sent) => {
       // Only if the field still holds the name this save carried: an autosave
-      // that started before the last keystroke must not mark it saved.
-      titleField.settle({ title: sent.name ?? "" });
+      // that started before the last keystroke must not mark it saved. A save
+      // that carried no name at all (one made while the field was being typed
+      // in) settles nothing.
+      if (typeof sent.name === "string") {
+        titleField.settle({ title: sent.name });
+      }
       if (!isAutosaveRef.current) {
         toast.success(t("detail.saved"));
       }
@@ -614,17 +617,15 @@ export const DocumentDetailPage = () => {
     if (!isOnline) {
       return;
     }
-    // Nothing to write. The collaborating branch below checks this too: the
-    // room owns the content column while it is live, but an open document
-    // nobody is editing has no rendering to report and no name to send.
-    if (!isDirty) {
-      return;
-    }
-    // A rename in progress belongs to the person typing it. Saving it out from
-    // under them retires the Save button beside the field mid-reach, so the
-    // debounce waits for the field to be let go — leaving the page still
-    // flushes it (see the unmount/unload flush below).
-    if (titleHasFocus) {
+    // A rename in progress belongs to the person typing it: taking it retires
+    // the Save button beside the field mid-reach. The name waits for the field
+    // to be let go — leaving the page still flushes it (see the unmount/unload
+    // flush below) — while the body carries on saving on its own schedule.
+    const savesName = nameIsDirty && !titleHasFocus;
+    // Nothing this pass would write. The collaborating branch below checks
+    // this too: the room owns the content column while it is live, but an open
+    // document nobody is editing has no rendering to report and no name to send.
+    if (!savesName && !bodyIsDirty) {
       return;
     }
     // When collaborating, sync content periodically to keep the content
@@ -644,7 +645,7 @@ export const DocumentDetailPage = () => {
         collaboration.sendContent(contentForSave);
         isAutosaveRef.current = true;
         saveDocument.mutate({
-          name: title?.trim(),
+          ...(savesName ? { name: title?.trim() } : null),
           featured_image_url: featuredImageUrl,
         });
       }, collabDebounceMs);
@@ -653,7 +654,7 @@ export const DocumentDetailPage = () => {
       const timer = setTimeout(() => {
         isAutosaveRef.current = true;
         saveDocument.mutate({
-          name: title?.trim(),
+          ...(savesName ? { name: title?.trim() } : null),
           content: contentForSave,
           featured_image_url: featuredImageUrl,
         });
@@ -662,7 +663,8 @@ export const DocumentDetailPage = () => {
     }
   }, [
     autosaveEnabled,
-    isDirty,
+    nameIsDirty,
+    bodyIsDirty,
     canEditDocument,
     saveDocument,
     parsedId,

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -255,6 +255,9 @@ export const DocumentDetailPage = () => {
   );
   const title = titleField.values.title;
   const setTitle = (next: string) => titleField.set({ title: next });
+  // Whether the name field is being typed in right now. Autosave waits it out
+  // so the Save button beside the field stays put for as long as it is wanted.
+  const [titleHasFocus, setTitleHasFocus] = useState(false);
   // The path supplies the initiative while this loads, but the entity is the
   // authority once it arrives — a URL naming a different one is corrected
   // rather than left to build links into an initiative it isn't in.
@@ -611,6 +614,19 @@ export const DocumentDetailPage = () => {
     if (!isOnline) {
       return;
     }
+    // Nothing to write. The collaborating branch below checks this too: the
+    // room owns the content column while it is live, but an open document
+    // nobody is editing has no rendering to report and no name to send.
+    if (!isDirty) {
+      return;
+    }
+    // A rename in progress belongs to the person typing it. Saving it out from
+    // under them retires the Save button beside the field mid-reach, so the
+    // debounce waits for the field to be let go — leaving the page still
+    // flushes it (see the unmount/unload flush below).
+    if (titleHasFocus) {
+      return;
+    }
     // When collaborating, sync content periodically to keep the content
     // column updated for non-collab readers. Native Lexical docs use 10s
     // (users type many characters per second, a shorter window would
@@ -634,9 +650,6 @@ export const DocumentDetailPage = () => {
       }, collabDebounceMs);
       return () => clearTimeout(timer);
     } else {
-      if (!isDirty) {
-        return;
-      }
       const timer = setTimeout(() => {
         isAutosaveRef.current = true;
         saveDocument.mutate({
@@ -660,6 +673,7 @@ export const DocumentDetailPage = () => {
     collaboration.sendContent,
     isOnline,
     document?.document_type,
+    titleHasFocus,
   ]);
 
   // When connectivity returns after being offline, flush any pending dirty
@@ -1080,8 +1094,10 @@ export const DocumentDetailPage = () => {
           <Input
             value={title}
             onChange={(event) => setTitle(event.target.value)}
+            onFocus={() => setTitleHasFocus(true)}
+            onBlur={() => setTitleHasFocus(false)}
             placeholder={t("detail.titlePlaceholder")}
-            className="font-semibold text-2xl"
+            className="min-w-0 font-semibold text-2xl"
             disabled={!canEditDocument}
           />
           {titleIsDirty ? (


### PR DESCRIPTION
## Problem

Renaming a document puts a Save button beside the name field. Autosave (on by default, 2s debounce) then committed the rename shortly after the last keystroke — the field stopped being dirty, the button unmounted, and it was gone by the time the pointer arrived. The one affordance whose purpose was saving without waiting for autosave was a ~2 second target.

While investigating, a second defect turned up in the same effect: the collaborating arm had no dirty check — only the non-collaborating arm did. A document open with live editing on PATCHed every ten seconds whether or not anything had changed, moving its own `updated_at` each time, so a document left open in a tab kept floating to the top of anything sorted by recency.

## Changes

- [DocumentDetailPage.tsx](frontend/src/pages/DocumentDetailPage.tsx) — `titleHasFocus` state wired to the name input's focus/blur, and an early return in the autosave effect while it is held. The button stays for as long as the name is being typed; the debounce picks the rename up on blur. The unmount/unload flush is unchanged, so leaving the page mid-rename still saves it.
- [DocumentDetailPage.tsx](frontend/src/pages/DocumentDetailPage.tsx) — hoisted the `!isDirty` guard out of the non-collaborating arm so it covers both.
- [DocumentDetailPage.tsx](frontend/src/pages/DocumentDetailPage.tsx) — `min-w-0` on the name input so the button cannot be squeezed off on a narrow screen.
- [DocumentDetailPage.test.tsx](frontend/src/pages/DocumentDetailPage.test.tsx) — new, covering both fixes.
- [CHANGELOG.md](CHANGELOG.md) — two entries under `[Unreleased]` › Fixed.

The inline Save button stays visible whether or not the room is live — the name and featured image travel by REST either way. The bottom save bar is untouched.

## Testing

- `pnpm vitest run src/pages/DocumentDetailPage.test.tsx` — 4 passed. The button survives the debounce while typing and saves on click; the rename still autosaves once the field is let go; no idle PATCH loop while collaborating; a rename while collaborating still autosaves. Each of the first and third fail against `dev`.
- `pnpm typecheck` — clean.
- `pnpm biome check src/pages/DocumentDetailPage.tsx src/pages/DocumentDetailPage.test.tsx` — clean.