### PR TITLE
Let a reference outlive nobody

### DIFF
--- a/backend/app/services/marketplace/app_refs.py
+++ b/backend/app/services/marketplace/app_refs.py
@@ -237,8 +237,9 @@ async def drop_install_refs(*, guild_id: int, app_install_id: int) -> int:
 async def drop_guild_app_refs(*, guild_id: int) -> int:
     """Remove every reference minted in one guild. Returns the count.
 
-    Every purpose, not only this module's: the guild is going, so nothing
-    scoped to it has anything left to name.
+    Every purpose, not only this module's, and the guild's own names as well
+    as its members': the guild is going, so nothing it appears in has anything
+    left to name.
 
     Called when the guild is deleted, for the same reason as
     ``drop_install_refs``, and like it opens its own session: guild deletion
@@ -246,9 +247,7 @@ async def drop_guild_app_refs(*, guild_id: int) -> int:
     them routed into the guild role being deleted.
     """
     async with db_session.AdminSessionLocal() as session:
-        dropped = await identity_refs.drop_sector_refs(
-            session, sector_guild_id=guild_id
-        )
+        dropped = await identity_refs.drop_guild_refs(session, guild_id=guild_id)
         await session.commit()
     return dropped
 

--- a/backend/app/services/platform/identity_refs.py
+++ b/backend/app/services/platform/identity_refs.py
@@ -14,10 +14,12 @@ See ``history/opaque-identity-design.md``.
 
 from __future__ import annotations
 
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import and_, exists, func, or_
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import delete, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -38,7 +40,9 @@ __all__ = [
     "billing_refs",
     "billing_user_ref",
     "drop_entity_refs",
+    "drop_guild_refs",
     "drop_sector_refs",
+    "forget_user",
     "ensure_ref",
     "existing_ref",
     "mint_ref",
@@ -49,6 +53,8 @@ __all__ = [
     "resolve_billing_guild",
     "resolve_ref",
 ]
+
+logger = logging.getLogger(__name__)
 
 #: How long a replaced reference keeps resolving. Long enough for the other
 #: party to pick up the new value and for anything already in flight to land.
@@ -424,6 +430,46 @@ async def drop_sector_refs(
         clause = and_(clause, IdentityRef.purpose == purpose.value)
     result = await session.exec(delete(IdentityRef).where(clause))
     return result.rowcount or 0
+
+
+async def drop_guild_refs(session: AsyncSession, *, guild_id: int) -> int:
+    """Everything a deleted guild leaves in this table. Returns the count.
+
+    Two halves, because a guild appears here in two ways. The sectors INSIDE
+    it name its members to each app installed there. The guild itself is also
+    named — by billing, whose sector is the whole deployment and whose rows
+    therefore carry no ``sector_guild_id`` to find them by.
+    """
+    return await drop_sector_refs(
+        session, sector_guild_id=guild_id
+    ) + await drop_entity_refs(
+        session, entity_type=IdentityEntity.guild, entity_id=guild_id
+    )
+
+
+async def forget_user(*, user_id: int) -> int:
+    """Drop every reference to one person, reporting rather than raising.
+
+    Called once the account is erased and after the apps holding those
+    references have been told, so a revocation already on its way still names
+    somebody. Opens its own session for the reason ``billing_user_ref`` does —
+    the callers are request handlers routed to other roles — and runs after the
+    commit, where a failure must not undo the erasure.
+    """
+    from app.db.session import AdminSessionLocal
+
+    try:
+        async with AdminSessionLocal() as session:
+            dropped = await drop_entity_refs(
+                session, entity_type=IdentityEntity.user, entity_id=user_id
+            )
+            await session.commit()
+    except SQLAlchemyError:
+        logger.warning(
+            "identity refs: references for erased user %s were not removed", user_id
+        )
+        return 0
+    return dropped
 
 
 async def purge_orphaned_sector_refs(session: AsyncSession) -> int:

--- a/backend/app/services/platform/identity_refs_test.py
+++ b/backend/app/services/platform/identity_refs_test.py
@@ -22,6 +22,7 @@ from app.models.platform.identity_ref import (
 from app.services.platform.identity_refs import (
     REF_GRACE_PERIOD,
     drop_entity_refs,
+    drop_guild_refs,
     ensure_ref,
     mint_ref,
     purge_retired_refs,
@@ -339,6 +340,36 @@ class TestRemoval:
         assert dropped == 2
         assert await resolve_ref(session, ref=billing) is None
         assert await resolve_ref(session, ref=at_app) is None
+
+    @pytest.mark.integration
+    async def test_a_deleted_guild_leaves_neither_half(self, session):
+        """A guild is in this table twice and both have to go.
+
+        Its members are named to each app installed there, in sectors the guild
+        owns. The guild itself is named by billing, whose sector is the whole
+        deployment — so those rows carry no ``sector_guild_id`` and a sweep
+        looking for one never finds them.
+        """
+        own = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=5, purpose=BILLING
+        )
+        member = await ensure_ref(
+            session,
+            entity_type=IdentityEntity.user,
+            entity_id=9,
+            purpose=IdentityPurpose.app,
+            sector_guild_id=5,
+            sector_id=2,
+        )
+        elsewhere = await ensure_ref(
+            session, entity_type=IdentityEntity.guild, entity_id=6, purpose=BILLING
+        )
+
+        assert await drop_guild_refs(session, guild_id=5) == 2
+        assert await resolve_ref(session, ref=own) is None
+        assert await resolve_ref(session, ref=member) is None
+        # Another guild's name is not this guild's to take.
+        assert await resolve_ref(session, ref=elsewhere) is not None
 
     @pytest.mark.integration
     async def test_the_sweep_takes_only_what_has_stopped_resolving(self, session):

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -17,6 +17,7 @@ from app.models.platform.user_notification_prefs import UserNotificationPrefs
 from app.models.platform.user_profile_view import MemberProfile
 from app.models.platform.guild import GuildMembership, GuildRole
 from app.services.auth import identity as identity_service
+from app.services.platform import identity_refs
 from app.services.platform import user_avatars as user_avatars_service
 from app.models.tenant.resource_grant import ResourceGrant
 from app.models.tenant.task import TaskAssignee
@@ -508,6 +509,9 @@ async def soft_delete_user(session: AsyncSession, user_id: int) -> None:
     # revocation either all succeed or all roll back together.
     await session.commit()
     await _dispatch_queued_revocations(session)
+    # Last, because the revocations above name this person to each app by the
+    # very references this removes.
+    await identity_refs.forget_user(user_id=user_id)
 
 
 async def _dispatch_queued_revocations(session: AsyncSession) -> None:
@@ -774,6 +778,9 @@ async def hard_delete_user(
     await session.delete(user)
 
     await session.commit()
+    # After the commit: the row is gone, so what outside parties were given to
+    # name this person by should stop resolving to anybody.
+    await identity_refs.forget_user(user_id=user_id)
 
 
 # The member-lookup helpers below bind to ``MemberProfile`` — the guild

--- a/backend/app/services/platform/users_test.py
+++ b/backend/app/services/platform/users_test.py
@@ -318,6 +318,55 @@ async def test_soft_delete_user_anonymizes_pii(session: AsyncSession):
 
 @pytest.mark.unit
 @pytest.mark.service
+async def test_erasing_a_user_stops_their_references_resolving(
+    session: AsyncSession,
+):
+    """The names outside parties know somebody by are part of the erasure.
+
+    Billing holds one and keeps it — it is the key an account's history hangs
+    on — and each installed app holds its own. Once the person is gone, none of
+    them has anyone left to resolve to, and the mapping is the only thing that
+    could still join them back to a row.
+
+    Anonymizing counts: the row survives so old content stays legible, but the
+    person does not, and a reference is a name for the person.
+    """
+    from app.models.platform.identity_ref import IdentityEntity, IdentityPurpose
+    from app.services.platform.identity_refs import ensure_ref, resolve_ref
+
+    victim = await create_user(session, email="forgetme@example.com")
+    bystander = await create_user(session, email="stays@example.com")
+
+    billing_ref = await ensure_ref(
+        session,
+        entity_type=IdentityEntity.user,
+        entity_id=victim.id,
+        purpose=IdentityPurpose.billing,
+    )
+    app_ref = await ensure_ref(
+        session,
+        entity_type=IdentityEntity.user,
+        entity_id=victim.id,
+        purpose=IdentityPurpose.app,
+        sector_guild_id=1,
+        sector_id=1,
+    )
+    kept = await ensure_ref(
+        session,
+        entity_type=IdentityEntity.user,
+        entity_id=bystander.id,
+        purpose=IdentityPurpose.billing,
+    )
+    await session.commit()
+
+    await user_service.soft_delete_user(session, victim.id)
+
+    assert await resolve_ref(session, ref=billing_ref) is None
+    assert await resolve_ref(session, ref=app_ref) is None
+    # One person's erasure is not everybody's.
+    assert await resolve_ref(session, ref=kept) is not None
+
+
 async def test_soft_delete_user_scrubs_addressed_invites(session: AsyncSession):
     """Anonymizing a user must erase their address from any guild invite bound
     to it — a lingering invite otherwise keeps a reversible copy of the very


### PR DESCRIPTION
## Problem

A reference is the only link between a person and what an outside service calls them. That link survived the person.

`identity_refs.entity_id` is a plain `Integer` with no foreign key, so nothing cascades — and [`drop_entity_refs`](backend/app/services/platform/identity_refs.py), written and tested for exactly this, had **no production caller**. Neither `soft_delete_user` nor `hard_delete_user` touched the table, though both already scrub tokens, API keys, push tokens and invite addresses.

The sector half was handled: `drop_sector_refs` runs on app uninstall and webhook removal, and guild deletion reaches it through `forget_guild` at all three call sites. What that misses is anything without a sector — a billing reference's sector is the whole deployment, so its rows carry no `sector_guild_id` and no sweep keyed on one ever finds them.

So after an erasure, these stayed:

- every reference to the erased **person**, for every purpose
- a deleted **guild's own** name, as distinct from its members' names inside it

Not a misrouting risk — ids are not reused, so a stale reference resolves to nothing. It is an erasure gap: something still holding a reference kept a mapping back to whoever it named.

## Changes

- `identity_refs.drop_guild_refs` — both halves of what a deleted guild leaves: the sectors inside it, and the guild's own names. `drop_guild_app_refs` calls this instead of `drop_sector_refs`, so all three guild-deletion sites are covered without touching them.
- `identity_refs.forget_user` — every reference to one person. Opens its own system-engine session (the callers are request handlers routed to other roles) and reports rather than raises, since a failure must not undo an erasure that has committed.
- Called from **both** erasure paths. Placed after `_dispatch_queued_revocations`, deliberately: those tell each app the person's credentials are finished and name them by the very references being removed.

Anonymizing counts as erasure here. The row survives so old content stays legible, but the person does not, and a reference is a name for the person.

## Testing

- `test_a_deleted_guild_leaves_neither_half` — a guild's own billing reference and a member's app reference in its sector both go; another guild's is untouched.
- `test_erasing_a_user_stops_their_references_resolving` — a person's billing and app references stop resolving after anonymizing; a bystander's does not.
- Both verified load-bearing: unwiring `forget_user` fails the second, dropping the entity half of `drop_guild_refs` fails the first.
- `identity_refs_test.py` + `app_refs_test.py` — 40 passed. `users_test.py` — 18 passed. `ruff` and `ty` clean.