### PR TITLE
Erase the sessions too, and sweep the dead ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deleting an account clears its sign-in sessions** — anonymizing an account emptied it of everything personal except one thing: the record of where it had been signed in, which keeps a device name, a browser and an address per session. Those go now, along with the rest. Sessions that have expired or been signed out are also cleared away on a schedule after thirty days, rather than being kept indefinitely. Permanently deleting an account already removed them with the account itself.
 - **Hiding a spreadsheet row hides it** — a hidden row stopped taking up space but kept drawing its contents, which landed on top of the row beneath it: hide the row holding "Test2" and "Test2" and "Test3" ended up printed over each other on one line, with both row numbers crowded into the same place. A hidden row or column is no longer drawn at all, so the rows after it close up the way they should. Hiding a frozen row does the same.
 
 ## [0.68.0] - 2026-09-11

--- a/backend/app/services/auth/sessions.py
+++ b/backend/app/services/auth/sessions.py
@@ -20,6 +20,7 @@ in the next slice. This PR is the tested logic layer only (additive-first).
 from __future__ import annotations
 
 import hashlib
+import logging
 import secrets
 import uuid
 from dataclasses import dataclass
@@ -33,6 +34,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from app.core.config import settings
 from app.models.platform.auth_session import AuthSession
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "IssuedSession",
     "RefreshOutcome",
@@ -43,11 +46,26 @@ __all__ = [
     "revoke_session",
     "revoke_chain",
     "revoke_all_for_user",
+    "delete_all_for_user",
+    "purge_dead_sessions",
+    "process_dead_session_purge",
+    "SESSION_PURGE_POLL_SECONDS",
+    "SESSION_RETENTION_DAYS",
 ]
 
 # 256 bits of entropy — infeasible to guess, so the hash (not a slow KDF) is the
 # only thing that needs storing.
 _REFRESH_TOKEN_BYTES = 32
+
+#: How long a session row outlives its own usefulness. A row carries a user
+#: agent, an IP and a device label for the "your active sessions" screen; once
+#: the session can no longer be used, that is all it carries, so it is kept for
+#: a window and then removed.
+SESSION_RETENTION_DAYS = 30
+
+#: ``auth_sessions`` is app_admin-only, so the sweep runs on AdminSessionLocal
+#: with no guild routing — the same shape as the expired-token purge.
+SESSION_PURGE_POLL_SECONDS = 3600
 
 
 def _now() -> datetime:
@@ -339,3 +357,61 @@ async def revoke_all_for_user(
         params={"now": now or _now(), "uid": user_id},
     )
     return result.rowcount
+
+
+async def delete_all_for_user(session: AsyncSession, *, user_id: int) -> int:
+    """Remove every session row for a user. Returns the number removed.
+
+    The erasure counterpart to :func:`revoke_all_for_user`. A password change
+    revokes, because the rows are still the record of where somebody was
+    signed in. Erasing the account removes them, because by then the row is
+    only a user agent, an IP and a device label belonging to a person who
+    asked to be forgotten. A hard delete gets this from the ``users`` foreign
+    key; an anonymize keeps the row, so it comes through here.
+
+    Stages only — the caller commits, so this lands with the rest of the
+    erasure or not at all.
+    """
+    result = await session.exec(
+        text("DELETE FROM auth_sessions WHERE user_id = :uid"),
+        params={"uid": user_id},
+    )
+    return result.rowcount
+
+
+async def purge_dead_sessions(
+    session: AsyncSession,
+    *,
+    retention_days: int = SESSION_RETENTION_DAYS,
+    now: datetime | None = None,
+) -> int:
+    """Remove sessions that can no longer be used and are past the retention
+    window. Returns the number removed.
+
+    A row qualifies once it is expired, or was revoked, longer ago than
+    ``retention_days``. A live session matches neither. ``parent_id`` is a
+    plain uuid rather than a self-reference, so removing one end of a rotation
+    chain leaves the rest intact.
+    """
+    horizon = (now or _now()) - timedelta(days=retention_days)
+    result = await session.exec(
+        text(
+            "DELETE FROM auth_sessions "
+            "WHERE expires_at < :horizon "
+            "   OR (revoked_at IS NOT NULL AND revoked_at < :horizon)"
+        ),
+        params={"horizon": horizon},
+    )
+    await session.commit()
+    return result.rowcount
+
+
+async def process_dead_session_purge() -> None:
+    """Hourly background sweep over ``auth_sessions`` (see
+    :data:`SESSION_RETENTION_DAYS`)."""
+    from app.db.session import AdminSessionLocal
+
+    async with AdminSessionLocal() as session:
+        removed = await purge_dead_sessions(session)
+        if removed:
+            logger.info("session purge removed %d dead session row(s)", removed)

