### PR TITLE
Let a delegation name its own guild

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -659,31 +659,43 @@ async def _load_guild_context(
     )
 
 
+def addressed_guild_id(request: Request, path_guild_id: int) -> int:
+    """Which guild this request operates in.
+
+    Two kinds of caller say it two ways.
+
+    A **browser** says it in the path, and has to: a tab, a download, an
+    ``<img>``, an SSE stream and a WebSocket all carry the guild, and the URL is
+    the only thing all of them can carry (#680 removed the header version).
+
+    A **delegate** says it in its token, and only there. It holds one
+    credential, that credential is for one guild, and which guild was settled
+    when the call authenticated. Our id is an index and its reference is minted
+    for it alone, so neither is a name it should be spelling into a URL — the
+    segment it writes is its own business, and this does not read it.
+
+    See ``history/opaque-identity-design.md`` §13.
+    """
+    delegated = getattr(request.state, "delegated_guild_id", None)
+    return path_guild_id if delegated is None else delegated
+
+
 async def get_guild_membership(
     request: Request,
     session: SessionDep,
     current_user: Annotated[User, Depends(get_current_active_user)],
     guild_id: Annotated[int, Path(description="Guild this request operates in")],
 ) -> GuildContext:
-    """Strict guild context resolved from the ``/g/{guild_id}`` path segment.
+    """Strict guild context for the guild this request addresses.
 
