### PR TITLE
Let a resource be created before it is shared

### DIFF
--- a/backend/app/db/frozen.py
+++ b/backend/app/db/frozen.py
@@ -330,6 +330,51 @@ def render_resource_frozen_fn() -> str:
     return _RESOURCE_FROZEN_TEMPLATE.format(arms="\n".join(arms), purging=_PURGING)
 
 
+_RESOURCE_KNOWN_FROZEN_TEMPLATE = """
+CREATE OR REPLACE FUNCTION public.resource_known_frozen(
+    kind text, rid bigint, trashed_ok boolean DEFAULT false
+) RETURNS boolean LANGUAGE plpgsql STABLE AS $resource_known_frozen$
+BEGIN
+    IF rid IS NULL THEN
+        RETURN false;
+    END IF;
+    CASE kind
+{arms}
+      ELSE
+        RETURN false;
+    END CASE;
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+    RETURN public.resource_frozen(kind, rid, trashed_ok);
+END;
+$resource_known_frozen$;
+"""
+
+
+def render_resource_known_frozen_fn() -> str:
+    """``public.resource_known_frozen(kind, id, trashed_ok)`` — the same answer
+    as :func:`render_resource_frozen_fn`, for callers that have to tell a row
+    they cannot see from a row that is put away.
+
+    ``resource_frozen`` answers "frozen" for a row it cannot find, which is the
+    right answer for a child being written under an ancestor. It is the wrong
+    one where the write is what will make the row reachable in the first place
+    — the first grant on a resource — so this one says no instead and leaves
+    the decision to the permissive policies.
+
+    A function rather than an ``EXISTS`` beside the call, because these legs are
+    rendered into trigger ``WHEN`` clauses as well as policies, and a ``WHEN``
+    takes no subquery.
+    """
+    arms = "\n".join(
+        f"      WHEN '{tool.plural}' THEN\n"
+        f"        PERFORM 1 FROM {tool.plural} WHERE id = rid;"  # noqa: S608
+        for tool in Tool
+    )
+    return _RESOURCE_KNOWN_FROZEN_TEMPLATE.format(arms=arms)
+
+
 def render_frozen_ancestor_fn() -> str:
     """``public.fn_frozen_ancestor_guard()`` — says no, and nothing else.
 
@@ -575,13 +620,22 @@ def _edge_leg(alias: str, trashed_ok: str) -> str:
 
 
 def _resource_grants_leg(alias: str, trashed_ok: str) -> str:
-    """A grant freezes with the resource it shares.
+    """A grant freezes with the resource it shares, WHEN it can see it.
 
     Sharing an archived project is a change to the project, which is why the
     endpoint already refused it — this is the same rule, one layer down.
+
+    Asked through ``resource_known_frozen`` rather than ``resource_frozen``,
+    which is what makes that rule expressible here at all. A grant is what makes
+    a resource reachable, so the FIRST one is written while the resource still
+    answers to nobody: asked the ordinary way, every creation would be refused.
+    A row this statement cannot see is therefore not an answer here, and the
+    permissive policies stay the ones deciding whether it may be named at all.
+
+    Archiving hides nothing, so the case this leg exists for still reaches it.
     """
     arms = " ".join(
-        f"WHEN '{tool.value}' THEN public.resource_frozen("
+        f"WHEN '{tool.value}' THEN public.resource_known_frozen("
         f"'{tool.plural}', {alias}.resource_id, {trashed_ok})"
         for tool in Tool
     )

--- a/backend/app/db/frozen.py
+++ b/backend/app/db/frozen.py
@@ -330,12 +330,17 @@ def render_resource_frozen_fn() -> str:
     return _RESOURCE_FROZEN_TEMPLATE.format(arms="\n".join(arms), purging=_PURGING)
 
 
-_RESOURCE_KNOWN_FROZEN_TEMPLATE = """
-CREATE OR REPLACE FUNCTION public.resource_known_frozen(
+_RESOURCE_FROZEN_FOR_GRANT_TEMPLATE = """
+CREATE OR REPLACE FUNCTION public.resource_frozen_for_grant(
     kind text, rid bigint, trashed_ok boolean DEFAULT false
-) RETURNS boolean LANGUAGE plpgsql STABLE AS $resource_known_frozen$
+) RETURNS boolean LANGUAGE plpgsql STABLE AS $resource_frozen_for_grant$
 BEGIN
     IF rid IS NULL THEN
