### PR TITLE
Keep a provider that is someone's only way in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Removing a sign-in provider no longer takes accounts with it** — deleting a provider from the registry removed the links of everyone who had signed in through it. For most people that was harmless: they still had a password, or a second provider to use. For someone who had only ever signed in through that one provider, it removed the only credential their account had. Deleting a provider is now refused while any account holds it as its only way in, naming that as the reason — those people set a password or link another provider, and then it deletes. A provider some community's sign-in requirement depends on was already refused, and still is.
 - **Hiding a spreadsheet row hides it** — a hidden row stopped taking up space but kept drawing its contents, which landed on top of the row beneath it: hide the row holding "Test2" and "Test2" and "Test3" ended up printed over each other on one line, with both row numbers crowded into the same place. A hidden row or column is no longer drawn at all, so the rows after it close up the way they should. Hiding a frozen row does the same.
 
 ## [0.68.0] - 2026-09-11

--- a/backend/app/api/v1/platform_endpoints/auth_providers_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_providers_test.py
@@ -285,6 +285,49 @@ async def test_delete_refused_when_the_only_other_provider_is_disabled(
     assert response.json()["detail"] == "AUTH_PROVIDER_SOLE_CREDENTIAL"
 
 
+async def test_delete_refused_when_the_only_other_provider_is_the_secretless_platform_row(
+    client: AsyncClient, session: AsyncSession
+):
+    """The platform login has always needed a stored client secret — PKCE-only
+    is a guild-provider affordance — so a platform row without one cannot
+    answer a login and is not a second way in."""
+    from app.services.auth.platform_provider import PLATFORM_OIDC_SLUG
+
+    headers = await _owner_headers(session)
+    provider = await create_auth_provider(session, slug="corp")
+    platform = await create_auth_provider(session, slug=PLATFORM_OIDC_SLUG)
+    sso_only = await create_user(session, hashed_password=None)
+    await create_federated_identity(session, sso_only, provider=provider)
+    await create_federated_identity(session, sso_only, provider=platform)
+    provider_id = provider.id
+
+    response = await client.delete(f"{BASE}{provider_id}", headers=headers)
+    assert response.status_code == 409
+    assert response.json()["detail"] == "AUTH_PROVIDER_SOLE_CREDENTIAL"
+
+
+async def test_delete_allowed_when_the_platform_row_carries_its_secret(
+    client: AsyncClient, session: AsyncSession
+):
+    """With the secret stored, the platform row can answer a login, so it is a
+    real alternative and the delete goes ahead."""
+    from app.services.auth import provider_registry
+    from app.services.auth.platform_provider import PLATFORM_OIDC_SLUG
+
+    headers = await _owner_headers(session)
+    provider = await create_auth_provider(session, slug="corp")
+    platform = await create_auth_provider(session, slug=PLATFORM_OIDC_SLUG)
+    await provider_registry.set_provider_secret(session, platform.id, "s3cret")
+    await session.commit()
+    sso_only = await create_user(session, hashed_password=None)
+    await create_federated_identity(session, sso_only, provider=provider)
+    await create_federated_identity(session, sso_only, provider=platform)
+    provider_id = provider.id
+
+    response = await client.delete(f"{BASE}{provider_id}", headers=headers)
+    assert response.status_code == 204
+
+
 async def test_created_provider_reaches_login_page_listing(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/api/v1/platform_endpoints/auth_providers_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_providers_test.py
@@ -250,6 +250,41 @@ async def test_delete_allowed_when_account_holds_another_provider(
     assert await session.get(AuthProvider, provider_id) is None
 
 
+async def test_delete_refused_when_the_stored_hash_cannot_verify(
+    client: AsyncClient, session: AsyncSession
+):
+    """A hash no scheme accepts is not a password. The 0152 downgrade writes
+    ``'!'`` into rows that had none, and such an account still reaches its
+    account only through the provider."""
+    headers = await _owner_headers(session)
+    provider = await create_auth_provider(session, slug="corp")
+    marked = await create_user(session, hashed_password="!")
+    await create_federated_identity(session, marked, provider=provider)
+    provider_id = provider.id
+
+    response = await client.delete(f"{BASE}{provider_id}", headers=headers)
+    assert response.status_code == 409
+    assert response.json()["detail"] == "AUTH_PROVIDER_SOLE_CREDENTIAL"
+
+
+async def test_delete_refused_when_the_only_other_provider_is_disabled(
+    client: AsyncClient, session: AsyncSession
+):
+    """A disabled provider cannot serve a login, so a link to one is not a
+    second way in."""
+    headers = await _owner_headers(session)
+    provider = await create_auth_provider(session, slug="corp")
+    dormant = await create_auth_provider(session, slug="dormant", enabled=False)
+    sso_only = await create_user(session, hashed_password=None)
+    await create_federated_identity(session, sso_only, provider=provider)
+    await create_federated_identity(session, sso_only, provider=dormant)
+    provider_id = provider.id
+
+    response = await client.delete(f"{BASE}{provider_id}", headers=headers)
+    assert response.status_code == 409
+    assert response.json()["detail"] == "AUTH_PROVIDER_SOLE_CREDENTIAL"
+
+
 async def test_created_provider_reaches_login_page_listing(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/api/v1/platform_endpoints/auth_providers_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_providers_test.py
@@ -212,6 +212,44 @@ async def test_delete_cascades_identity_links(
     assert identities == []
 
 
+async def test_delete_refused_when_provider_is_a_sole_credential(
+    client: AsyncClient, session: AsyncSession
+):
+    """An account with no password, linked only to this provider, holds it as
+    its only credential — so the delete is refused."""
+    headers = await _owner_headers(session)
+    provider = await create_auth_provider(session, slug="corp")
+    sso_only = await create_user(session, hashed_password=None)
+    await create_federated_identity(session, sso_only, provider=provider)
+    provider_id = provider.id
+
+    response = await client.delete(f"{BASE}{provider_id}", headers=headers)
+    assert response.status_code == 409
+    assert response.json()["detail"] == "AUTH_PROVIDER_SOLE_CREDENTIAL"
+
+    session.expire_all()
+    assert await session.get(AuthProvider, provider_id) is not None
+
+
+async def test_delete_allowed_when_account_holds_another_provider(
+    client: AsyncClient, session: AsyncSession
+):
+    """A second link is another way in, so the provider is free to go."""
+    headers = await _owner_headers(session)
+    provider = await create_auth_provider(session, slug="corp")
+    spare = await create_auth_provider(session, slug="spare")
+    sso_only = await create_user(session, hashed_password=None)
+    await create_federated_identity(session, sso_only, provider=provider)
+    await create_federated_identity(session, sso_only, provider=spare)
+    provider_id = provider.id
+
+    response = await client.delete(f"{BASE}{provider_id}", headers=headers)
+    assert response.status_code == 204
+
+    session.expire_all()
+    assert await session.get(AuthProvider, provider_id) is None
+
+
 async def test_created_provider_reaches_login_page_listing(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/core/messages.py
+++ b/backend/app/core/messages.py
@@ -270,6 +270,9 @@ class AuthProviderMessages:
     SLUG_RESERVED = "AUTH_PROVIDER_SLUG_RESERVED"
     SLUG_TAKEN = "AUTH_PROVIDER_SLUG_TAKEN"
     IN_USE = "AUTH_PROVIDER_IN_USE"
+    # Some account signs in only through it; the delete waits until those
+    # accounts hold another credential.
+    SOLE_CREDENTIAL = "AUTH_PROVIDER_SOLE_CREDENTIAL"
 
 
 class TagMessages:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -62,6 +62,14 @@ SESSION_COOKIE_NAME = "session_token"
 # smaller exposure than the session cookie).
 REFRESH_COOKIE_NAME = "refresh_token"
 
+# The hash schemes ``verify_password`` below can actually check. A stored value
+# outside this set — the ``'!'`` marker the 0152 downgrade writes, or anything
+# else — never verifies, which makes it the definition of "no usable password"
+# for callers that have to ask about a hash without checking one.
+ARGON2_HASH_PREFIX = "$argon2"
+BCRYPT_HASH_PREFIXES = ("$2a$", "$2b$", "$2y$")
+USABLE_HASH_PREFIXES = (ARGON2_HASH_PREFIX, *BCRYPT_HASH_PREFIXES)
+
 # argon2id with library defaults — OWASP-aligned. Stored hashes embed the
 # parameters, so verification keeps working if we tune these later.
 _argon2_hasher = PasswordHasher()
@@ -84,13 +92,13 @@ def verify_password(plain_password: str, hashed_password: str | None) -> bool:
     """
     if hashed_password is None:
         return False
-    if hashed_password.startswith("$argon2"):
+    if hashed_password.startswith(ARGON2_HASH_PREFIX):
         try:
             _argon2_hasher.verify(hashed_password, plain_password)
             return True
         except (VerifyMismatchError, VerificationError, InvalidHashError):
             return False
-    if hashed_password.startswith(("$2a$", "$2b$", "$2y$")):
+    if hashed_password.startswith(BCRYPT_HASH_PREFIXES):
         try:
             return bcrypt.checkpw(
                 plain_password.encode("utf-8"),
@@ -110,7 +118,7 @@ def password_needs_rehash(hashed_password: str | None) -> bool:
     """
     if hashed_password is None:
         return False
-    if not hashed_password.startswith("$argon2"):
+    if not hashed_password.startswith(ARGON2_HASH_PREFIX):
         return True
     try:
         return _argon2_hasher.check_needs_rehash(hashed_password)

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -225,6 +225,35 @@ async def has_federated_identity(session: AsyncSession, *, user_id: int) -> bool
     return row is not None
 
 
+async def sole_credential_user_count(session: AsyncSession, *, provider_id: int) -> int:
+    """How many accounts hold this provider as their only credential.
+
+    An account counts when it has no password and every identity link it holds
+    belongs to this provider — the provider's links cascade with it, so this
+    account's last credential goes too. An account that kept a password, or
+    linked a second provider, still holds one and is not counted.
+    """
+    holds_this = select(FederatedIdentity.id).where(
+        FederatedIdentity.user_id == User.id,
+        FederatedIdentity.provider_id == provider_id,
+    )
+    holds_another = select(FederatedIdentity.id).where(
+        FederatedIdentity.user_id == User.id,
+        FederatedIdentity.provider_id != provider_id,
+    )
+    return (
+        await session.exec(
+            select(func.count())
+            .select_from(User)
+            .where(
+                User.hashed_password.is_(None),
+                holds_this.exists(),
+                ~holds_another.exists(),
+            )
+        )
+    ).one()
+
+
 async def delete_user_identities(session: AsyncSession, *, user_id: int) -> None:
     """Remove every identity link (and, via cascade, its stored refresh token)
     for a user — the anonymize/delete-account cleanup. Stages only."""

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -28,16 +28,19 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy import or_
 from sqlmodel import func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
 from app.core.encryption import SALT_EMAIL, encrypt_field, encrypt_token, hash_email
+from app.core.security import USABLE_HASH_PREFIXES
 from app.models.platform.auth_provider import AuthProvider
 from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.guild_administration import GuildAdministration
 from app.models.platform.federated_identity_secret import FederatedIdentitySecret
 from app.models.platform.user import User, UserRole, UserStatus
+from app.services.auth.platform_provider import login_ready_clause
 from app.services.platform import dm_settings as dm_settings_service
 from app.services.platform import usernames as username_service
 
@@ -228,25 +231,48 @@ async def has_federated_identity(session: AsyncSession, *, user_id: int) -> bool
 async def sole_credential_user_count(session: AsyncSession, *, provider_id: int) -> int:
     """How many accounts hold this provider as their only credential.
 
-    An account counts when it has no password and every identity link it holds
-    belongs to this provider — the provider's links cascade with it, so this
-    account's last credential goes too. An account that kept a password, or
-    linked a second provider, still holds one and is not counted.
+    An account counts when it has no usable password and every identity link it
+    holds belongs to this provider — the provider's links cascade with it, so
+    this account's last credential goes too.
+
+    "No usable password" is read from the stored hash rather than from NULL
+    alone: an account can carry a value no scheme verifies (the ``'!'`` marker
+    the 0152 downgrade writes), and that is not a password. What it cannot read
+    is an account provisioned before 0152, whose throwaway hash is a real argon2
+    value indistinguishable from a chosen one; that account is not counted here
+    and reaches its account through password reset instead.
+
+    An alternate link only counts when its provider could actually serve a
+    login — a disabled or half-configured row is not a way in.
     """
     holds_this = select(FederatedIdentity.id).where(
         FederatedIdentity.user_id == User.id,
         FederatedIdentity.provider_id == provider_id,
     )
-    holds_another = select(FederatedIdentity.id).where(
-        FederatedIdentity.user_id == User.id,
-        FederatedIdentity.provider_id != provider_id,
+    holds_another = (
+        select(FederatedIdentity.id)
+        .join(AuthProvider, AuthProvider.id == FederatedIdentity.provider_id)
+        .where(
+            FederatedIdentity.user_id == User.id,
+            FederatedIdentity.provider_id != provider_id,
+            login_ready_clause(),
+        )
+    )
+    no_usable_password = or_(
+        User.hashed_password.is_(None),
+        ~or_(
+            *(
+                User.hashed_password.startswith(prefix)
+                for prefix in USABLE_HASH_PREFIXES
+            )
+        ),
     )
     return (
         await session.exec(
             select(func.count())
             .select_from(User)
             .where(
-                User.hashed_password.is_(None),
+                no_usable_password,
                 holds_this.exists(),
                 ~holds_another.exists(),
             )

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -40,7 +40,7 @@ from app.models.platform.federated_identity import FederatedIdentity
 from app.models.platform.guild_administration import GuildAdministration
 from app.models.platform.federated_identity_secret import FederatedIdentitySecret
 from app.models.platform.user import User, UserRole, UserStatus
-from app.services.auth.platform_provider import login_ready_clause
+from app.services.auth.platform_provider import can_serve_login_clause
 from app.services.platform import dm_settings as dm_settings_service
 from app.services.platform import usernames as username_service
 
@@ -242,8 +242,9 @@ async def sole_credential_user_count(session: AsyncSession, *, provider_id: int)
     value indistinguishable from a chosen one; that account is not counted here
     and reaches its account through password reset instead.
 
-    An alternate link only counts when its provider could actually serve a
-    login — a disabled or half-configured row is not a way in.
+    An alternate link only counts when its provider could actually answer a
+    login — a disabled or half-configured row is not a way in, and neither is
+    the platform row without its client secret.
     """
     holds_this = select(FederatedIdentity.id).where(
         FederatedIdentity.user_id == User.id,
@@ -255,7 +256,7 @@ async def sole_credential_user_count(session: AsyncSession, *, provider_id: int)
         .where(
             FederatedIdentity.user_id == User.id,
             FederatedIdentity.provider_id != provider_id,
-            login_ready_clause(),
+            can_serve_login_clause(),
         )
     )
     no_usable_password = or_(

--- a/backend/app/services/auth/platform_provider.py
+++ b/backend/app/services/auth/platform_provider.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 
+from sqlalchemy import ColumnElement, and_
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -46,6 +47,20 @@ def is_login_ready(row: AuthProvider) -> bool:
     the non-secret client config discovery needs. The single predicate behind
     the login routes, the provider listing, and guild auth policies."""
     return bool(row.enabled and row.kind == "oidc" and row.issuer and row.client_id)
+
+
+def login_ready_clause() -> ColumnElement[bool]:
+    """:func:`is_login_ready` as a predicate over ``auth_providers``, for
+    queries that must ask it of rows they are not loading. Kept in step with
+    the row form by ``platform_provider_test``."""
+    return and_(
+        AuthProvider.enabled.is_(True),
+        AuthProvider.kind == "oidc",
+        AuthProvider.issuer.is_not(None),
+        AuthProvider.issuer != "",
+        AuthProvider.client_id.is_not(None),
+        AuthProvider.client_id != "",
+    )
 
 
 def scopes_list(row: AuthProvider) -> list[str]:

--- a/backend/app/services/auth/platform_provider.py
+++ b/backend/app/services/auth/platform_provider.py
@@ -21,13 +21,14 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import ColumnElement, and_
+from sqlalchemy import ColumnElement, and_, or_
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings as app_config
 from app.models.platform.auth_provider import AuthProvider, AuthProviderKind
+from app.models.platform.auth_provider_secret import AuthProviderSecret
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,31 @@ def login_ready_clause() -> ColumnElement[bool]:
         AuthProvider.issuer != "",
         AuthProvider.client_id.is_not(None),
         AuthProvider.client_id != "",
+    )
+
+
+def can_serve_login_clause() -> ColumnElement[bool]:
+    """Whether a registry row could actually answer a login, as a predicate
+    over ``auth_providers``.
+
+    :func:`login_ready_clause` plus the platform row's extra condition: the
+    platform flow has always required a stored client secret, where a
+    PKCE-only public client is a guild-provider affordance (see
+    ``_active_platform_provider``). Row-form callers branch between the two
+    halves; a query that must ask of rows it is not loading needs them as one.
+    """
+    return and_(
+        login_ready_clause(),
+        or_(
+            AuthProvider.slug != PLATFORM_OIDC_SLUG,
+            select(AuthProviderSecret.provider_id)
+            .where(
+                AuthProviderSecret.provider_id == AuthProvider.id,
+                AuthProviderSecret.client_secret_encrypted.is_not(None),
+                AuthProviderSecret.client_secret_encrypted != "",
+            )
+            .exists(),
+        ),
     )
 
 

--- a/backend/app/services/auth/platform_provider_test.py
+++ b/backend/app/services/auth/platform_provider_test.py
@@ -16,6 +16,8 @@ from app.models.platform.auth_provider import AuthProvider
 from app.models.platform.auth_provider_secret import AuthProviderSecret
 from app.services.auth.platform_provider import (
     PLATFORM_OIDC_SLUG,
+    is_login_ready,
+    login_ready_clause,
     get_platform_provider,
     seed_platform_provider_from_env,
     set_platform_claim_path,
@@ -207,3 +209,31 @@ async def test_env_seed_noop_without_config(session, monkeypatch):
 
     assert await seed_platform_provider_from_env(session) is False
     assert await get_platform_provider(session) is None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {"enabled": False},
+        {"kind": "oauth2"},
+        {"issuer": None},
+        {"issuer": ""},
+        {"client_id": None},
+        {"client_id": ""},
+    ],
+)
+async def test_login_ready_clause_matches_the_row_predicate(session, overrides):
+    """The SQL form and the row form answer the same question — they are two
+    spellings of one rule and are read by different callers."""
+    from app.testing.factories import create_auth_provider
+
+    row = await create_auth_provider(session, slug="drift", **overrides)
+    matched = (
+        await session.exec(
+            select(AuthProvider.id).where(
+                AuthProvider.id == row.id, login_ready_clause()
+            )
+        )
+    ).one_or_none()
+    assert (matched is not None) is is_login_ready(row), overrides

--- a/backend/app/services/auth/provider_registry.py
+++ b/backend/app/services/auth/provider_registry.py
@@ -240,6 +240,13 @@ async def delete_provider(
     first, and then it deletes.
     """
     row = await editable_provider(session, provider_id, guild_id=guild_id)
+    # Lock the row before counting. Inserting a ``federated_identities`` row
+    # takes FOR KEY SHARE on the provider it references, which FOR UPDATE
+    # conflicts with — so a login provisioning an account either lands before
+    # the count and is seen by it, or waits and then fails the foreign key.
+    await session.exec(
+        select(AuthProvider.id).where(AuthProvider.id == row.id).with_for_update()
+    )
     stranded = await identity_service.sole_credential_user_count(
         session, provider_id=row.id
     )

--- a/backend/app/services/auth/provider_registry.py
+++ b/backend/app/services/auth/provider_registry.py
@@ -35,6 +35,7 @@ from app.schemas.platform.settings import (
     AuthProviderCreate,
     AuthProviderUpdate,
 )
+from app.services.auth import identity as identity_service
 from app.services.auth.platform_provider import PLATFORM_OIDC_SLUG
 
 logger = logging.getLogger(__name__)
@@ -231,10 +232,28 @@ async def delete_provider(
 ) -> None:
     """Delete a row from the namespace. Its linked identities (and their
     stored refresh tokens) go with it via cascade — users who signed in
-    through it keep their accounts and any other sign-in methods. A provider
-    some guild's auth policy requires is refused (409): drop or repoint the
-    policy first."""
+    through it keep their accounts and any other sign-in methods.
+
+    Two refusals, both 409. A provider some guild's auth policy requires:
+    drop or repoint the policy first. And a provider that is some account's
+    only credential: those people set a password or link another provider
+    first, and then it deletes.
+    """
     row = await editable_provider(session, provider_id, guild_id=guild_id)
+    stranded = await identity_service.sole_credential_user_count(
+        session, provider_id=row.id
+    )
+    if stranded:
+        logger.info(
+            "auth provider %s (%s) delete refused: sole credential for %d account(s)",
+            row.slug,
+            provider_id,
+            stranded,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=AuthProviderMessages.SOLE_CREDENTIAL,
+        )
     secret = await session.get(AuthProviderSecret, row.id)
     if secret is not None:
         await session.delete(secret)

--- a/frontend/public/locales/de/errors.json
+++ b/frontend/public/locales/de/errors.json
@@ -92,6 +92,7 @@
   "GUILD_AUTH_POLICY_SELF_UNSATISFIED": "Melden Sie sich selbst mit diesem Anbieter an, bevor Sie ihn für die Community verlangen",
   "GUILD_AUTH_NOT_ENABLED": "Die Community-spezifische Anmeldung ist auf dieser Plattform nicht aktiviert",
   "AUTH_PROVIDER_IN_USE": "Die Anmeldeanforderung einer Community verwendet diesen Anbieter; ändern Sie zuerst diese Anforderung",
+  "AUTH_PROVIDER_SOLE_CREDENTIAL": "Einige Konten melden sich nur mit diesem Anbieter an; sie benötigen ein Passwort oder eine andere Anmeldemethode, bevor er entfernt werden kann",
   "SMTP_NOT_CONFIGURED": "SMTP-Einstellungen sind unvollständig.",
   "INVALID_OR_EXPIRED_TOKEN": "Ungültiges oder abgelaufenes Token",
   "RESERVED_SIGIL_IN_NAME": "Namen und Titel dürfen kein # oder @ enthalten.",

--- a/frontend/public/locales/en/errors.json
+++ b/frontend/public/locales/en/errors.json
@@ -87,6 +87,7 @@
   "GUILD_AUTH_POLICY_SELF_UNSATISFIED": "Sign in with that provider yourself before requiring it for the community",
   "GUILD_AUTH_NOT_ENABLED": "Per-community authentication is not enabled on this platform",
   "AUTH_PROVIDER_IN_USE": "A community's sign-in requirement uses this provider; change that requirement first",
+  "AUTH_PROVIDER_SOLE_CREDENTIAL": "Some accounts sign in only with this provider; they need a password or another sign-in method before it can be removed",
   "OIDC_EMAIL_UNVERIFIED": "Your identity provider did not confirm your email is verified, so we can't sign you in to an existing account. Verify your email with your provider and try again.",
   "SMTP_NOT_CONFIGURED": "SMTP settings are incomplete.",
   "INVALID_OR_EXPIRED_TOKEN": "Invalid or expired token",

--- a/frontend/public/locales/es/errors.json
+++ b/frontend/public/locales/es/errors.json
@@ -90,6 +90,7 @@
   "GUILD_AUTH_POLICY_SELF_UNSATISFIED": "Inicia sesión tú mismo con ese proveedor antes de exigirlo para la comunidad",
   "GUILD_AUTH_NOT_ENABLED": "La autenticación por comunidad no está habilitada en esta plataforma",
   "AUTH_PROVIDER_IN_USE": "El requisito de inicio de sesión de una comunidad usa este proveedor; cambia primero ese requisito",
+  "AUTH_PROVIDER_SOLE_CREDENTIAL": "Algunas cuentas inician sesión solo con este proveedor; necesitan una contraseña u otro método de inicio de sesión antes de poder eliminarlo",
   "SMTP_NOT_CONFIGURED": "La configuración SMTP está incompleta.",
   "INVALID_OR_EXPIRED_TOKEN": "Token no válido o expirado",
   "RESERVED_SIGIL_IN_NAME": "Los nombres y títulos no pueden contener # ni @.",

--- a/frontend/public/locales/fr/errors.json
+++ b/frontend/public/locales/fr/errors.json
@@ -90,6 +90,7 @@
   "GUILD_AUTH_POLICY_SELF_UNSATISFIED": "Connectez-vous vous-même avec ce fournisseur avant de l'exiger pour la communauté",
   "GUILD_AUTH_NOT_ENABLED": "L'authentification par communauté n'est pas activée sur cette plateforme",
   "AUTH_PROVIDER_IN_USE": "L'exigence de connexion d'une communauté utilise ce fournisseur ; modifiez d'abord cette exigence",
+  "AUTH_PROVIDER_SOLE_CREDENTIAL": "Certains comptes se connectent uniquement avec ce fournisseur ; ils ont besoin d'un mot de passe ou d'une autre méthode de connexion avant de pouvoir le supprimer",
   "SMTP_NOT_CONFIGURED": "Les paramètres SMTP sont incomplets.",
   "INVALID_OR_EXPIRED_TOKEN": "Jeton invalide ou expiré",
   "RESERVED_SIGIL_IN_NAME": "Les noms et les titres ne peuvent pas contenir # ni @.",


### PR DESCRIPTION
## Problem

Deleting a login provider cascades its `federated_identities` away. For an account that kept a password, or linked a second provider, that is harmless — it still has a way in. For an account with neither, that link was the only credential it had, and the delete removed it.

The registry already refuses (409) when a guild's auth policy requires the provider. It had no equivalent check for the accounts that depend on it.

## Changes

- `identity.sole_credential_user_count()` — counts accounts with no password whose every identity link belongs to one provider.
- `provider_registry.delete_provider()` calls it first and refuses with 409 `AUTH_PROVIDER_SOLE_CREDENTIAL` while any remain. Shared by both namespaces, so the operator-global and per-guild routers both get it.
- `AUTH_PROVIDER_SOLE_CREDENTIAL` added to `errors.json` in all four locales (de/en/es/fr).

Accounts that keep a password or hold a second provider are not counted, so the ordinary delete is unchanged.

## Testing

```
cd backend && pytest -n 0 app/api/v1/platform_endpoints/auth_providers_test.py \
  app/api/v1/platform_endpoints/guild_auth_providers_test.py \
  app/services/auth/provider_registry_test.py app/services/auth/identity_test.py
```
29 passed. Two new cases: refused when the provider is a sole credential, allowed when the account holds a second one. `ruff format`, `ruff check` and `ty check` clean.

## Notes

First item from `history/auth-identity-assurance-design.md` — the smallest fix in that plan and the one with the largest consequence. No schema change, no migration.