-    Every guild-scoped router mounts under that prefix, so FastAPI injects
-    ``guild_id`` from the path into this dependency. Membership (or a live PAM
-    grant) is validated fresh; a non-member or stale grant gets 403. A
+    Every guild-scoped router mounts under ``/g/{guild_id}``, so FastAPI injects
+    the segment here; :func:`addressed_guild_id` decides whether that is the
+    answer or whether the call's delegation already gave one. Membership (or a
+    live PAM grant) is validated fresh; a non-member or stale grant gets 403. A
     guild-scoped route mounted *outside* the prefix fails at startup (missing
     path param) — a useful guard that every such route is path-addressed.
     """
-    # Auto-delegation tokens are pinned to one guild at mint time; refuse if the
-    # path addresses a different guild than the token was minted for. This is a
-    # REST/token-only guard (a delegation token can only arrive over HTTP), so it
-    # lives here — the one place that sees both the token's guild and the path's —
-    # not in the shared resolver that the WebSocket/keepalive callers also use.
-    delegated = getattr(request.state, "delegated_guild_id", None)
-    if delegated is not None and delegated != guild_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=GuildMessages.GUILD_ACCESS_DENIED,
-        )
+    guild_id = addressed_guild_id(request, guild_id)
     # A guild-bound API key (PAT) is pinned to one guild the same way: refuse if
     # the path addresses a different guild than the key was scoped to.
     key_guild = getattr(request.state, "api_key_guild_id", None)

--- a/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
+++ b/backend/app/api/v1/tenant_endpoints/auto_delegation_test.py
@@ -5,9 +5,9 @@ JWTs minted by initiative-auto:
 
 * signature, audience, issuer (negative tests against tampered tokens)
 * one-shot replay rejection via the jti blocklist
-* the guild_ref JWT claim pins the request's guild context (validated against
-  the user's memberships, and refused if it disagrees with the ``/g/{guild_id}``
-  path)
+* the guild_ref JWT claim IS the request's guild context (validated against the
+  user's memberships; the ``/g/{guild_id}`` segment is not read on a delegated
+  call — see ``history/opaque-identity-design.md`` §13)
 * deactivated users can't be impersonated even with a valid token
 
 These don't repeat the unit tests on token issuance — those live in
@@ -30,6 +30,7 @@ from app.services.marketplace.registration_lookup import invalidate_registration
 from app.testing import (
     create_guild,
     create_guild_membership,
+    create_initiative,
     create_user,
 )
 from app.testing.delegation import (
@@ -112,33 +113,44 @@ async def test_delegation_token_is_one_shot(
 
 
 @pytest.mark.integration
-async def test_delegation_token_guild_claim_pins_context(
+async def test_delegation_reaches_the_guild_its_token_names_whatever_the_path_says(
     client: AsyncClient, session: AsyncSession, delegate_guild
 ):
-    """The token's guild_ref claim IS the request's guild context — it takes
-    precedence over whatever guild the human happens to be in, and it is
-    validated against the user's memberships like any other context. A token
-    minted for a guild the user can't access must not reach guild data even
-    while the user's own flag points at a guild they CAN access. Stops
-    cross-guild lateral movement using a single delegation."""
+    """The token's guild_ref claim IS the request's guild context.
+
+    A delegate holds one credential for one guild, so it addresses nothing: the
+    ``/g/{guild_id}`` segment exists for browsers, which have nowhere else to
+    carry a guild, and a delegated call does not read it. Here the path names
+    the OTHER guild this person belongs to, and the call still answers about
+    the one the token was minted for.
+
+    The human is legitimately in both, which is what makes this worth pinning:
+    a single delegation reaches exactly one of them.
+    """
     user = await create_user(session, email="cross-guild@example.com")
-    guild = await create_guild(session, creator=user)
-    await create_guild_membership(session, user=user, guild=guild)
+    other_guild = await create_guild(session, creator=user)
+    await create_guild_membership(session, user=user, guild=other_guild)
+    await create_guild_membership(session, user=user, guild=delegate_guild)
     await authorize_delegate(session, delegate_guild, user)
     subject = await delegate_subject(session, delegate_guild, user)
-    # The human is legitimately in their own guild, and the app is installed in
-    # the guild its token names — so what refuses this is the pin itself, not a
-    # missing install or an unknown guild.
+
+    named = await create_initiative(session, delegate_guild, user, name="In the token")
+    await create_initiative(session, other_guild, user, name="In the path")
+
     token = _mint_delegation(
         subject=subject, guild_ref=await delegate_guild_ref(session, delegate_guild)
     )
 
     response = await client.get(
-        f"/api/v1/g/{guild.id}/initiatives/",
+        f"/api/v1/g/{other_guild.id}/initiatives/",
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert response.status_code == 403
-    assert response.json()["detail"] == "GUILD_ACCESS_DENIED"
+
+    assert response.status_code == 200
+    names = {row["name"] for row in response.json()}
+    assert "In the token" in names
+    assert "In the path" not in names
+    assert named.guild_id == delegate_guild.id
 
 
 @pytest.mark.integration

--- a/backend/app/api/v1/tenant_endpoints/documents.py
+++ b/backend/app/api/v1/tenant_endpoints/documents.py
@@ -31,6 +31,7 @@ from app.api.deps import (
     SessionDep,
     UploadUserDep,
     UserSessionDep,
+    addressed_guild_id,
     establish_guild_access,
     get_current_active_user,
     get_guild_membership,
@@ -1998,6 +1999,9 @@ async def download_document_file(
     inline: bool = False,
 ) -> Response:
     """Download a file-type document — requires read permission on the document."""
+    # These two routes resolve the guild themselves rather than through
+    # ``get_guild_membership``, so they ask the same question it does.
+    guild_id = addressed_guild_id(request, guild_id)
     document, guild_role = await _load_download_document(
         session, current_user, guild_id, document_id
     )
@@ -2050,6 +2054,7 @@ async def download_document_file_version(
     inline: bool = False,
 ) -> Response:
     """Download a specific stored version of a file document — read permission."""
+    guild_id = addressed_guild_id(request, guild_id)
     document, guild_role = await _load_download_document(
         session, current_user, guild_id, document_id
     )

--- a/backend/app/api/v1/tenant_endpoints/documents_test.py
+++ b/backend/app/api/v1/tenant_endpoints/documents_test.py
@@ -14,6 +14,7 @@ from app.core.config import settings
 from app.core.security import create_upload_token
 from app.models.tenant.document import (
     Document,
+    DocumentFileVersion,
     DocumentType,
 )
 from app.models.platform.guild import GuildRole
@@ -1164,3 +1165,114 @@ async def test_a_live_document_can_still_be_renamed(
 
     assert response.status_code == 200
     assert response.json()["name"] == "Renamed while live"
+
+
+# ── downloads on a delegated call ────────────────────────────────────────────
+#
+# These two routes resolve the guild themselves rather than through
+# ``get_guild_membership`` — they establish access, route the session and pick
+# the guild's storage by hand — so the rule that a delegation names its own
+# guild has to be asserted against them directly. See
+# ``history/opaque-identity-design.md`` §13.
+
+
+@pytest.fixture
+async def _delegation_enabled(session: AsyncSession):
+    """Register the delegate whose tokens these two tests present."""
+    from app.core import config as config_module
+    from app.services.marketplace.registration_lookup import invalidate_registrations
+    from app.testing.delegation import register_delegate
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(
+            config_module.settings,
+            "APP_PLATFORM_SIGNING_PRIVATE_KEY_PEM",
+            "-----BEGIN PRIVATE KEY-----",
+        )
+        await register_delegate(session)
+        yield
+    invalidate_registrations()
+
+
+async def _delegated_headers(session: AsyncSession, *, guild, user) -> dict[str, str]:
+    """A delegation this app may present for this member in this guild."""
+    from app.testing.delegation import (
+        authorize_delegate,
+        delegate_guild_ref,
+        delegate_subject,
+        mint_delegation_token,
+    )
+
+    await authorize_delegate(session, guild, user)
+    token = mint_delegation_token(
+        subject=await delegate_subject(session, guild, user),
+        guild_ref=await delegate_guild_ref(session, guild),
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.integration
+async def test_a_delegated_download_reads_the_guild_its_token_names(
+    client: AsyncClient, session: AsyncSession, acting_user, _delegation_enabled
+) -> None:
+    """The path names the other guild this person belongs to. The file served
+    is the one in the guild the delegation was minted for."""
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    elsewhere = await acting_user(
+        guild_role=GuildRole.member, initiative=True, user=a.user
+    )
+
+    doc = await _create_file_document(
+        session, initiative=a.initiative, owner=a.user, filename="dl_delegated.pdf"
+    )
+    headers = await _delegated_headers(session, guild=a.guild, user=a.user)
+
+    try:
+        response = await client.get(
+            f"/api/v1/g/{elsewhere.guild.id}/documents/{doc.id}/download",
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        assert response.content == b"%PDF-1.4 test"
+    finally:
+        (_uploads_dir() / "dl_delegated.pdf").unlink(missing_ok=True)
+
+
+@pytest.mark.integration
+async def test_a_delegated_version_download_reads_the_same_guild(
+    client: AsyncClient, session: AsyncSession, acting_user, _delegation_enabled
+) -> None:
+    """The version route loads the document the same way, so it answers the
+    same — asserted separately because it resolves the guild separately."""
+    a = await acting_user(guild_role=GuildRole.member, initiative=True)
+    elsewhere = await acting_user(
+        guild_role=GuildRole.member, initiative=True, user=a.user
+    )
+
+    doc = await _create_file_document(
+        session, initiative=a.initiative, owner=a.user, filename="dl_delegated_v.pdf"
+    )
+    version = DocumentFileVersion(
+        document_id=doc.id,
+        guild_id=a.guild.id,
+        version_number=1,
+        file_url=doc.file_url,
+        original_filename=doc.original_filename,
+        file_content_type="application/pdf",
+        file_size=13,
+        created_by=a.user.id,
+    )
+    session.add(version)
+    await session.commit()
+    headers = await _delegated_headers(session, guild=a.guild, user=a.user)
+
+    try:
+        response = await client.get(
+            f"/api/v1/g/{elsewhere.guild.id}/documents/{doc.id}"
+            f"/versions/{version.id}/download",
+            headers=headers,
+        )
+        assert response.status_code == 200, response.text
+        assert response.content == b"%PDF-1.4 test"
+    finally:
+        (_uploads_dir() / "dl_delegated_v.pdf").unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

Every guild-scoped route is addressed `/g/{guild_id}/…`, and a delegated call had to write our row id into that segment as well as carry the guild in its token. `get_guild_membership` then required the two to agree, or answered 403.

That held only while the other side keyed on our numbers. `initiative_auto` stopped: its `guilds` mapping table (auto#152) gives each guild an id from **its own** sequence, and that id is what flows through the service after a handoff and into `InitiativeClient.guild_path`. The token names the guild by reference and resolves to our id; the path names it by auto's. They agree only where auto's sequence happens to land on our number — guild 1, and nothing after it.

So every guild-scoped delegated call answers 403 today: the member feed, reading and writing every tool, listing installs, registering and removing webhook subscriptions. Thirty-seven call sites. It reads as "this member has not authorized us", because that is the other thing a 403 means there.

## Changes

- `addressed_guild_id()` takes the guild from the delegation where there is one and from the path otherwise. The segment stays for browsers, which have nowhere else to carry a guild — a tab, a download, an `<img>`, an SSE stream, a WebSocket — and #680 is why it is not a header.
- The two document download routes resolve the guild themselves rather than through the dependency, so they ask the same question now. A delegated call could not reach a different guild through those before either, because nothing checked.
- Guild-bound API keys are unchanged: a PAT is still pinned to the guild in its path.

Auto needs no change — its id becomes a segment nobody reads.

## Contract note

Naming a guild a delegation was not minted for used to answer 403; it now answers about the guild the token names. One credential still reaches exactly one guild, so the property that 403 protected is intact. `test_delegation_reaches_the_guild_its_token_names_whatever_the_path_says` asserts it directly — the path names the other guild the person belongs to, and the response carries the token guild's rows and not that one's.

Design note: `history/opaque-identity-design.md` §13.

## Testing

```
pytest -n 0 app/api/v1/tenant_endpoints/auto_delegation_test.py                      # 10 passed
pytest -n 0 app/api/v1/platform_endpoints/delegation_exchange_test.py \
            app/api/v1/tenant_endpoints/guild_app_service_test.py \
            app/api/v1/app_service_endpoints/installs_test.py                        # 63 passed
ruff check app && ty check app
```

No OpenAPI change, so no generated types move.