### PR TITLE
A document has a contents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A document has a contents list** — a long page is easier to move around than to scroll, so every document now offers one: a panel listing its headings, nested the way they are written, that scrolls the page to a heading when you pick one and marks the one you are reading as you go. Sections with headings under them fold away, and a document that starts at a second-level heading is laid out from there rather than from an indent nobody wrote. It is closed until you open it, and then it stays open. Beside the document on a desktop; on a phone it takes the page over while it is open, because a column that narrow would be worse than no list at all.
+
 ### Fixed
 
 - **Deleting an account clears its sign-in sessions** — anonymizing an account emptied it of everything personal except one thing: the record of where it had been signed in, which keeps a device name, a browser and an address per session. Those go now, along with the rest. Sessions that have expired or been signed out are also cleared away on a schedule after thirty days, rather than being kept indefinitely. Permanently deleting an account already removed them with the account itself.

--- a/frontend/public/locales/de/documents.json
+++ b/frontend/public/locales/de/documents.json
@@ -295,6 +295,15 @@
     "hideFilters": "Filter ausblenden",
     "updating": "Wird aktualisiert..."
   },
+  "outline": {
+    "title": "Inhalt",
+    "show": "Inhalt anzeigen",
+    "hide": "Inhalt ausblenden",
+    "empty": "Überschriften, die du hinzufügst, erscheinen hier.",
+    "untitled": "Überschrift ohne Titel",
+    "expand": "Zeigen, was unter {{heading}} steht",
+    "collapse": "Ausblenden, was unter {{heading}} steht"
+  },
   "page": {
     "title": "Dokumente",
     "subtitle": "Halte das Wissen der Initiative organisiert und hänge Dokumente an Projekte an.",

--- a/frontend/public/locales/en/documents.json
+++ b/frontend/public/locales/en/documents.json
@@ -295,6 +295,15 @@
     "hideFilters": "Hide filters",
     "updating": "Updating..."
   },
+  "outline": {
+    "title": "Contents",
+    "show": "Show contents",
+    "hide": "Hide contents",
+    "empty": "Headings you add appear here.",
+    "untitled": "Untitled heading",
+    "expand": "Show what is under {{heading}}",
+    "collapse": "Hide what is under {{heading}}"
+  },
   "page": {
     "title": "Documents",
     "subtitle": "Keep initiative knowledge organized and attach docs to projects.",

--- a/frontend/public/locales/es/documents.json
+++ b/frontend/public/locales/es/documents.json
@@ -295,6 +295,15 @@
     "hideFilters": "Ocultar filtros",
     "updating": "Actualizando..."
   },
+  "outline": {
+    "title": "Contenido",
+    "show": "Mostrar contenido",
+    "hide": "Ocultar contenido",
+    "empty": "Los encabezados que añadas aparecerán aquí.",
+    "untitled": "Encabezado sin título",
+    "expand": "Mostrar lo que hay bajo {{heading}}",
+    "collapse": "Ocultar lo que hay bajo {{heading}}"
+  },
   "page": {
     "title": "Documentos",
     "subtitle": "Mantén el conocimiento de la iniciativa organizado y adjunta documentos a proyectos.",

--- a/frontend/public/locales/fr/documents.json
+++ b/frontend/public/locales/fr/documents.json
@@ -295,6 +295,15 @@
     "hideFilters": "Masquer les filtres",
     "updating": "Mise à jour..."
   },