+        RETURN false;
+    END IF;
+    PERFORM 1 FROM resource_grants g
+     WHERE g.resource_type = kind AND g.resource_id = rid;
+    IF NOT FOUND THEN
         RETURN false;
     END IF;
     CASE kind
@@ -343,36 +348,38 @@ BEGIN
       ELSE
         RETURN false;
     END CASE;
-    IF NOT FOUND THEN
-        RETURN false;
-    END IF;
-    RETURN public.resource_frozen(kind, rid, trashed_ok);
 END;
-$resource_known_frozen$;
+$resource_frozen_for_grant$;
 """
 
 
-def render_resource_known_frozen_fn() -> str:
-    """``public.resource_known_frozen(kind, id, trashed_ok)`` — the same answer
-    as :func:`render_resource_frozen_fn`, for callers that have to tell a row
-    they cannot see from a row that is put away.
+def render_resource_frozen_for_grant_fn() -> str:
+    """``public.resource_frozen_for_grant(tool, id, trashed_ok)`` — the freeze,
+    asked the way a grant has to ask it.
 
-    ``resource_frozen`` answers "frozen" for a row it cannot find, which is the
-    right answer for a child being written under an ancestor. It is the wrong
-    one where the write is what will make the row reachable in the first place
-    — the first grant on a resource — so this one says no instead and leaves
-    the decision to the permissive policies.
+    A grant is what makes a resource reachable, so the FIRST one is written
+    while the resource still answers to nobody. Asked the ordinary way — where
+    a row the caller cannot find is a row put away — no resource could ever be
+    created, because the question is about a row this very statement is about
+    to make visible.
 
-    A function rather than an ``EXISTS`` beside the call, because these legs are
+    What tells that state apart from every other invisible one is the grants
+    themselves: a resource with none is one being created, and a resource that
+    has any is an existing one being shared, which asks in full. Grants outlive
+    both lifecycles and carry no visibility rule of their own, so they answer
+    here whatever state the resource is in.
+
+    A function rather than the test written beside the call, because this leg is
     rendered into trigger ``WHEN`` clauses as well as policies, and a ``WHEN``
     takes no subquery.
     """
     arms = "\n".join(
-        f"      WHEN '{tool.plural}' THEN\n"
-        f"        PERFORM 1 FROM {tool.plural} WHERE id = rid;"  # noqa: S608
+        f"      WHEN '{tool.value}' THEN\n"
+        f"        RETURN public.resource_frozen("
+        f"'{tool.plural}', rid, trashed_ok);"
         for tool in Tool
     )
-    return _RESOURCE_KNOWN_FROZEN_TEMPLATE.format(arms=arms)
+    return _RESOURCE_FROZEN_FOR_GRANT_TEMPLATE.format(arms=arms)
 
 
 def render_frozen_ancestor_fn() -> str:
@@ -625,21 +632,15 @@ def _resource_grants_leg(alias: str, trashed_ok: str) -> str:
     Sharing an archived project is a change to the project, which is why the
     endpoint already refused it — this is the same rule, one layer down.
 