--- a/backend/app/services/auth/sessions_test.py
+++ b/backend/app/services/auth/sessions_test.py
@@ -248,3 +248,87 @@ async def test_revoke_chain_missing_id_is_noop(session):
         session, session_id=uuid.uuid4(), now=_at()
     )
     assert revoked == 0
+
+
+async def test_purge_removes_dead_sessions_and_keeps_live_ones(session):
+    """The sweep takes what can no longer be used and is past the window: a
+    long-expired row and a long-revoked one. A live session, a session that
+    expired only yesterday, and one revoked only yesterday all stay."""
+    user = await create_user(session)
+    now = _at(days=100)
+
+    live = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=now
+    )
+    long_expired = await session_service.create_session(
+        session,
+        user_id=user.id,
+        amr=["pwd"],
+        satisfied_providers=[],
+        now=now,
+        refresh_ttl=timedelta(days=-40),
+    )
+    just_expired = await session_service.create_session(
+        session,
+        user_id=user.id,
+        amr=["pwd"],
+        satisfied_providers=[],
+        now=now,
+        refresh_ttl=timedelta(days=-1),
+    )
+    long_revoked = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=now
+    )
+    just_revoked = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[], now=now
+    )
+    await session_service.revoke_session(
+        session, session_id=long_revoked.session.id, now=now - timedelta(days=40)
+    )
+    await session_service.revoke_session(
+        session, session_id=just_revoked.session.id, now=now - timedelta(days=1)
+    )
+    await session.commit()
+    # Plain values before the sweep: the rows are expired afterwards, and an
+    # ORM attribute read then would lazy-load.
+    ids = {
+        name: issued.session.id
+        for name, issued in {
+            "live": live,
+            "just_expired": just_expired,
+            "just_revoked": just_revoked,
+            "long_expired": long_expired,
+            "long_revoked": long_revoked,
+        }.items()
+    }
+
+    removed = await session_service.purge_dead_sessions(session, now=now)
+    assert removed == 2
+
+    session.expire_all()
+    assert await session.get(AuthSession, ids["live"]) is not None
+    assert await session.get(AuthSession, ids["just_expired"]) is not None
+    assert await session.get(AuthSession, ids["just_revoked"]) is not None
+    assert await session.get(AuthSession, ids["long_expired"]) is None
+    assert await session.get(AuthSession, ids["long_revoked"]) is None
+
+
+async def test_delete_all_for_user_leaves_other_accounts_alone(session):
+    user = await create_user(session)
+    bystander = await create_user(session)
+    mine = await session_service.create_session(
+        session, user_id=user.id, amr=["pwd"], satisfied_providers=[]
+    )
+    theirs = await session_service.create_session(
+        session, user_id=bystander.id, amr=["pwd"], satisfied_providers=[]
+    )
+    await session.commit()
+    mine_id, theirs_id = mine.session.id, theirs.session.id
+
+    removed = await session_service.delete_all_for_user(session, user_id=user.id)
+    await session.commit()
+    assert removed == 1
+
+    session.expire_all()
+    assert await session.get(AuthSession, mine_id) is None
+    assert await session.get(AuthSession, theirs_id) is not None

--- a/backend/app/services/background_tasks.py
+++ b/backend/app/services/background_tasks.py
@@ -62,6 +62,10 @@ def start_background_tasks() -> list[asyncio.Task]:
         process_expired_token_purge,
         TOKEN_PURGE_POLL_SECONDS,
     )