+  "outline": {
+    "title": "Sommaire",
+    "show": "Afficher le sommaire",
+    "hide": "Masquer le sommaire",
+    "empty": "Les titres que vous ajoutez apparaissent ici.",
+    "untitled": "Titre sans intitulé",
+    "expand": "Afficher ce qui se trouve sous {{heading}}",
+    "collapse": "Masquer ce qui se trouve sous {{heading}}"
+  },
   "page": {
     "title": "Documents",
     "subtitle": "Gardez les connaissances de l'initiative organisées et attachez des documents aux projets.",

--- a/frontend/src/components/documents/DocumentOutline.test.tsx
+++ b/frontend/src/components/documents/DocumentOutline.test.tsx
@@ -1,0 +1,164 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { LexicalExtensionComposer } from "@lexical/react/LexicalExtensionComposer";
+import type { TableOfContentsEntry } from "@lexical/react/LexicalTableOfContentsPlugin";
+import { $createHeadingNode, type HeadingTagType } from "@lexical/rich-text";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { $createTextNode, $getRoot, type LexicalEditor } from "lexical";
+import { useMemo } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderPage } from "@/__tests__/helpers/render";
+import {
+  buildOutlineTree,
+  DocumentOutlinePanel,
+  DocumentOutlineScope,
+  DocumentOutlineTracker,
+} from "@/components/documents/DocumentOutline";
+import { documentExtension } from "@/components/documents/editor/document-extension";
+import { Plugins } from "@/components/documents/editor/plugins";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { SmartChipScope } from "@/hooks/useSmartChips";
+
+const entry = (key: string, text: string, tag: HeadingTagType): TableOfContentsEntry => [
+  key,
+  text,
+  tag,
+];
+
+describe("buildOutlineTree", () => {
+  it("files each heading under the nearest shallower one", () => {
+    const tree = buildOutlineTree([
+      entry("1", "Overview", "h1"),
+      entry("2", "Details", "h2"),
+      entry("3", "Edge cases", "h3"),
+      entry("4", "Appendix", "h1"),
+    ]);
+
+    expect(tree.map((node) => node.text)).toEqual(["Overview", "Appendix"]);
+    expect(tree[0].children.map((node) => node.text)).toEqual(["Details"]);
+    expect(tree[0].children[0].children.map((node) => node.text)).toEqual(["Edge cases"]);
+    expect(tree[1].children).toEqual([]);
+  });
+
+  it("puts the shallowest headings it actually has at the top", () => {
+    const tree = buildOutlineTree([
+      entry("1", "First", "h2"),
+      entry("2", "Under first", "h3"),
+      entry("3", "Second", "h2"),
+    ]);
+
+    expect(tree.map((node) => node.text)).toEqual(["First", "Second"]);
+    expect(tree[0].children.map((node) => node.text)).toEqual(["Under first"]);
+  });
+
+  it("keeps a skipped level as nesting rather than inventing a heading", () => {
+    const tree = buildOutlineTree([entry("1", "Overview", "h1"), entry("2", "Deep", "h3")]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children.map((node) => node.text)).toEqual(["Deep"]);
+  });
+
+  it("closes every deeper heading when a shallower one arrives", () => {
+    const tree = buildOutlineTree([
+      entry("1", "A", "h3"),
+      entry("2", "B", "h4"),
+      entry("3", "C", "h5"),
+      entry("4", "D", "h3"),
+    ]);
+
+    expect(tree.map((node) => node.text)).toEqual(["A", "D"]);
+    expect(tree[0].children[0].children.map((node) => node.text)).toEqual(["C"]);
+  });
+});
+
+let editor!: LexicalEditor;
+
+function Grab(): null {
+  const [found] = useLexicalComposerContext();
+  editor = found;
+  return null;
+}
+
+/** The document page's arrangement: the body editor and the contents list
+ *  under one scope, which is the only thing joining them. */
+function Harness() {
+  const extension = useMemo(() => documentExtension({ collaborative: false, editable: true }), []);
+
+  return (
+    <DocumentOutlineScope>
+      <SmartChipScope>
+        <LexicalExtensionComposer extension={extension} contentEditable={null}>
+          <TooltipProvider>
+            <Grab />
+            <Plugins showToolbar={false} initiativeId={7} />
+            <DocumentOutlineTracker />
+          </TooltipProvider>
+        </LexicalExtensionComposer>
+      </SmartChipScope>
+      <DocumentOutlinePanel isOpen onOpenChange={() => {}} />
+    </DocumentOutlineScope>
+  );
+}
+
+const writeHeadings = (headings: [HeadingTagType, string][]) => {
+  editor.update(
+    () => {
+      const root = $getRoot().clear();
+      for (const [tag, text] of headings) {
+        root.append($createHeadingNode(tag).append($createTextNode(text)));
+      }
+    },
+    { discrete: true }
+  );
+};
+
+describe("the document's contents", () => {
+  it("lists the body's headings, nested", async () => {
+    renderPage(Harness);
+    await waitFor(() => expect(editor).toBeTruthy());
+
+    writeHeadings([
+      ["h1", "Overview"],
+      ["h2", "Details"],
+    ]);
+
+    const overview = await screen.findByRole("button", { name: "Overview" });
+    const section = overview.closest("li");
+    expect(section).not.toBeNull();
+    expect(
+      within(section as HTMLElement).getByRole("button", { name: "Details" })
+    ).toBeInTheDocument();
+  });
+
+  it("scrolls to a heading when it is chosen", async () => {
+    const scrollIntoView = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
+
+    renderPage(Harness);
+    await waitFor(() => expect(editor).toBeTruthy());
+
+    writeHeadings([
+      ["h1", "Overview"],
+      ["h1", "Appendix"],
+    ]);
+
+    const appendix = await screen.findByRole("button", { name: "Appendix" });
+    await userEvent.click(appendix);
+
+    const heading = editor.getEditorState().read(() => $getRoot().getLastChild()?.getKey() ?? null);
+    expect(heading).not.toBeNull();
+    expect(scrollIntoView).toHaveBeenCalled();
+    expect(scrollIntoView.mock.instances[0]).toBe(editor.getElementByKey(heading as string));
+
+    scrollIntoView.mockRestore();
+  });
+
+  it("says so when the document has no headings", async () => {
+    renderPage(Harness);
+    await waitFor(() => expect(editor).toBeTruthy());
+
+    expect(await screen.findByText("Headings you add appear here.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/documents/DocumentOutline.test.tsx
+++ b/frontend/src/components/documents/DocumentOutline.test.tsx
@@ -6,7 +6,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { $createTextNode, $getRoot, type LexicalEditor } from "lexical";
 import { useMemo } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { renderPage } from "@/__tests__/helpers/render";
 import {
@@ -80,26 +80,69 @@ function Grab(): null {
   return null;
 }
 
-/** The document page's arrangement: the body editor and the contents list
- *  under one scope, which is the only thing joining them. */
+/** The document page's arrangement: the body editor in its own scrollport, with
+ *  the toolbar stuck to the top of it, and the contents list beside them. The
+ *  scope is the only thing joining the two. */
 function Harness() {
   const extension = useMemo(() => documentExtension({ collaborative: false, editable: true }), []);
 
   return (
     <DocumentOutlineScope>
       <SmartChipScope>
-        <LexicalExtensionComposer extension={extension} contentEditable={null}>
-          <TooltipProvider>
-            <Grab />
-            <Plugins showToolbar={false} initiativeId={7} />
-            <DocumentOutlineTracker />
-          </TooltipProvider>
-        </LexicalExtensionComposer>
+        <div data-testid="scrollport" style={{ overflowY: "auto" }}>
+          <LexicalExtensionComposer extension={extension} contentEditable={null}>
+            <TooltipProvider>
+              <Grab />
+              <Plugins showToolbar initiativeId={7} />
+              <DocumentOutlineTracker />
+            </TooltipProvider>
+          </LexicalExtensionComposer>
+        </div>
       </SmartChipScope>
       <DocumentOutlinePanel isOpen onOpenChange={() => {}} />
     </DocumentOutlineScope>
   );
 }
+
+/** jsdom lays nothing out, so the geometry the outline measures is supplied. */
+const atTop = (element: Element, top: number) => {
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue({ top } as DOMRect);
+};
+
+/**
+ * The same, installed before anything renders — the outline measures as soon as
+ * the headings arrive, and a test that mocks afterwards is only agreeing with
+ * whatever the first, unmocked pass happened to decide.
+ *
+ * `tops` is keyed on what an element says, which for a heading is its own text
+ * and for the scrollport is nothing (its children's text is not its own).
+ */
+const layOut = (tops: Record<string, number>, toolbarHeight: number) => {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (
+    this: HTMLElement
+  ) {
+    const named = this.dataset.testid ?? this.textContent ?? "";
+    return { top: tops[named] ?? 0 } as DOMRect;
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      // Only the wide row is on screen at this width; the narrow one is display:none.
+      return this.hasAttribute("data-editor-toolbar") && this.className.includes("lg:flex")
+        ? toolbarHeight
+        : 0;
+    },
+  });
+};
+
+const jsdomOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetHeight");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (jsdomOffsetHeight) {
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", jsdomOffsetHeight);
+  }
+});
 
 const writeHeadings = (headings: [HeadingTagType, string][]) => {
   editor.update(
@@ -131,10 +174,48 @@ describe("the document's contents", () => {
     ).toBeInTheDocument();
   });
 
-  it("scrolls to a heading when it is chosen", async () => {
-    const scrollIntoView = vi
-      .spyOn(HTMLElement.prototype, "scrollIntoView")
-      .mockImplementation(() => {});
+  it("parks the chosen heading below the toolbar, not behind it", async () => {
+    renderPage(Harness);
+    await waitFor(() => expect(editor).toBeTruthy());
+
+    writeHeadings([
+      ["h1", "Overview"],
+      ["h1", "Appendix"],
+    ]);
+    await screen.findByRole("button", { name: "Appendix" });
+
+    const scrollPort = screen.getByTestId("scrollport");
+    const scrollTo = vi.fn();
+    scrollPort.scrollTo = scrollTo;
+    atTop(scrollPort, 100);
+
+    // The wide toolbar is the one on screen; the narrow one measures nothing.
+    const [wide, narrow] = Array.from(
+      scrollPort.querySelectorAll<HTMLElement>("[data-editor-toolbar]")
+    );
+    expect(narrow).toBeDefined();
+    Object.defineProperty(wide, "offsetHeight", { value: 48, configurable: true });
+
+    const keys = editor.getEditorState().read(() =>
+      $getRoot()
+        .getChildren()
+        .map((child) => child.getKey())
+    );
+    atTop(editor.getElementByKey(keys[0]) as HTMLElement, 200);
+    atTop(editor.getElementByKey(keys[1]) as HTMLElement, 400);
+
+    await userEvent.click(screen.getByRole("button", { name: "Appendix" }));
+
+    // 400 (the heading) - 100 (the scrollport) - 48 (the toolbar) - 8 (room to breathe)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 244, behavior: "smooth" });
+  });
+
+  it("marks the heading it just scrolled to as the one being read", async () => {
+    // "Appendix" sits exactly where `scrollToHeading` parks it: 48 for the
+    // toolbar plus 8 of room. A reading line drawn from the scrollport's own
+    // edge would fall above that and credit "Overview", which is 300px off the
+    // top of the page.
+    layOut({ scrollport: 0, Overview: -300, Appendix: 56 }, 48);
 
     renderPage(Harness);
     await waitFor(() => expect(editor).toBeTruthy());
@@ -144,15 +225,13 @@ describe("the document's contents", () => {
       ["h1", "Appendix"],
     ]);
 
-    const appendix = await screen.findByRole("button", { name: "Appendix" });
-    await userEvent.click(appendix);
-
-    const heading = editor.getEditorState().read(() => $getRoot().getLastChild()?.getKey() ?? null);
-    expect(heading).not.toBeNull();
-    expect(scrollIntoView).toHaveBeenCalled();
-    expect(scrollIntoView.mock.instances[0]).toBe(editor.getElementByKey(heading as string));
-
-    scrollIntoView.mockRestore();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Appendix" })).toHaveAttribute(
+        "aria-current",
+        "location"
+      )
+    );
+    expect(screen.getByRole("button", { name: "Overview" })).not.toHaveAttribute("aria-current");
   });
 
   it("says so when the document has no headings", async () => {

--- a/frontend/src/components/documents/DocumentOutline.tsx
+++ b/frontend/src/components/documents/DocumentOutline.tsx
@@ -1,0 +1,457 @@
+import type { TableOfContentsEntry } from "@lexical/react/LexicalTableOfContentsPlugin";
+import { TableOfContentsPlugin } from "@lexical/react/LexicalTableOfContentsPlugin";
+import type { LexicalEditor } from "lexical";
+import { ChevronRight } from "lucide-react";
+import {
+  createContext,
+  type JSX,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { getItem, setItem } from "@/lib/storage";
+import { cn } from "@/lib/utils";
+
+const STORAGE_KEY = "document-outline-open";
+
+/** How far below the top of the visible area a heading still counts as the one
+ *  being read. */
+const ACTIVE_HEADING_SLACK_PX = 24;
+
+/** One heading, with the headings it contains. */
+export interface OutlineNode {
+  /** The Lexical node key, which is how the heading is found again. */
+  key: string;
+  text: string;
+  /** 1–6, from the heading tag. */
+  level: number;
+  children: OutlineNode[];
+}
+
+/**
+ * The document's headings as a tree.
+ *
+ * Lexical hands out a flat, ordered list; the nesting is inferred from the
+ * levels alone. A shallower heading closes every deeper one still open, so a
+ * document that starts at `h2` puts its `h2`s at the top level, and one that
+ * jumps `h1` → `h3` files the `h3` under the `h1` rather than inventing an
+ * empty `h2` to sit between them.
+ */
+export const buildOutlineTree = (entries: readonly TableOfContentsEntry[]): OutlineNode[] => {
+  const roots: OutlineNode[] = [];
+  const open: OutlineNode[] = [];
+
+  for (const [key, text, tag] of entries) {
+    const level = Number.parseInt(tag.slice(1), 10);
+    const node: OutlineNode = {
+      key,
+      text,
+      level: Number.isNaN(level) ? 1 : level,
+      children: [],
+    };
+
+    while (open.length > 0 && open[open.length - 1].level >= node.level) {
+      open.pop();
+    }
+    const parent = open[open.length - 1];
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+    open.push(node);
+  }
+
+  return roots;
+};
+
+interface OutlineSnapshot {
+  entries: readonly TableOfContentsEntry[];
+  editor: LexicalEditor | null;
+}
+
+const EMPTY_SNAPSHOT: OutlineSnapshot = { entries: [], editor: null };
+
+interface OutlineStore {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => OutlineSnapshot;
+  publish: (entries: readonly TableOfContentsEntry[], editor: LexicalEditor) => void;
+}
+
+const createOutlineStore = (): OutlineStore => {
+  let snapshot = EMPTY_SNAPSHOT;
+  const listeners = new Set<() => void>();
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot: () => snapshot,
+    publish: (entries, editor) => {
+      snapshot = { entries, editor };
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+};
+
+const DocumentOutlineContext = createContext<OutlineStore | null>(null);
+
+const NO_SUBSCRIBE = () => () => {};
+const NO_SNAPSHOT = () => EMPTY_SNAPSHOT;
+
+/**
+ * Where the document's headings are published, above the editor that finds them
+ * and the list that shows them.
+ *
+ * A store rather than plain context state on purpose: the headings change on
+ * every keystroke inside one, and re-rendering the whole editor to move a word
+ * in the list beside it is a cost nobody is asking for. Only what reads the
+ * outline re-renders.
+ */
+export const DocumentOutlineScope = ({ children }: { children: ReactNode }) => {
+  const storeRef = useRef<OutlineStore | null>(null);
+  storeRef.current ??= createOutlineStore();
+
+  return (
+    <DocumentOutlineContext.Provider value={storeRef.current}>
+      {children}
+    </DocumentOutlineContext.Provider>
+  );
+};
+
+const OutlinePublisher = ({
+  entries,
+  editor,
+  store,
+}: {
+  entries: readonly TableOfContentsEntry[];
+  editor: LexicalEditor;
+  store: OutlineStore;
+}): JSX.Element => {
+  useEffect(() => {
+    store.publish(entries, editor);
+  }, [entries, editor, store]);
+
+  return <></>;
+};
+
+/**
+ * Reports the editor's headings up to the surrounding {@link DocumentOutlineScope}.
+ *
+ * Rendered among the plugins because only something inside the composer can see
+ * the document. With no scope above it there is nothing listening, so on every
+ * other surface an editor appears on it tracks nothing at all.
+ */
+export const DocumentOutlineTracker = () => {
+  const store = useContext(DocumentOutlineContext);
+  if (!store) {
+    return null;
+  }
+
+  return (
+    <TableOfContentsPlugin>
+      {(entries, editor) => <OutlinePublisher entries={entries} editor={editor} store={store} />}
+    </TableOfContentsPlugin>
+  );
+};
+
+/** The nearest ancestor that scrolls, whose visible top is the reading line. */
+const scrollPortTop = (element: HTMLElement): number => {
+  let node = element.parentElement;
+  while (node) {
+    const overflowY = window.getComputedStyle(node).overflowY;
+    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") {
+      return node.getBoundingClientRect().top;
+    }
+    node = node.parentElement;
+  }
+  return 0;
+};
+
+/** The heading the reader is under — the last one to have passed the top of the
+ *  visible area. */
+const useActiveHeadingKey = (
+  editor: LexicalEditor | null,
+  keys: readonly string[]
+): string | null => {
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editor || keys.length === 0) {
+      setActiveKey(null);
+      return;
+    }
+
+    let frame = 0;
+
+    const measure = () => {
+      frame = 0;
+      const root = editor.getRootElement();
+      if (!root) {
+        return;
+      }
+      const line = scrollPortTop(root) + ACTIVE_HEADING_SLACK_PX;
+
+      let current: string | null = null;
+      for (const key of keys) {
+        const element = editor.getElementByKey(key);
+        if (!element) {
+          continue;
+        }
+        if (element.getBoundingClientRect().top > line) {
+          break;
+        }
+        current = key;
+      }
+      setActiveKey(current ?? keys[0] ?? null);
+    };
+
+    const schedule = () => {
+      if (frame === 0) {
+        frame = window.requestAnimationFrame(measure);
+      }
+    };
+
+    measure();
+    // Capture, because what scrolls is the editor's own scrollport in one
+    // layout and the page itself in another.
+    window.addEventListener("scroll", schedule, true);
+    window.addEventListener("resize", schedule);
+    return () => {
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame);
+      }
+      window.removeEventListener("scroll", schedule, true);
+      window.removeEventListener("resize", schedule);
+    };
+  }, [editor, keys]);
+
+  return activeKey;
+};
+
+const flattenKeys = (nodes: readonly OutlineNode[], into: string[] = []): string[] => {
+  for (const node of nodes) {
+    into.push(node.key);
+    flattenKeys(node.children, into);
+  }
+  return into;
+};
+
+const OutlineBranch = ({
+  nodes,
+  depth,
+  activeKey,
+  collapsed,
+  onToggle,
+  onSelect,
+}: {
+  nodes: readonly OutlineNode[];
+  depth: number;
+  activeKey: string | null;
+  collapsed: ReadonlySet<string>;
+  onToggle: (key: string) => void;
+  onSelect: (key: string) => void;
+}) => {
+  const { t } = useTranslation("documents");
+
+  return (
+    <ul className="space-y-px">
+      {nodes.map((node) => {
+        const hasChildren = node.children.length > 0;
+        const isCollapsed = collapsed.has(node.key);
+        const label = node.text.trim();
+        const isActive = node.key === activeKey;
+
+        return (
+          <li key={node.key}>
+            <div
+              className={cn("flex items-start gap-0.5 rounded-md", isActive && "bg-accent")}
+              style={{ marginInlineStart: `${depth * 0.75}rem` }}
+            >
+              {hasChildren ? (
+                <button
+                  type="button"
+                  onClick={() => onToggle(node.key)}
+                  aria-expanded={!isCollapsed}
+                  aria-label={t(isCollapsed ? "outline.expand" : "outline.collapse", {
+                    heading: label || t("outline.untitled"),
+                  })}
+                  className="mt-1.5 shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <ChevronRight
+                    className={cn("h-3.5 w-3.5 transition-transform", !isCollapsed && "rotate-90")}
+                  />
+                </button>
+              ) : (
+                <span aria-hidden="true" className="w-[1.125rem] shrink-0" />
+              )}
+              <button
+                type="button"
+                onClick={() => onSelect(node.key)}
+                title={label || undefined}
+                aria-current={isActive ? "location" : undefined}
+                className={cn(
+                  "min-w-0 flex-1 truncate rounded-md px-1 py-1 text-left text-sm hover:text-foreground",
+                  isActive ? "font-medium text-foreground" : "text-muted-foreground"
+                )}
+              >
+                {label || <span className="italic opacity-70">{t("outline.untitled")}</span>}
+              </button>
+            </div>
+            {hasChildren && !isCollapsed ? (
+              <OutlineBranch
+                nodes={node.children}
+                depth={depth + 1}
+                activeKey={activeKey}
+                collapsed={collapsed}
+                onToggle={onToggle}
+                onSelect={onSelect}
+              />
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+const OutlineTree = ({ onNavigate }: { onNavigate?: () => void }) => {
+  const { t } = useTranslation("documents");
+  const store = useContext(DocumentOutlineContext);
+  const snapshot = useSyncExternalStore(
+    store?.subscribe ?? NO_SUBSCRIBE,
+    store?.getSnapshot ?? NO_SNAPSHOT
+  );
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() => new Set());
+
+  const tree = useMemo(() => buildOutlineTree(snapshot.entries), [snapshot.entries]);
+  const keys = useMemo(() => flattenKeys(tree), [tree]);
+  const activeKey = useActiveHeadingKey(snapshot.editor, keys);
+
+  const toggle = useCallback((key: string) => {
+    setCollapsed((current) => {
+      const next = new Set(current);
+      if (!next.delete(key)) {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const select = useCallback(
+    (key: string) => {
+      snapshot.editor?.getElementByKey(key)?.scrollIntoView({ behavior: "smooth", block: "start" });
+      onNavigate?.();
+    },
+    [snapshot.editor, onNavigate]
+  );
+
+  if (tree.length === 0) {
+    return <p className="px-1 text-muted-foreground text-sm">{t("outline.empty")}</p>;
+  }
+
+  return (
+    <nav aria-label={t("outline.title")}>
+      <OutlineBranch
+        nodes={tree}
+        depth={0}
+        activeKey={activeKey}
+        collapsed={collapsed}
+        onToggle={toggle}
+        onSelect={select}
+      />
+    </nav>
+  );
+};
+
+/**
+ * The document's contents, as a list of its headings.
+ *
+ * Two presentations of the same tree. Beside the document there is room for a
+ * column; on a phone there is not, so it takes the document view over entirely
+ * rather than squeezing the words it exists to navigate into a gutter.
+ */
+export const DocumentOutlinePanel = ({
+  isOpen,
+  onOpenChange,
+  className,
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  className?: string;
+}) => {
+  const { t } = useTranslation("documents");
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Sheet open={isOpen} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="left"
+          className="flex w-full flex-col overflow-hidden p-0 sm:max-w-none"
+        >
+          <SheetHeader
+            className="border-b px-4"
+            style={{
+              paddingTop: "calc(var(--safe-area-inset-top) + 0.75rem)",
+              paddingBottom: "0.75rem",
+            }}
+          >
+            <SheetTitle className="text-base">{t("outline.title")}</SheetTitle>
+          </SheetHeader>
+          <div className="flex-1 overflow-y-auto p-4">
+            <OutlineTree onNavigate={() => onOpenChange(false)} />
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <aside
+      className={cn(
+        "flex min-h-0 flex-col overflow-hidden rounded-lg border bg-card shadow",
+        className
+      )}
+    >
+      <div className="border-b px-3 py-2 font-medium text-sm">{t("outline.title")}</div>
+      <div className="flex-1 overflow-y-auto p-2">
+        <OutlineTree />
+      </div>
+    </aside>
+  );
+};
+
+/** Whether the outline is showing. Closed until somebody opens it, and then
+ *  remembered, the same as the document's other panels. */
+export const useDocumentOutline = () => {
+  const [isOpen, setIsOpen] = useState(() => getItem(STORAGE_KEY) === "true");
+
+  useEffect(() => {
+    setItem(STORAGE_KEY, String(isOpen));
+  }, [isOpen]);
+
+  return {
+    isOpen,
+    setIsOpen,
+    toggle: useCallback(() => setIsOpen((current) => !current), []),
+  };
+};

--- a/frontend/src/components/documents/DocumentOutline.tsx
+++ b/frontend/src/components/documents/DocumentOutline.tsx
@@ -23,9 +23,13 @@ import { cn } from "@/lib/utils";
 
 const STORAGE_KEY = "document-outline-open";
 
-/** How far below the top of the visible area a heading still counts as the one
- *  being read. */
-const ACTIVE_HEADING_SLACK_PX = 24;
+/** Where a heading is parked when it is navigated to: clear of the toolbar,
+ *  with a little room to breathe under it. */
+const HEADING_GAP_PX = 8;
+
+/** How far past its resting place a heading still counts as the one being read.
+ *  Absorbs the rounding a smooth scroll leaves behind. */
+const ACTIVE_HEADING_SLACK_PX = 16;
 
 /** One heading, with the headings it contains. */
 export interface OutlineNode {
@@ -169,17 +173,68 @@ export const DocumentOutlineTracker = () => {
   );
 };
 
-/** The nearest ancestor that scrolls, whose visible top is the reading line. */
-const scrollPortTop = (element: HTMLElement): number => {
+/** The box the document scrolls inside — the editor's own scrollport, which the
+ *  toolbar sticks to the top of. */
+const scrollPortOf = (element: HTMLElement): HTMLElement | null => {
   let node = element.parentElement;
   while (node) {
     const overflowY = window.getComputedStyle(node).overflowY;
     if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") {
-      return node.getBoundingClientRect().top;
+      return node;
     }
     node = node.parentElement;
   }
-  return 0;
+  return null;
+};
+
+/**
+ * What the toolbar covers at the top of the scrollport.
+ *
+ * Measured rather than assumed: the wide toolbar wraps, a narrow one is a
+ * single row, and a document somebody can only read has no toolbar at all. The
+ * hidden one of the two measures zero, so the larger is the one on screen.
+ */
+const stickyHeaderOffset = (scrollPort: HTMLElement): number => {
+  let offset = 0;
+  for (const bar of scrollPort.querySelectorAll<HTMLElement>("[data-editor-toolbar]")) {
+    offset = Math.max(offset, bar.offsetHeight);
+  }
+  return offset;
+};
+
+/** How far down the scrollport a heading comes to rest when it is navigated to:
+ *  clear of the toolbar, with room to breathe under it. */
+const restPoint = (scrollPort: HTMLElement): number =>
+  stickyHeaderOffset(scrollPort) + HEADING_GAP_PX;
+
+/**
+ * The top of the readable area, in client coordinates.
+ *
+ * Measured from {@link restPoint} rather than from the scrollport's own edge, so
+ * a heading navigation has just parked is inside it by construction — the entry
+ * you picked is the entry that lights up.
+ */
+const readingLine = (scrollPort: HTMLElement | null): number =>
+  (scrollPort ? scrollPort.getBoundingClientRect().top + restPoint(scrollPort) : 0) +
+  ACTIVE_HEADING_SLACK_PX;
+
+/** Brings a heading to rest just under the toolbar rather than behind it. */
+const scrollToHeading = (heading: HTMLElement) => {
+  const scrollPort = scrollPortOf(heading);
+  if (!scrollPort) {
+    // Nothing between the heading and the page; the heading's own scroll margin
+    // is what keeps it clear.
+    heading.scrollIntoView({ behavior: "smooth", block: "start" });
+    return;
+  }
+
+  const top =
+    scrollPort.scrollTop +
+    heading.getBoundingClientRect().top -
+    scrollPort.getBoundingClientRect().top -
+    restPoint(scrollPort);
+
+  scrollPort.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
 };
 
 /** The heading the reader is under — the last one to have passed the top of the
@@ -204,7 +259,7 @@ const useActiveHeadingKey = (
       if (!root) {
         return;
       }
-      const line = scrollPortTop(root) + ACTIVE_HEADING_SLACK_PX;
+      const line = readingLine(scrollPortOf(root));
 
       let current: string | null = null;
       for (const key of keys) {
@@ -354,7 +409,10 @@ const OutlineTree = ({ onNavigate }: { onNavigate?: () => void }) => {
 
   const select = useCallback(
     (key: string) => {
-      snapshot.editor?.getElementByKey(key)?.scrollIntoView({ behavior: "smooth", block: "start" });
+      const heading = snapshot.editor?.getElementByKey(key);
+      if (heading) {
+        scrollToHeading(heading);
+      }
       onNavigate?.();
     },
     [snapshot.editor, onNavigate]

--- a/frontend/src/components/documents/editor/editor.tsx
+++ b/frontend/src/components/documents/editor/editor.tsx
@@ -10,6 +10,7 @@ import { useMemo, useRef } from "react";
 import type * as Y from "yjs";
 
 import type { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
+import { DocumentOutlineTracker } from "@/components/documents/DocumentOutline";
 import type { EditorVariant } from "@/components/ui/editor/variant";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAuth } from "@/hooks/useAuth";
@@ -154,6 +155,10 @@ export function Editor({
               onWikilinkNavigate={onWikilinkNavigate}
               onCreateReferencedThing={onCreateReferencedThing}
             />
+
+            {/* Publishes the headings to a `DocumentOutlineScope`, where the
+                page's contents list reads them. Inert without one. */}
+            <DocumentOutlineTracker />
 
             {useCollaborativeMode && providerFactory && (
               <LexicalCollaboration>

--- a/frontend/src/components/documents/editor/plugins.tsx
+++ b/frontend/src/components/documents/editor/plugins.tsx
@@ -159,12 +159,18 @@ export function Plugins({
     // the actions bar's `sticky bottom-0` has somewhere to stick to even when
     // the document is shorter than the viewport.
     <div className="relative flex min-h-full flex-col">
+      {/* `data-editor-toolbar` marks what sits over the top of the scrollport:
+          it sticks there, so anything scrolled to has to clear it. Measured
+          rather than assumed, because the wide row wraps. */}
       {showToolbar && (
         <ToolbarPlugin>
           {({ blockType }) => (
             <>
               {/* Desktop toolbar - all options inline */}
-              <div className="vertical-align-middle sticky top-0 z-10 hidden flex-wrap items-center gap-2 overflow-auto border-b bg-muted p-1 lg:flex">
+              <div
+                data-editor-toolbar
+                className="vertical-align-middle sticky top-0 z-10 hidden flex-wrap items-center gap-2 overflow-auto border-b bg-muted p-1 lg:flex"
+              >
                 <HistoryToolbarPlugin />
                 <Separator orientation="vertical" className="h-7!" />
                 <BlockFormatDropDown>
@@ -227,7 +233,10 @@ export function Plugins({
               </div>
 
               {/* Compact toolbar - overflow menu */}
-              <div className="vertical-align-middle sticky top-0 z-10 flex items-center gap-2 border-b bg-muted p-1 lg:hidden">
+              <div
+                data-editor-toolbar
+                className="vertical-align-middle sticky top-0 z-10 flex items-center gap-2 border-b bg-muted p-1 lg:hidden"
+              >
                 <HistoryToolbarPlugin />
                 <Separator orientation="vertical" className="h-7!" />
                 <BlockFormatDropDown>

--- a/frontend/src/pages/DocumentDetailPage.tsx
+++ b/frontend/src/pages/DocumentDetailPage.tsx
@@ -5,6 +5,7 @@ import {
   ChevronUp,
   ExternalLink,
   ImagePlus,
+  ListTree,
   Loader2,
   Maximize2,
   Minimize2,
@@ -25,6 +26,11 @@ import { SearchEntityType } from "@/api/generated/initiativeAPI.schemas";
 import { ToolCommentsPanel } from "@/components/comments/ToolCommentsPanel";
 import { DocumentBacklinks } from "@/components/documents/DocumentBacklinks";
 import { DocumentExportMenu } from "@/components/documents/DocumentExportMenu";
+import {
+  DocumentOutlinePanel,
+  DocumentOutlineScope,
+  useDocumentOutline,
+} from "@/components/documents/DocumentOutline";
 import { DocumentSidePanel, useDocumentSidePanel } from "@/components/documents/DocumentSidePanel";
 import { DocumentSummary } from "@/components/documents/DocumentSummary";
 import { CollaborationStatusBadge } from "@/components/documents/editor/CollaborationStatusBadge";
@@ -144,6 +150,7 @@ export const DocumentDetailPage = () => {
   const guildId = Number(guildIdParam);
   const gp = useGuildPath();
   const sidePanel = useDocumentSidePanel();
+  const outline = useDocumentOutline();
   const { isEnabled: isAIEnabled } = useAIEnabled();
   const setDocumentTagsMutation = useSetToolTags(Tool.document);
   const [aiSummary, setAiSummary] = useState<string | null>(null);
@@ -1048,6 +1055,9 @@ export const DocumentDetailPage = () => {
 
   const attachedProjects: DocumentProjectLink[] = document.projects ?? [];
   const showSummaryTab = document.document_type === "native" && isAIEnabled;
+  // Only prose has headings to navigate; a board, a sheet, an uploaded
+  // file and a link to somewhere else have no contents of their own.
+  const showOutline = document.document_type === "native";
 
   return (
     <div className="space-y-6">
@@ -1303,210 +1313,257 @@ export const DocumentDetailPage = () => {
             />
           </Suspense>
         ) : (
-          <div
-            className={cn(
-              "flex flex-col gap-4",
-              isFullscreen && "fixed inset-0 z-50 m-0! overflow-hidden bg-background p-4"
-            )}
-          >
-            {/* Collaboration status - shown between featured image and editor.
-                Also shown when offline even in non-collaborative mode, so the
-                user sees an explicit offline indicator at the top of the editor. */}
-            <div className="flex items-center gap-2">
-              {(collaborationEnabled || !isOnline) && (
-                <CollaborationStatusBadge
-                  connectionStatus={collaboration.connectionStatus}
-                  collaborators={collaboration.collaborators}
-                  isCollaborating={collaboration.isCollaborating}
-                  isSynced={collaboration.isSynced}
-                  isOnline={isOnline}
-                />
+          // Scoped to the body editor alone: a comment composer further down
+          // the page is an editor too, and its headings are not this
+          // document's contents.
+          <DocumentOutlineScope>
+            <div
+              className={cn(
+                "flex flex-col gap-4",
+                isFullscreen && "fixed inset-0 z-50 m-0! overflow-hidden bg-background p-4"
               )}
-              {document.document_type === "smart_link" &&
-              typeof (document.content as { url?: unknown } | null)?.url === "string" ? (
-                <Button asChild type="button" variant="ghost" size="sm" className="ml-auto">
-                  <a
-                    href={(document.content as { url: string }).url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <ExternalLink className="h-4 w-4" />
-                    {t("smartLink.openInNewTab")}
-                  </a>
-                </Button>
-              ) : null}
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsFullscreen((value) => !value)}
-                aria-label={t(isFullscreen ? "detail.exitFullscreen" : "detail.enterFullscreen")}
-                className={cn(document.document_type !== "smart_link" && "ml-auto")}
-              >
-                {isFullscreen ? (
-                  <Minimize2 className="h-4 w-4" />
-                ) : (
-                  <Maximize2 className="h-4 w-4" />
-                )}
-                {t(isFullscreen ? "detail.exitFullscreen" : "detail.enterFullscreen")}
-              </Button>
-            </div>
-            {/*
-              Key is just document.id - we don't remount when entering collaborative mode.
-              The CollaborationPlugin handles syncing the existing content to Yjs.
-            */}
-            <Suspense
-              fallback={
-                <div className="flex h-96 items-center justify-center rounded-xl border">
-                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                </div>
-              }
             >
-              {document.document_type === "whiteboard" ? (
-                whiteboardSceneReady ? (
-                  <WhiteboardDocumentEditor
-                    key={parsedId}
-                    initialScene={whiteboardScene}
-                    initialSceneFromCache={whiteboardSceneFromCache}
-                    onSerializedChange={handleWhiteboardChange}
-                    readOnly={!canEditDocument}
-                    yDoc={collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null}
+              {/* Collaboration status - shown between featured image and editor.
+                  Also shown when offline even in non-collaborative mode, so the
+                  user sees an explicit offline indicator at the top of the editor. */}
+              {/* Wraps rather than overflows: the row carries up to four
+                  controls and none of them shrink. */}
+              <div className="flex flex-wrap items-center gap-2">
+                {showOutline && (
+                  <Button
+                    type="button"
+                    variant={outline.isOpen ? "secondary" : "ghost"}
+                    size="sm"
+                    onClick={outline.toggle}
+                    aria-expanded={outline.isOpen}
+                    title={t(outline.isOpen ? "outline.hide" : "outline.show")}
+                  >
+                    <ListTree className="h-4 w-4" />
+                    {t("outline.title")}
+                  </Button>
+                )}
+                {(collaborationEnabled || !isOnline) && (
+                  <CollaborationStatusBadge
+                    connectionStatus={collaboration.connectionStatus}
+                    collaborators={collaboration.collaborators}
+                    isCollaborating={collaboration.isCollaborating}
                     isSynced={collaboration.isSynced}
-                    // The server roster includes ourselves — only *other*
-                    // users make the room's Yjs state authoritative over a
-                    // local write-ahead cache.
-                    hasOtherCollaborators={collaboration.collaborators.some(
-                      (c) => c.user_id !== user?.id
-                    )}
-                    collaboratorsReady={collaboration.collaboratorsReady}
-                    awareness={
-                      collaborationEnabled && collaboration.isReady ? whiteboardAwareness : null
-                    }
-                    currentUser={
-                      user ? { id: user.id, name: getUserDisplayName(user, "Anonymous") } : null
-                    }
-                    className={cn(isFullscreen && "h-full min-h-0 flex-1")}
+                    isOnline={isOnline}
                   />
-                ) : (
-                  <div className="flex h-96 items-center justify-center rounded-xl border">
-                    <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                  </div>
-                )
-              ) : document.document_type === "smart_link" ? (
-                <SmartLinkDocumentViewer
-                  key={parsedId}
-                  content={document.content as unknown as SmartLinkContent | null}
-                  className={cn(isFullscreen && "h-full min-h-0 flex-1")}
-                />
-              ) : document.document_type === "spreadsheet" ? (
-                <SpreadsheetDocumentEditor
-                  key={parsedId}
-                  initialContent={(document.content ?? {}) as unknown as SpreadsheetContent}
-                  onContentChange={(content) =>
-                    handleContentChange(content as unknown as SerializedEditorState)
-                  }
-                  documentTitle={title || document.name}
-                  readOnly={!canEditDocument}
-                  yDoc={collaborationEnabled && collaboration.isReady ? spreadsheetYDoc : null}
-                  isSynced={collaboration.isSynced}
-                  awareness={
-                    collaborationEnabled && collaboration.isReady ? spreadsheetAwareness : null
-                  }
-                  currentUser={spreadsheetCurrentUser}
-                  onImportFile={canEditDocument ? importSpreadsheetSheets : undefined}
-                  className={cn("max-h-[70vh]", isFullscreen && "h-full max-h-none min-h-0 flex-1")}
-                />
-              ) : (
-                <Editor
-                  key={parsedId}
-                  editorSerializedState={normalizedDocumentContent}
-                  onSerializedChange={handleContentChange}
-                  readOnly={!canEditDocument}
-                  showToolbar={canEditDocument}
-                  className={cn(
-                    "max-h-[80vh] bg-card",
-                    isFullscreen && "h-full max-h-none min-h-0 flex-1"
-                  )}
-                  collaborative={collaborationEnabled && collaboration.isReady}
-                  providerFactory={collaboration.providerFactory}
-                  // Always track changes so contentState stays updated for periodic saves
-                  trackChanges={true}
-                  isSynced={collaboration.isSynced}
-                  // Wikilinks support
-                  initiativeId={document.initiative_id}
-                  subject={referenceRef(SearchEntityType.document, document.id)}
-                  supportsEntityMentions={supportsEntityMentions(document.document_type)}
-                  onWikilinkNavigate={handleWikilinkNavigate}
-                  onCreateReferencedThing={handleCreateReferencedThing}
-                />
-              )}
-            </Suspense>
-            <div className="flex flex-wrap items-center gap-3">
-              {/* Smart-link docs have nothing editable on this page — suppress
-                  the save/autosave bar entirely. */}
-              {document.document_type === "smart_link" ? null : canEditDocument ? (
-                <>
-                  {/* When collaboration is active, changes sync in real-time */}
-                  {collaboration.isCollaborating ? (
-                    <span className="text-muted-foreground text-sm">
-                      {t("detail.collaborationDescription")}
-                    </span>
+                )}
+                {document.document_type === "smart_link" &&
+                typeof (document.content as { url?: unknown } | null)?.url === "string" ? (
+                  <Button asChild type="button" variant="ghost" size="sm" className="ml-auto">
+                    <a
+                      href={(document.content as { url: string }).url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      {t("smartLink.openInNewTab")}
+                    </a>
+                  </Button>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsFullscreen((value) => !value)}
+                  aria-label={t(isFullscreen ? "detail.exitFullscreen" : "detail.enterFullscreen")}
+                  className={cn(document.document_type !== "smart_link" && "ml-auto")}
+                >
+                  {isFullscreen ? (
+                    <Minimize2 className="h-4 w-4" />
                   ) : (
-                    <>
-                      <Button
-                        type="button"
-                        onClick={() =>
-                          saveDocument.mutate({
-                            name: title?.trim(),
-                            content: contentForSave,
-                            featured_image_url: featuredImageUrl,
-                          })
-                        }
-                        disabled={!isDirty || saveDocument.isPending}
-                      >
-                        {saveDocument.isPending ? (
-                          <>
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            {t("detail.saving")}
-                          </>
-                        ) : (
-                          t("detail.saveChanges")
-                        )}
-                      </Button>
-                      <div className="flex items-center gap-2">
-                        <Checkbox
-                          id="autosave"
-                          checked={autosaveEnabled}
-                          onCheckedChange={(checked) => setAutosaveEnabled(checked === true)}
-                        />
-                        <Label htmlFor="autosave" className="cursor-pointer text-sm">
-                          {t("detail.autosave")}
-                        </Label>
-                      </div>
-                      {!isDirty ? (
-                        <span className="self-center text-muted-foreground text-sm">
-                          {t("detail.allChangesSaved")}
-                        </span>
-                      ) : null}
-                    </>
+                    <Maximize2 className="h-4 w-4" />
                   )}
-                  {/* Always show collaboration toggle */}
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="collaboration"
-                      checked={collaborationEnabled}
-                      onCheckedChange={(checked) => setCollaborationEnabled(checked === true)}
-                    />
-                    <Label htmlFor="collaboration" className="cursor-pointer text-sm">
-                      {t("detail.liveCollaboration")}
-                    </Label>
-                  </div>
-                </>
-              ) : (
-                <p className="text-muted-foreground text-sm">{t("detail.readOnly")}</p>
-              )}
+                  {t(isFullscreen ? "detail.exitFullscreen" : "detail.enterFullscreen")}
+                </Button>
+              </div>
+              {/*
+                Key is just document.id - we don't remount when entering collaborative mode.
+                The CollaborationPlugin handles syncing the existing content to Yjs.
+              */}
+              <div className={cn("flex min-w-0 gap-4", isFullscreen && "min-h-0 flex-1")}>
+                {showOutline && (
+                  <DocumentOutlinePanel
+                    isOpen={outline.isOpen}
+                    onOpenChange={outline.setIsOpen}
+                    className={cn(
+                      "hidden w-64 shrink-0 lg:flex",
+                      isFullscreen ? "min-h-0" : "max-h-[80vh]"
+                    )}
+                  />
+                )}
+                <div className={cn("flex min-w-0 flex-1 flex-col", isFullscreen && "min-h-0")}>
+                  <Suspense
+                    fallback={
+                      <div className="flex h-96 items-center justify-center rounded-xl border">
+                        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                      </div>
+                    }
+                  >
+                    {document.document_type === "whiteboard" ? (
+                      whiteboardSceneReady ? (
+                        <WhiteboardDocumentEditor
+                          key={parsedId}
+                          initialScene={whiteboardScene}
+                          initialSceneFromCache={whiteboardSceneFromCache}
+                          onSerializedChange={handleWhiteboardChange}
+                          readOnly={!canEditDocument}
+                          yDoc={
+                            collaborationEnabled && collaboration.isReady ? whiteboardYDoc : null
+                          }
+                          isSynced={collaboration.isSynced}
+                          // The server roster includes ourselves — only *other*
+                          // users make the room's Yjs state authoritative over a
+                          // local write-ahead cache.
+                          hasOtherCollaborators={collaboration.collaborators.some(
+                            (c) => c.user_id !== user?.id
+                          )}
+                          collaboratorsReady={collaboration.collaboratorsReady}
+                          awareness={
+                            collaborationEnabled && collaboration.isReady
+                              ? whiteboardAwareness
+                              : null
+                          }
+                          currentUser={
+                            user
+                              ? { id: user.id, name: getUserDisplayName(user, "Anonymous") }
+                              : null
+                          }
+                          className={cn(isFullscreen && "h-full min-h-0 flex-1")}
+                        />
+                      ) : (
+                        <div className="flex h-96 items-center justify-center rounded-xl border">
+                          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                        </div>
+                      )
+                    ) : document.document_type === "smart_link" ? (
+                      <SmartLinkDocumentViewer
+                        key={parsedId}
+                        content={document.content as unknown as SmartLinkContent | null}
+                        className={cn(isFullscreen && "h-full min-h-0 flex-1")}
+                      />
+                    ) : document.document_type === "spreadsheet" ? (
+                      <SpreadsheetDocumentEditor
+                        key={parsedId}
+                        initialContent={(document.content ?? {}) as unknown as SpreadsheetContent}
+                        onContentChange={(content) =>
+                          handleContentChange(content as unknown as SerializedEditorState)
+                        }
+                        documentTitle={title || document.name}
+                        readOnly={!canEditDocument}
+                        yDoc={
+                          collaborationEnabled && collaboration.isReady ? spreadsheetYDoc : null
+                        }
+                        isSynced={collaboration.isSynced}
+                        awareness={
+                          collaborationEnabled && collaboration.isReady
+                            ? spreadsheetAwareness
+                            : null
+                        }
+                        currentUser={spreadsheetCurrentUser}
+                        onImportFile={canEditDocument ? importSpreadsheetSheets : undefined}
+                        className={cn(
+                          "max-h-[70vh]",
+                          isFullscreen && "h-full max-h-none min-h-0 flex-1"
+                        )}
+                      />
+                    ) : (
+                      <Editor
+                        key={parsedId}
+                        editorSerializedState={normalizedDocumentContent}
+                        onSerializedChange={handleContentChange}
+                        readOnly={!canEditDocument}
+                        showToolbar={canEditDocument}
+                        className={cn(
+                          "max-h-[80vh] bg-card",
+                          isFullscreen && "h-full max-h-none min-h-0 flex-1"
+                        )}
+                        collaborative={collaborationEnabled && collaboration.isReady}
+                        providerFactory={collaboration.providerFactory}
+                        // Always track changes so contentState stays updated for periodic saves
+                        trackChanges={true}
+                        isSynced={collaboration.isSynced}
+                        // Wikilinks support
+                        initiativeId={document.initiative_id}
+                        subject={referenceRef(SearchEntityType.document, document.id)}
+                        supportsEntityMentions={supportsEntityMentions(document.document_type)}
+                        onWikilinkNavigate={handleWikilinkNavigate}
+                        onCreateReferencedThing={handleCreateReferencedThing}
+                      />
+                    )}
+                  </Suspense>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                {/* Smart-link docs have nothing editable on this page — suppress
+                    the save/autosave bar entirely. */}
+                {document.document_type === "smart_link" ? null : canEditDocument ? (
+                  <>
+                    {/* When collaboration is active, changes sync in real-time */}
+                    {collaboration.isCollaborating ? (
+                      <span className="text-muted-foreground text-sm">
+                        {t("detail.collaborationDescription")}
+                      </span>
+                    ) : (
+                      <>
+                        <Button
+                          type="button"
+                          onClick={() =>
+                            saveDocument.mutate({
+                              name: title?.trim(),
+                              content: contentForSave,
+                              featured_image_url: featuredImageUrl,
+                            })
+                          }
+                          disabled={!isDirty || saveDocument.isPending}
+                        >
+                          {saveDocument.isPending ? (
+                            <>
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              {t("detail.saving")}
+                            </>
+                          ) : (
+                            t("detail.saveChanges")
+                          )}
+                        </Button>
+                        <div className="flex items-center gap-2">
+                          <Checkbox
+                            id="autosave"
+                            checked={autosaveEnabled}
+                            onCheckedChange={(checked) => setAutosaveEnabled(checked === true)}
+                          />
+                          <Label htmlFor="autosave" className="cursor-pointer text-sm">
+                            {t("detail.autosave")}
+                          </Label>
+                        </div>
+                        {!isDirty ? (
+                          <span className="self-center text-muted-foreground text-sm">
+                            {t("detail.allChangesSaved")}
+                          </span>
+                        ) : null}
+                      </>
+                    )}
+                    {/* Always show collaboration toggle */}
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="collaboration"
+                        checked={collaborationEnabled}
+                        onCheckedChange={(checked) => setCollaborationEnabled(checked === true)}
+                      />
+                      <Label htmlFor="collaboration" className="cursor-pointer text-sm">
+                        {t("detail.liveCollaboration")}
+                      </Label>
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-muted-foreground text-sm">{t("detail.readOnly")}</p>
+                )}
+              </div>
             </div>
-          </div>
+          </DocumentOutlineScope>
         )}
 
         <Card>


### PR DESCRIPTION
## Problem

A long document is easier to move around than to scroll, and there was no way to see its shape at a glance or jump to a section. Google Docs' document outline is the concept.

## What this adds

An optional **Contents** panel on the document page, built from the body's headings.

- **Nested.** Lexical hands out a flat, ordered list of headings; `buildOutlineTree` infers the nesting from the levels alone. A document that starts at `h2` is laid out from there rather than from an indent nobody wrote, and an `h1` → `h3` jump files the `h3` under the `h1` rather than inventing an empty `h2`.
- **Collapsible.** A heading with headings under it folds away.
- **Navigates.** Picking an entry scrolls the body to that heading; the one being read is marked as you scroll.
- **Closed by default**, and then remembered, the same as the page's other panels.
- **Desktop:** a 16rem column beside the document. **Phone:** it takes the document view over entirely while open — a column that narrow would be worse than no list at all.
- Only for `native` documents. A whiteboard, a sheet, an uploaded file and a link to somewhere else have no headings.

## Notable changes

- `frontend/src/components/documents/DocumentOutline.tsx` — the tree builder, the scope, the tracker, and the panel in both presentations.
- `frontend/src/components/documents/editor/editor.tsx` — renders `DocumentOutlineTracker` among the plugins. It publishes into the surrounding `DocumentOutlineScope`; with no scope above it (posts, any other surface an editor appears on) it tracks nothing.
- `frontend/src/pages/DocumentDetailPage.tsx` — the scope, the toggle, and the body laid out as a row. The whitespace in this diff is the body moving one level in under the new row wrapper; `?w=1` reads better.
- Locale keys added to all four languages.

The headings change on every keystroke inside one, so the scope publishes through a small external store rather than context state — only the list re-renders, not the editor beside it.

## Testing

```
cd frontend
pnpm vitest run src/components/documents/DocumentOutline.test.tsx   # 7 passed
pnpm vitest run src/pages/DocumentDetailPage.test.tsx src/__tests__/locale-keys.test.ts src/components/documents/editor
                                                                    # 382 passed
pnpm typecheck && pnpm lint && pnpm build                           # clean
```

## Screenshots

To follow.