### PR TITLE
Stop drawing rows that are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Archived and finished work is properly read-only** — archiving a project stopped edits on a handful of screens and left the rest open; archiving an initiative only hid it from the sidebar, with everything inside still editable; an archived task could be edited as though it were not. Archiving now means what it says, everywhere: an archived initiative, project or task is read-only until you bring it back, and so is everything inside it — tasks, comments, reactions, attachments, properties and sharing alike. The trash works the same way: a trashed item and its contents can be restored or emptied, and nothing else. Deleted work is also out of sight now, not just out of the way — once something is in the trash only you, as the person who deleted it, and your community's admins can still see it. Unarchiving and restoring are unchanged, and so is reading — archived work still opens, searches and exports the way it always did.
 - **"Linked from" counts what a conversation says, not just what a page says** — a document's backlinks were read from links typed into other documents' text. A `#` mention written in a comment now counts too, recorded against whatever the comment is about, so a page mentioned while discussing a project shows up under that project the way one mentioned in its body always has. What a page refers to is also kept for every kind of thing now, not only for other documents — a task or a queue named in a document is remembered as a reference to it, ready for the surfaces that will read them.
 
+### Fixed
+
+- **Hiding a spreadsheet row hides it** — a hidden row stopped taking up space but kept drawing its contents, which landed on top of the row beneath it: hide the row holding "Test2" and "Test2" and "Test3" ended up printed over each other on one line, with both row numbers crowded into the same place. A hidden row or column is no longer drawn at all, so the rows after it close up the way they should. Hiding a frozen row does the same.
+
 ## [0.68.0] - 2026-09-11
 
 ### Added