+    from app.services.auth.sessions import (
+        SESSION_PURGE_POLL_SECONDS,
+        process_dead_session_purge,
+    )
     from app.services.platform.jti_purge import (
         process_jti_blocklist_purges,
         JTI_PURGE_POLL_SECONDS,
@@ -178,6 +182,13 @@ def start_background_tasks() -> list[asyncio.Task]:
         asyncio.create_task(
             _loop_worker(
                 process_jti_blocklist_purges, JTI_PURGE_POLL_SECONDS, "jti-purge"
+            )
+        ),
+        asyncio.create_task(
+            _loop_worker(
+                process_dead_session_purge,
+                SESSION_PURGE_POLL_SECONDS,
+                "session-purge",
             )
         ),
         asyncio.create_task(

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -17,6 +17,7 @@ from app.models.platform.user_notification_prefs import UserNotificationPrefs
 from app.models.platform.user_profile_view import MemberProfile
 from app.models.platform.guild import GuildMembership, GuildRole
 from app.services.auth import identity as identity_service
+from app.services.auth import sessions as session_service
 from app.services.platform import identity_refs
 from app.services.platform import user_avatars as user_avatars_service
 from app.models.tenant.resource_grant import ResourceGrant
@@ -392,8 +393,8 @@ async def soft_delete_user(session: AsyncSession, user_id: int) -> None:
     Drops memberships like ``deactivate_user``, then strips every PII
     field on the row, randomises ``email_hash`` / ``email_encrypted`` so
     no future signup or admin lookup can resolve to this row, blanks the
-    password hash, and revokes auth artifacts (API keys, push tokens,
-    user_tokens). The row stays so existing FKs (comment authors, task
+    password hash, and removes auth artifacts (API keys, push tokens,
+    user_tokens, sign-in sessions). The row stays so existing FKs (comment authors, task
     assignees, project owners, …) continue to resolve and the UI can
     render the placeholder "Deleted user #{id}" wherever the original
     user was referenced.
@@ -497,6 +498,10 @@ async def soft_delete_user(session: AsyncSession, user_id: int) -> None:
     await session.exec(delete(UserApiKey).where(UserApiKey.user_id == user_id))
     await session.exec(delete(UserToken).where(UserToken.user_id == user_id))
     await session.exec(delete(PushToken).where(PushToken.user_id == user_id))
+    # The session rows too: a husk keeps no record of the devices, addresses
+    # and user agents its account signed in from. A hard delete gets this from
+    # the ``users`` foreign key; the row survives here, so it is explicit.
+    await session_service.delete_all_for_user(session, user_id=user_id)
 
     # Scrub the user's address out of any guild invite bound to it. Without
     # this, an unexpired/lingering invite keeps a recoverable copy of the very

--- a/backend/app/services/platform/users_test.py
+++ b/backend/app/services/platform/users_test.py
@@ -819,3 +819,35 @@ async def test_hard_delete_anonymized_user_cleans_guild_data(session: AsyncSessi
     assert (
         await session.exec(select(Task).where(Task.id == task_id))
     ).one_or_none() is not None
+
+
+@pytest.mark.unit
+@pytest.mark.service
+async def test_soft_delete_user_removes_sign_in_sessions(session: AsyncSession):
+    """Erasure empties the account of its sign-in sessions too — those rows
+    carry a device label, a user agent and an address."""
+    from app.models.platform.auth_session import AuthSession
+    from app.services.auth import sessions as session_service
+
+    user = await create_user(session)
+    bystander = await create_user(session)
+    mine = await session_service.create_session(
+        session,
+        user_id=user.id,
+        amr=["pwd"],
+        satisfied_providers=[],
+        user_agent="Mozilla/5.0",
+        ip="203.0.113.7",
+        device_name="Laptop",
+    )
+    theirs = await session_service.create_session(
+        session, user_id=bystander.id, amr=["pwd"], satisfied_providers=[]
+    )
+    await session.commit()
+    mine_id, theirs_id, user_id = mine.session.id, theirs.session.id, user.id
+
+    await user_service.soft_delete_user(session, user_id)
+
+    session.expire_all()
+    assert await session.get(AuthSession, mine_id) is None
+    assert await session.get(AuthSession, theirs_id) is not None


### PR DESCRIPTION
## Problem

Two parts of the same table.

**Erasure.** `soft_delete_user` strips the account's PII, nulls the password, drops identities and the avatar, and deletes API keys, push tokens and user tokens. It never touched `auth_sessions`, whose rows carry `device_name`, `user_agent` and `ip` — so an anonymized husk kept a record of every device its account had signed in from. `hard_delete_user` was already fine: `auth_sessions.user_id` is `ON DELETE CASCADE`.

**Retention.** `ix_auth_sessions_expires_at` is annotated "Supports the background expiry sweep". The sweep was never written, so expired and revoked rows accumulated indefinitely, IP and user agent included.

## Changes

- `sessions.delete_all_for_user()` — the erasure counterpart to `revoke_all_for_user`. A password change revokes (the rows are still a record of where you were signed in); erasure removes. Stages only, so it lands inside the existing single-commit erasure or not at all.
- `soft_delete_user` calls it alongside the other auth-artifact deletes.
- `sessions.purge_dead_sessions()` + `process_dead_session_purge()`, registered as the hourly `session-purge` worker. A row goes once it is expired, or was revoked, longer than `SESSION_RETENTION_DAYS` (30) ago. A live session matches neither clause. `parent_id` is a plain uuid rather than a self-reference, so removing one end of a rotation chain leaves the rest intact.

## Testing

```
cd backend && pytest -n 0 app/services/auth/sessions_test.py app/services/platform/users_test.py
```
32 passed. New cases: the sweep takes a long-expired and a long-revoked row while leaving a live one, one that expired yesterday and one revoked yesterday; `delete_all_for_user` is scoped to its user; and erasure leaves no session row for the erased account and doesn't touch a bystander's.

Also ran the endpoint-level delete/anonymize tests in `platform_endpoints/{users,admin}_test.py` — 8 passed. `ruff format`, `ruff check`, `ty check` clean.

## Notes

Phase A of `history/auth-identity-assurance-design.md`, minus one item: that plan listed `drop_entity_refs` as uncalled, which was wrong — `identity_refs.forget_user()` wraps it and is already wired into both delete paths (`users.py:514`, `:783`). The design doc has been corrected. No schema change, no migration.