### PR TITLE
Record when a password was set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Accounts record when their password was set** — a stored password hash said a value was there, never whether anybody knew it. Accounts created through single sign-on before mid-2026 were given a throwaway password nobody ever held, which looks exactly like a real one. Setting or changing a password now records when, so the question stops being unanswerable for every account from here on, and the few stored values that could never have worked have been cleared. Nothing is guessed: an existing password is left alone, and how you sign in does not change.
+
 ### Fixed
 
 - **Deleting an account clears its sign-in sessions** — anonymizing an account emptied it of everything personal except one thing: the record of where it had been signed in, which keeps a device name, a browser and an address per session. Those go now, along with the rest. Sessions that have expired or been signed out are also cleared away on a schedule after thirty days, rather than being kept indefinitely. Permanently deleting an account already removed them with the account itself.

--- a/backend/alembic/versions/20260911_0258_record_when_a_password_was_set.py
+++ b/backend/alembic/versions/20260911_0258_record_when_a_password_was_set.py
@@ -1,0 +1,106 @@
+"""record when a password was set
+
+``users.hashed_password`` says a value is stored; it has never said whether
+anybody knows the plaintext. Before ``20260720_0152`` an account provisioned
+through an identity provider was given ``get_password_hash(token_urlsafe(32))``
+purely to satisfy a NOT NULL constraint, and 0152 left those rows as they were.
+Such a hash is a real argon2 value, so no query can tell it from a chosen
+password.
+
+This adds the column that records the answer going forward: every place that
+sets a password stamps it, so the set of accounts whose password state is
+unknown only shrinks — provisioning has stored NULL since 0152, so no new ones
+are created.
+
+It also normalises what *can* be settled from the data. A stored value outside
+the schemes ``verify_password`` accepts — the ``'!'`` marker this migration's
+own predecessor writes on downgrade, or any other leftover — can never verify,
+so it is not a password and the column is set to NULL.
+
+Nothing is inferred: a usable hash of unknown provenance is left exactly as it
+is, with ``password_set_at`` NULL meaning "not known" rather than "none".
+
+Revision ID: 20260911_0258
+Revises: 20260911_0257
+Create Date: 2026-09-11
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.core.config import settings
+
+revision = "20260911_0258"
+down_revision = "20260911_0257"
+branch_labels = None
+depends_on = None
+
+# The prefixes ``app.core.security.verify_password`` can check. Spelled out
+# here rather than imported: a migration is a record of what ran on a given
+# day, and must not change meaning when the application constant does.
+_USABLE_HASH_PREFIXES = ("$argon2", "$2a$", "$2b$", "$2y$")
+
+_NOT_USABLE = " AND ".join(
+    f"hashed_password NOT LIKE '{prefix}%'" for prefix in _USABLE_HASH_PREFIXES
+)
+
+
+def _write_roles() -> tuple[str, ...]:
+    """The floors that write ``public.users``. Deliberately not
+    ``app_guild_base``: ``20260904_0221`` took the guild path off this table
+    and onto ``public.guild_member_profiles``, and granting a new column to all
+    three floors would quietly undo that — ``security_invariants_test`` catches
+    it."""
+    return (
+        f'"{settings.PLATFORM_ROLE_PREFIX}platform_base"',
+        "app_user",
+    )
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("password_set_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    if not _is_postgres():
+        return
+
+    # ``users`` grants UPDATE column by column, so a new one is unwritable
+    # until it is named.
+    for role in _write_roles():
+        op.execute(f"GRANT UPDATE (password_set_at) ON TABLE public.users TO {role}")
+
+    # ``users`` is FORCE ROW LEVEL SECURITY, which binds the owner this runs
+    # as: the policies key on request GUCs a migration has no value for, so the
+    # UPDATE below would match zero rows and report success. Lift and restore
+    # around the write, in this transaction, and check the count.
+    bind = op.get_bind()
+    op.execute("ALTER TABLE public.users NO FORCE ROW LEVEL SECURITY")
+    try:
+        expected = bind.exec_driver_sql(
+            f"SELECT count(*) FROM public.users "
+            f"WHERE hashed_password IS NOT NULL AND {_NOT_USABLE}"
+        ).scalar_one()
+        result = bind.exec_driver_sql(
+            f"UPDATE public.users SET hashed_password = NULL "
+            f"WHERE hashed_password IS NOT NULL AND {_NOT_USABLE}"
+        )
+        if result.rowcount != expected:
+            raise RuntimeError(
+                "password_set_at migration: expected to clear "
+                f"{expected} unusable password hash(es), cleared {result.rowcount}"
+            )
+    finally:
+        op.execute("ALTER TABLE public.users FORCE ROW LEVEL SECURITY")
+
+
+def downgrade() -> None:
+    # The cleared hashes are not restored: the values were ones no scheme could
+    # verify, and the accounts they belonged to sign in the same way either way.
+    op.drop_column("users", "password_set_at")

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -255,6 +255,7 @@ async def register_user(
             username_chosen=True,
             full_name=user_in.full_name,
             hashed_password=get_password_hash(user_in.password),
+            password_set_at=datetime.now(timezone.utc),
             role=user_role,
             status=UserStatus.active,
             email_verified=is_first_user or not smtp_configured,
@@ -1565,6 +1566,7 @@ async def reset_password(
     await session.commit()
 
     user.hashed_password = get_password_hash(payload.password)
+    user.password_set_at = datetime.now(timezone.utc)
     # Bump token_version and revoke API keys / refresh sessions so no stale
     # credential (JWT or captured refresh) survives either. ``token_version``
     # is bumped on ``user``, which is bound to the system engine here, so that

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -2142,3 +2142,59 @@ async def test_password_change_revokes_refresh_session(
     client.cookies.set("refresh_token", captured, path="/api/v1/auth")
     replay = await client.post("/api/v1/auth/refresh")
     assert replay.status_code == 401
+
+
+async def test_registering_records_when_the_password_was_set(
+    client: AsyncClient, session: AsyncSession
+):
+    from sqlmodel import select
+
+    from app.core.encryption import hash_email
+    from app.models.platform.user import User
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "stamped@example.com",
+            "username": "stamped",
+            "full_name": "Stamped",
+            "password": "a-perfectly-fine-secret-1",
+        },
+    )
+    assert response.status_code == 201
+
+    session.expire_all()
+    user = (
+        await session.exec(
+            select(User).where(User.email_hash == hash_email("stamped@example.com"))
+        )
+    ).one()
+    assert user.password_set_at is not None
+
+
+async def test_password_reset_records_when_the_password_was_set(
+    client: AsyncClient, session: AsyncSession
+):
+    """An account carrying a hash nobody set — the pre-0152 SSO case — becomes
+    known the moment somebody actually sets one."""
+    from app.models.platform.user_token import UserTokenPurpose
+    from app.services.platform import user_tokens
+
+    user = await create_user(session, email="reset-stamp@example.com")
+    user.password_set_at = None
+    session.add(user)
+    await session.commit()
+    user_id = user.id
+
+    reset_token = await user_tokens.create_token(
+        session, user_id=user_id, purpose=UserTokenPurpose.password_reset
+    )
+    response = await client.post(
+        "/api/v1/auth/password/reset",
+        json={"token": reset_token, "password": "brand-new-secret-123"},
+    )
+    assert response.status_code == 200
+
+    session.expire_all()
+    refreshed = await session.get(User, user_id)
+    assert refreshed.password_set_at is not None

--- a/backend/app/api/v1/platform_endpoints/users.py
+++ b/backend/app/api/v1/platform_endpoints/users.py
@@ -830,6 +830,7 @@ async def update_users_me(
                 )
         await enforce_password_policy(password)
         current_user.hashed_password = get_password_hash(password)
+        current_user.password_set_at = datetime.now(timezone.utc)
         # Bump token_version and revoke device tokens + API keys + refresh
         # sessions so no stale credential can survive the password change.
         await user_tokens_service.revoke_user_sessions(

--- a/backend/app/api/v1/platform_endpoints/users_test.py
+++ b/backend/app/api/v1/platform_endpoints/users_test.py
@@ -2606,3 +2606,27 @@ async def test_search_users_says_where_each_member_stands(client, acting_user):
     roles = {item["username"]: item["guild_role"] for item in response.json()["items"]}
     assert roles[admin.user.username] == "admin"
     assert roles[member.user.username] == "member"
+
+
+async def test_changing_a_password_records_when_it_was_set(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session)
+    user.password_set_at = None
+    session.add(user)
+    await session.commit()
+    user_id = user.id
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=get_auth_headers(user),
+        json={
+            "current_password": "testpassword123",
+            "password": "a-new-and-longer-secret-1",
+        },
+    )
+    assert response.status_code == 200
+
+    session.expire_all()
+    refreshed = await session.get(User, user_id)
+    assert refreshed.password_set_at is not None

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 import asyncio
 from contextlib import suppress
 from urllib.parse import urlparse
@@ -51,6 +52,7 @@ async def init_owner() -> None:
             or usernames.random_name(),
             discriminator=usernames.random_discriminator(),
             hashed_password=get_password_hash(settings.FIRST_OWNER_PASSWORD),
+            password_set_at=datetime.now(timezone.utc),
             role=UserRole.owner,
             email_verified=True,
         )

--- a/backend/app/models/platform/user.py
+++ b/backend/app/models/platform/user.py
@@ -145,6 +145,16 @@ class User(SQLModel, table=True):
     # a missing hash as "never a match", so such an account can only sign in
     # through its identity provider until it explicitly sets a password.
     hashed_password: Optional[str] = Field(default=None)
+    #: When this account's password was last set, as far as the record goes.
+    #: NULL means one of two things a stored hash cannot tell apart: no
+    #: password at all, or one set before this column existed — an account
+    #: provisioned through an identity provider before ``20260720_0152`` carries
+    #: a throwaway argon2 hash indistinguishable from a chosen one. Every place
+    #: that sets a password stamps this, so the unknown set only shrinks.
+    password_set_at: Optional[datetime] = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
     role: UserRole = Field(
         default=UserRole.member,
         sa_column=Column(


### PR DESCRIPTION
## Problem

`users.hashed_password` says a value is stored. It has never said whether anybody knows the plaintext.

Before `20260720_0152`, an account provisioned through an identity provider was given `get_password_hash(secrets.token_urlsafe(32))` purely to satisfy a NOT NULL constraint, and 0152 explicitly left those rows as they were — "existing rows keep whatever hash they have". That hash is a genuine argon2 value, so no query can tell it from a chosen password. It came up on #1570, where the sole-credential guard has to ask exactly that question.

The set is closed — provisioning has stored `NULL` since 0152 ([`identity.py:303`](backend/app/services/auth/identity.py#L303)) — but it does not shrink on its own.

## Changes

- **`users.password_set_at`** (timestamptz, nullable). NULL means *not known*, which is honestly two things a hash cannot separate: no password, or one set before this column existed.
- **Stamped at every site that sets a password**: registration, the first-owner seed, forgot-password reset, and the self-service change.
- **The migration clears what can be settled from the data**: a stored value outside the schemes `verify_password` accepts — the `'!'` marker 0152's own downgrade writes, or any other leftover — can never verify, so it is not a password and becomes NULL. Row-count asserted, and run with `NO FORCE ROW LEVEL SECURITY` lifted and restored in the same transaction, because `users` is FORCE RLS and the policies key on request GUCs a migration has no value for.
- **Column grant**: `UPDATE (password_set_at)` to `platform_base` and `app_user` — deliberately **not** `app_guild_base`, since `20260904_0221` took the guild path off this table and granting all three floors would quietly undo it. Caught by the endpoint test failing with `permission denied for table users` before the grant was added.

**Nothing is inferred.** A usable hash of unknown provenance is left exactly as it is. Nulling on a guess would strip a working credential from somebody who did set one — both that and the status quo end at password reset, but one is harm we caused and the other is a gap we inherited.

## Testing

```
cd backend && pytest -n 0 app/api/v1/platform_endpoints/auth_test.py \
  app/api/v1/platform_endpoints/users_test.py app/services/platform/users_test.py \
  app/db/security_invariants_test.py app/db/migration_backfill_order_test.py
```
Green. New cases: registering stamps it, a reset stamps it on an account that had none, and a self-service change stamps it. `ruff format`, `ruff check`, `ty check` clean.

## Follow-up, not in this PR

With the column in place, the provider-delete refusal on #1570 can report how many linked accounts hold an *unconfirmed* password (`hashed_password IS NOT NULL AND password_set_at IS NULL`), turning the residue into an operator decision made with the facts. Left out while #1570 is in review. Reasoning in `history/auth-identity-assurance-design.md` §9.6.