--- a/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
+++ b/frontend/src/components/documents/SpreadsheetDocumentEditor.tsx
@@ -613,14 +613,31 @@ export const SpreadsheetDocumentEditor = ({
   // draws at zero size. Every "where can the cursor go", "which cells does
   // this range cover" and "what is the next cell" question goes through it,
   // so there is one answer rather than one per call site.
+  const isRowHidden = useCallback(
+    (r: number) => formatting.rows[String(r)]?.hidden === true,
+    [formatting.rows]
+  );
+  const isColHidden = useCallback(
+    (c: number) => formatting.columns[String(c)]?.hidden === true,
+    [formatting.columns]
+  );
+
   const grid = useMemo(
-    () =>
-      sheetGrid({
-        bounds: dimensions,
-        isRowHidden: (r) => formatting.rows[String(r)]?.hidden === true,
-        isColHidden: (c) => formatting.columns[String(c)]?.hidden === true,
-      }),
-    [dimensions, formatting.rows, formatting.columns]
+    () => sheetGrid({ bounds: dimensions, isRowHidden, isColHidden }),
+    [dimensions, isRowHidden, isColHidden]
+  );
+
+  // What actually gets drawn. A hidden line still has a place in the
+  // virtualizer — at zero size, so the lines after it sit where they should —
+  // but it has no cells and no header on screen. Its offset is the next
+  // line's, so anything it drew would sit on top of that line.
+  const visibleRows = useMemo(
+    () => virtualRows.filter((row) => !isRowHidden(row.index)),
+    [virtualRows, isRowHidden]
+  );
+  const visibleCols = useMemo(
+    () => virtualCols.filter((col) => !isColHidden(col.index)),
+    [virtualCols, isColHidden]
   );
 
   const selBox = useMemo(
@@ -2241,7 +2258,7 @@ export const SpreadsheetDocumentEditor = ({
               className="sticky top-0 left-0 z-30 border-border border-r border-b bg-muted"
               style={{ width: ROW_HEADER_WIDTH, height: COL_HEADER_HEIGHT }}
             />
-            {virtualCols.map((col) => {
+            {visibleCols.map((col) => {
               const header = (
                 <button
                   type="button"
@@ -2341,11 +2358,13 @@ export const SpreadsheetDocumentEditor = ({
                   height: frozenBandHeight,
                 }}
               />
-              {virtualCols.map((col) =>
+              {visibleCols.map((col) =>
                 col.index < frozenCols
                   ? null
                   : Array.from({ length: frozenRows }, (_, r) =>
-                      renderCell(r, col.index, ROW_HEADER_WIDTH + col.start, prefixRow[r])
+                      isRowHidden(r)
+                        ? null
+                        : renderCell(r, col.index, ROW_HEADER_WIDTH + col.start, prefixRow[r])
                     )
               )}
             </div>
@@ -2362,11 +2381,11 @@ export const SpreadsheetDocumentEditor = ({
                 className="absolute bg-background"
                 style={{ left: 0, top: 0, width: frozenBandWidth, height: totalGridHeight }}
               />
-              {virtualRows.map((row) =>
+              {visibleRows.map((row) =>
                 row.index < frozenRows
                   ? null
                   : Array.from({ length: frozenCols }, (_, c) =>
-                      renderCell(row.index, c, prefixCol[c], row.start)
+                      isColHidden(c) ? null : renderCell(row.index, c, prefixCol[c], row.start)
                     )
               )}
             </div>
@@ -2402,7 +2421,7 @@ export const SpreadsheetDocumentEditor = ({
             className="sticky left-0 z-10 bg-muted"
             style={{ width: ROW_HEADER_WIDTH, height: totalGridHeight }}
           >
-            {virtualRows.map((row) => {
+            {visibleRows.map((row) => {
               const header = (
                 <button
                   type="button"
@@ -2475,8 +2494,8 @@ export const SpreadsheetDocumentEditor = ({
           </div>
 
           {/* Body cells (excludes anything covered by a frozen band). */}
-          {virtualRows.map((row) =>
-            virtualCols.map((col) => {
+          {visibleRows.map((row) =>
+            visibleCols.map((col) => {
               if (row.index < frozenRows || col.index < frozenCols) return null;
               return renderCell(
                 row.index,

--- a/frontend/src/components/documents/SpreadsheetHiddenLines.test.tsx
+++ b/frontend/src/components/documents/SpreadsheetHiddenLines.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * A hidden row or column is not drawn.
+ *
+ * The virtualizer keeps a hidden line in its layout at zero size, so the
+ * lines after it sit at the right offsets. Drawing it anyway puts its cells
+ * at the same offset as the next line's, which is what
+ * https://github.com/Morelitea/initiative/issues/1562 showed: hiding a row
+ * left its text painted on top of the row below.
+ *
+ * The virtualizer is stubbed because jsdom gives every element a size of
+ * zero, so the real one reports nothing to draw. The stub lays items out
+ * from the same `estimateSize` the component supplies — which is where a
+ * hidden line's zero height comes from — so what is under test is the
+ * component's own decision about what to render.
+ */
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/__tests__/helpers/render";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: (options: { count: number; estimateSize: (index: number) => number }) => {
+    const items: { index: number; start: number; size: number; key: number }[] = [];
+    let start = 0;
+    // Enough of the sheet to cover the rows this test cares about.
+    const shown = Math.min(options.count, 20);
+    for (let index = 0; index < shown; index += 1) {
+      const size = options.estimateSize(index);
+      items.push({ index, start, size, key: index });
+      start += size;
+    }
+    return {
+      getVirtualItems: () => items,
+      getTotalSize: () => start,
+      measure: () => {},
+      scrollToIndex: () => {},
+      scrollToOffset: () => {},
+      options,
+    };
+  },
+}));
+
+const content = (hidden: Record<string, { hidden: true }>) => ({
+  schema_version: 3,
+  kind: "spreadsheet",
+  sheets: [
+    {
+      id: "s1",
+      name: "Sheet1",
+      dimensions: { rows: 20, cols: 4 },
+      cells: { "0:0": "Test1", "1:0": "Test2", "2:0": "Test3" },
+      columns: {},
+      rows: hidden,
+      cellStyles: {},
+      frozen: { rows: 0, cols: 0 },
+    },
+  ],
+});
+
+const renderSheet = async (rows: Record<string, { hidden: true }>) => {
+  const { SpreadsheetDocumentEditor } = await import(
+    "@/components/documents/SpreadsheetDocumentEditor"
+  );
+  renderWithProviders(
+    <SpreadsheetDocumentEditor
+      // biome-ignore lint/suspicious/noExplicitAny: the editor's own content type
+      initialContent={content(rows) as any}
+      onContentChange={() => {}}
+      documentTitle="Sheet"
+      readOnly={false}
+    />
+  );
+};
+
+describe("a hidden row", () => {
+  it("is drawn when nothing is hidden", async () => {
+    await renderSheet({});
+
+    expect(screen.getAllByText("Test2").length).toBeGreaterThan(0);
+  });
+
+  it("is not drawn once hidden, so it cannot land on the row below", async () => {
+    await renderSheet({ "1": { hidden: true } });
+
+    expect(screen.queryByText("Test2")).not.toBeInTheDocument();
+    // Its neighbours are untouched. ``Test1`` is the focused cell, so it is
+    // on screen twice — in the grid and in the formula bar.
+    expect(screen.getAllByText("Test1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Test3").length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #1562.

## What the screenshot shows

Hide the row holding `Test2`, and `Test2` ends up printed across `Test3` on one line, with row numbers 10 and 11 crowded into the same place.

## Why

Hiding a line collapses it to zero size, and the virtualizer lays the grid out from that — so the lines after it move up correctly. But the line was still *emitted*: `virtualRows`/`virtualCols` went straight into every render loop, so a hidden row produced its header and its cells like any other. Its `start` offset is now identical to the next line's, so what it drew sat on top of that line.

Hiding was never wrong in the data — `setLinesHidden`, `updateRow` and the normalizer all handled it correctly. Only the drawing was.

## The change

The two hidden predicates `sheetGrid` was already given are now their own callbacks, and the drawn rows and columns derive from them:

```ts
const visibleRows = useMemo(
  () => virtualRows.filter((row) => !isRowHidden(row.index)),
  [virtualRows, isRowHidden]
);
```

So what the cursor skips and what the screen shows come from one answer rather than two. All five render loops use the derived lists, and the frozen bands read the same predicates — a hidden frozen row had the same problem.

`virtualRows` is still what the grow-the-sheet-on-scroll effect reads, since that is about how far the sheet extends, not what is painted.

## Testing

```
cd frontend && pnpm vitest run src/components/documents/SpreadsheetHiddenLines.test.tsx \
                               src/components/documents/spreadsheet/     # 31 passed
cd frontend && pnpm lint && pnpm exec tsc --noEmit                       # clean
```

The regression test renders the editor with a hidden row and asserts its text is gone while its neighbours stay. The virtualizer is stubbed: jsdom gives every element a size of zero, so the real one reports nothing to draw. The stub lays items out from the component's own `estimateSize`, which is where a hidden line's zero height comes from — so the component's decision about what to render is what is under test, not the stub.

**Confirmed load-bearing:** reverting the one-line filter makes it fail on `queryByText("Test2")`, and restoring it makes it pass.