-    Asked through ``resource_known_frozen`` rather than ``resource_frozen``,
-    which is what makes that rule expressible here at all. A grant is what makes
-    a resource reachable, so the FIRST one is written while the resource still
-    answers to nobody: asked the ordinary way, every creation would be refused.
-    A row this statement cannot see is therefore not an answer here, and the
-    permissive policies stay the ones deciding whether it may be named at all.
-
-    Archiving hides nothing, so the case this leg exists for still reaches it.
+    Asked through ``resource_frozen_for_grant``, which is what makes that rule
+    expressible here at all: the first grant on a resource is part of creating
+    it, and every later one is sharing. That function carries the whole of the
+    distinction, including the per-tool dispatch, so this leg is one call.
     """
-    arms = " ".join(
-        f"WHEN '{tool.value}' THEN public.resource_known_frozen("
-        f"'{tool.plural}', {alias}.resource_id, {trashed_ok})"
-        for tool in Tool
+    return (
+        f"COALESCE(public.resource_frozen_for_grant("
+        f"{alias}.resource_type, {alias}.resource_id, {trashed_ok}), false)"
     )
-    return f"COALESCE((CASE {alias}.resource_type {arms} ELSE false END), false)"
 
 
 #: Tables whose ancestors are a property of the ROW rather than of the table,

--- a/backend/app/db/frozen_test.py
+++ b/backend/app/db/frozen_test.py
@@ -255,6 +255,59 @@ class TestAncestorFreeze:
             ).bindparams(pid=project.id, uid=user.id, gid=guild.id, iid=initiative.id)
         )
 
+    async def test_a_trashed_project_takes_no_new_sharing(
+        self, session, role_session, workspace
+    ):
+        """Asked by somebody the trashed row is hidden from.
+
+        Sharing asks only for the initiative, so the lifecycle check is what
+        stands between a member and a grant naming a resource that is on its way
+        out. The resource is out of sight for them, which is not the same as
+        there being nothing to ask about.
+        """
+        owner, guild, initiative, project, _t = workspace
+        await _trash(session, project, by=owner.id)
+
+        bystander = await create_user(session)
+        await create_guild_membership(
+            session, user=bystander, guild=guild, role=GuildRole.member
+        )
+        await create_initiative_member(session, initiative=initiative, user=bystander)
+        await session.commit()
+
+        s = await role_session("app_user")
+        await set_rls_context(
+            s,
+            user_id=bystander.id,
+            guild_id=guild.id,
+            guild_role=GuildRole.member.value,
+        )
+        try:
+            hidden = await s.exec(
+                text("SELECT count(*) FROM projects WHERE id = :id").bindparams(
+                    id=project.id
+                )
+            )
+            assert hidden.one()[0] == 0, "the row has to be out of sight to ask this"
+
+            with pytest.raises(DBAPIError) as excinfo:
+                await s.exec(
+                    text(
+                        "INSERT INTO resource_grants "
+                        "(resource_type, resource_id, user_id, level, guild_id, "
+                        " initiative_id, created_at) "
+                        "VALUES ('project', :pid, :uid, 'viewer', :gid, :iid, now())"
+                    ).bindparams(
+                        pid=project.id,
+                        uid=bystander.id,
+                        gid=guild.id,
+                        iid=initiative.id,
+                    )
+                )
+            assert "frozen_ancestor_insert" in str(excinfo.value)
+        finally:
+            await s.rollback()
+
     async def test_a_refused_delete_says_so_rather_than_removing_nothing(
         self, session, admin_routed, workspace
     ):

--- a/backend/app/db/frozen_test.py
+++ b/backend/app/db/frozen_test.py
@@ -209,6 +209,52 @@ class TestAncestorFreeze:
             )
         assert "frozen_ancestor_insert" in str(excinfo.value)
 
+    async def test_an_archived_project_takes_no_new_sharing(
+        self, session, routed, workspace
+    ):
+        """Sharing an archived thing is a change to it. The endpoint refuses
+        this too; the point here is that the table does."""
+        user, guild, initiative, project, _t = workspace
+        await _archive(session, project)
+        with pytest.raises(DBAPIError) as excinfo:
+            await routed.exec(
+                text(
+                    "INSERT INTO resource_grants "
+                    "(resource_type, resource_id, user_id, level, guild_id, "
+                    " initiative_id, created_at) "
+                    "VALUES ('project', :pid, :uid, 'viewer', :gid, :iid, now())"
+                ).bindparams(
+                    pid=project.id, uid=user.id, gid=guild.id, iid=initiative.id
+                )
+            )
+        assert "frozen_ancestor_insert" in str(excinfo.value)
+
+    async def test_the_first_grant_on_a_new_resource_is_not_sharing(
+        self, session, routed, workspace
+    ):
+        """A grant is what makes a resource reachable, so the first one is
+        written while the resource still answers to nobody. Asked the way every
+        other ancestor is asked, no resource could ever be created."""
+        user, guild, initiative, project, _t = workspace
+        # The state a resource is in between its own INSERT and its owner
+        # grant: it exists, and it answers to nobody yet.
+        await session.exec(
+            text(
+                "DELETE FROM resource_grants "
+                "WHERE resource_type = 'project' AND resource_id = :pid"
+            ).bindparams(pid=project.id)
+        )
+        await session.commit()
+
+        await routed.exec(
+            text(
+                "INSERT INTO resource_grants "
+                "(resource_type, resource_id, user_id, level, guild_id, "
+                " initiative_id, created_at) "
+                "VALUES ('project', :pid, :uid, 'owner', :gid, :iid, now())"
+            ).bindparams(pid=project.id, uid=user.id, gid=guild.id, iid=initiative.id)
+        )
+
     async def test_a_refused_delete_says_so_rather_than_removing_nothing(
         self, session, admin_routed, workspace
     ):

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -46,6 +46,7 @@ from app.db.frozen import (
     render_frozen_guard_fn,
     render_frozen_parent_guard_fn,
     render_resource_frozen_fn,
+    render_resource_known_frozen_fn,
 )
 from app.db.soft_delete_filter import SOFT_DELETE_TABLES
 from app.db.tenancy import GUILD_SCOPED_TABLES, OWN_ROW_TABLES
@@ -354,6 +355,8 @@ def render_guild_rls_ddl() -> str:
         + render_endpoint_access_fn()
         + "\n"
         + render_resource_frozen_fn()
+        + "\n"
+        + render_resource_known_frozen_fn()
         + "\n"
         + render_frozen_guard_fn()
         + "\n"

--- a/backend/app/db/guild_ddl.py
+++ b/backend/app/db/guild_ddl.py
@@ -46,7 +46,7 @@ from app.db.frozen import (
     render_frozen_guard_fn,
     render_frozen_parent_guard_fn,
     render_resource_frozen_fn,
-    render_resource_known_frozen_fn,
+    render_resource_frozen_for_grant_fn,
 )
 from app.db.soft_delete_filter import SOFT_DELETE_TABLES
 from app.db.tenancy import GUILD_SCOPED_TABLES, OWN_ROW_TABLES
@@ -356,7 +356,7 @@ def render_guild_rls_ddl() -> str:
         + "\n"
         + render_resource_frozen_fn()
         + "\n"
-        + render_resource_known_frozen_fn()
+        + render_resource_frozen_for_grant_fn()
         + "\n"
         + render_frozen_guard_fn()
         + "\n"


### PR DESCRIPTION
## Problem

**`dev` is red and has been since #1560.** Creating anything — a project, document, queue, calendar, counter group, gallery, or an import — returns `409 CONTENT_IS_FROZEN`. 61 tests fail.

Every create does the same two writes: the resource, then its owner grant. The owner grant is what makes the resource readable. The lifecycle freeze's leg on `resource_grants` asks whether the resource is frozen; that question reads the resource row under the caller's own policies; and a resource nobody has been granted yet resolves to nothing. `resource_frozen` reports "not found" as frozen — correct for every other table, where a row you cannot find is a row put away — so the grant is refused and the whole create rolls back.

Reproduced locally on `dev` at `884d6a5`; the underlying refusal is `new row violates row-level security policy "frozen_ancestor_insert" for table "resource_grants"`.

## Changes

- **`public.resource_frozen_for_grant(tool, id, trashed_ok)`** in [frozen.py](backend/app/db/frozen.py) — the freeze, asked the way a grant has to ask it. Rendered beside `resource_frozen` in [guild_ddl.py](backend/app/db/guild_ddl.py), so it reaches existing guilds on the next boot like every other policy change; no migration.
- **`_resource_grants_leg` is now a single call to it** — the per-tool dispatch moved into the function.

What tells the creation state apart from every other invisible one is the grants themselves: **a resource with none is one being made**, and the row being written is what will make it reachable. **A resource that has any is an existing one being shared**, and asks in full. Grants outlive both lifecycles and carry no visibility rule of their own, so they answer whatever state the resource is in.

A function rather than the test written beside the call: these legs are rendered into trigger `WHEN` clauses as well as policies, and a `WHEN` takes no subquery.

## What this deliberately does not change

Sharing asks only for the initiative — `resource_grants` carries no sharing leg of its own — so the lifecycle check is the whole of what stands between a member and a grant naming a resource on its way out. Three tests pin that:

- `test_a_trashed_project_takes_no_new_sharing` — a member the trashed row is hidden from still cannot name it. Verified to fail against the first shape of this fix.
- `test_an_archived_project_takes_no_new_sharing` — archiving hides nothing, so this case reaches the leg unchanged. Passes with and without the change, so a later edit cannot quietly drop the guard while making creation work.
- `test_the_first_grant_on_a_new_resource_is_not_sharing` — fails with the production error when the change is reverted.

## Testing

- `pytest -n 0 app/db/frozen_test.py` — 28 passed, three new
- `pytest -n 4 app/api/v1/tenant_endpoints/{projects,documents,counters,calendars,imports,initiative_share_override,query,archive}_test.py app/db/guild_rls_test.py app/services/permissions_test.py` — 274 passed (this is the whole failing set from the red run)
- `ruff check app`, `ruff format app`, `ty check app` — clean