### PR TITLE
Tests authenticate the way the app does

### DIFF
--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -46,7 +46,7 @@ from app.testing.factories import (
     create_user,
     get_auth_headers,
     get_auth_token,
-    get_new_access_token,
+    get_legacy_auth_headers,
     set_auth_scope,
 )
 from app.testing.oidc import (
@@ -697,7 +697,7 @@ async def test_new_access_token_authenticates(
     on the session path alongside legacy JWTs — the accept-before-issue half of
     the cutover."""
     user = await create_user(session)
-    token = get_new_access_token(user)
+    token = get_auth_token(user)
 
     response = await client.get(
         "/api/v1/users/me",
@@ -715,7 +715,7 @@ async def test_new_access_token_stale_version_returns_401(
     """The new token still carries ``ver``, so a token_version bump (logout /
     password change) revokes it exactly like a legacy token."""
     user = await create_user(session)
-    token = get_new_access_token(user)
+    token = get_auth_token(user)
     user.token_version += 1
     session.add(user)
     await session.commit()
@@ -758,7 +758,7 @@ async def test_upload_token_copies_session_satisfied_providers(
     satisfied = await client.post(
         "/api/v1/auth/upload-token",
         headers={
-            "Authorization": f"Bearer {get_new_access_token(user, satisfied_providers=[7, 3])}"
+            "Authorization": f"Bearer {get_auth_token(user, satisfied_providers=[7, 3])}"
         },
     )
     assert satisfied.status_code == 200, satisfied.text
@@ -766,7 +766,7 @@ async def test_upload_token_copies_session_satisfied_providers(
     assert sat == frozenset({3, 7})
 
     legacy = await client.post(
-        "/api/v1/auth/upload-token", headers=get_auth_headers(user)
+        "/api/v1/auth/upload-token", headers=get_legacy_auth_headers(user)
     )
     _, sat = verify_upload_token(legacy.json()["upload_token"])
     assert sat == frozenset()

--- a/backend/app/api/v1/platform_endpoints/guild_auth_policy_test.py
+++ b/backend/app/api/v1/platform_endpoints/guild_auth_policy_test.py
@@ -25,7 +25,7 @@ from app.testing.factories import (
     create_user,
     get_auth_headers,
     get_auth_token,
-    get_new_access_token,
+    get_legacy_auth_token,
     set_auth_scope,
 )
 
@@ -33,7 +33,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.auth]
 
 
 def _sat_headers(user, provider_ids: list[int]) -> dict[str, str]:
-    token = get_new_access_token(user, satisfied_providers=provider_ids)
+    token = get_auth_token(user, satisfied_providers=provider_ids)
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -389,7 +389,7 @@ async def test_ws_token_sat_gates_policy_guild(session: AsyncSession):
     guild_id, provider_id = guild.id, provider.id
 
     # Legacy session token: authenticates, but the policy gate refuses.
-    legacy_user = await authenticate_ws_token(get_auth_token(user), session)
+    legacy_user = await authenticate_ws_token(get_legacy_auth_token(user), session)
     assert legacy_user is not None
     assert satisfied_provider_ids() == frozenset()
     with pytest.raises(GuildAccessError):
@@ -397,7 +397,7 @@ async def test_ws_token_sat_gates_policy_guild(session: AsyncSession):
 
     # A satisfied session token joins.
     sat_user = await authenticate_ws_token(
-        get_new_access_token(user, satisfied_providers=[provider_id]), session
+        get_auth_token(user, satisfied_providers=[provider_id]), session
     )
     assert sat_user is not None
     assert satisfied_provider_ids() == frozenset({provider_id})

--- a/backend/app/services/platform/ws_auth_test.py
+++ b/backend/app/services/platform/ws_auth_test.py
@@ -11,7 +11,7 @@ from app.core.security import JWT_ALGORITHM, create_access_token
 from app.models.platform.user import UserStatus
 from app.services.platform import user_tokens
 from app.services.platform.ws_auth import authenticate_ws_token
-from app.testing import create_user, get_auth_token, get_new_access_token
+from app.testing import create_user, get_auth_token, get_legacy_auth_token
 
 
 async def test_valid_token_authenticates(session: AsyncSession):
@@ -24,11 +24,11 @@ async def test_valid_token_authenticates(session: AsyncSession):
     assert result.id == user.id
 
 
-async def test_new_access_token_authenticates(session: AsyncSession):
-    """Dual-verify: the WS path accepts the new-model access token too, so
-    realtime sockets stay in lockstep with the HTTP path."""
+async def test_a_legacy_token_still_authenticates(session: AsyncSession):
+    """Dual-verify, the other half: the WS path still accepts a pre-session
+    token, so realtime sockets stay in lockstep with the HTTP path."""
     user = await create_user(session)
-    token = get_new_access_token(user)
+    token = get_legacy_auth_token(user)
 
     result = await authenticate_ws_token(token, session)
 
@@ -36,10 +36,10 @@ async def test_new_access_token_authenticates(session: AsyncSession):
     assert result.id == user.id
 
 
-async def test_new_access_token_stale_version_rejected(session: AsyncSession):
-    """The new token's ``ver`` is enforced on the WS path as well."""
+async def test_a_legacy_tokens_version_is_enforced_too(session: AsyncSession):
+    """``ver`` is what revokes either scheme on the WS path."""
     user = await create_user(session)
-    token = get_new_access_token(user)
+    token = get_legacy_auth_token(user)
     user.token_version += 1
     session.add(user)
     await session.commit()

--- a/backend/app/testing/__init__.py
+++ b/backend/app/testing/__init__.py
@@ -69,7 +69,8 @@ from app.testing.factories import (
     set_notification_prefs,
     get_auth_headers,
     get_auth_token,
-    get_new_access_token,
+    get_legacy_auth_headers,
+    get_legacy_auth_token,
     set_auth_scope,
 )
 from app.testing.schema_harness import route_session_to_guild
@@ -132,7 +133,8 @@ __all__ = [
     "set_notification_prefs",
     "get_auth_headers",
     "get_auth_token",
-    "get_new_access_token",
+    "get_legacy_auth_headers",
+    "get_legacy_auth_token",
     "set_auth_scope",
     "route_session_to_guild",
 ]

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -342,37 +342,29 @@ async def create_guild_membership(
     return membership
 
 
-def get_auth_token(user: User) -> str:
-    """
-    Generate a valid JWT access token for a user.
-
-    Args:
-        user: User to generate token for
-
-    Returns:
-        JWT access token string
-
-    Example:
-        token = get_auth_token(test_user)
-        headers = {"Authorization": f"Bearer {token}"}
-        response = await client.get("/api/v1/users/me", headers=headers)
-    """
-    return create_access_token(subject=str(user.id), token_version=user.token_version)
-
-
-def get_new_access_token(
+def get_auth_token(
     user: User,
     *,
     session_id: uuid.UUID | None = None,
     amr: list[str] | None = None,
     satisfied_providers: list[int] | None = None,
 ) -> str:
-    """Mint a *new-model* access token (aud ``initiative:access``) for a user.
+    """A session credential for ``user`` — the token the app actually issues.
 
-    Mirrors :func:`get_auth_token` but for the dual-verify path: exercises that
-    the session-JWT verifiers accept the new scheme. ``session_id``/``amr``/
-    ``sat`` default to a throwaway session with ``pwd`` since the verify path
-    only checks ``sub``/``ver``.
+    ``aud=initiative:access``, carrying ``sid``/``amr``/``sat``, so a test
+    authenticates through the same verification a signed-in browser does.
+    ``sid`` is a throwaway uuid: the access token is stateless and nothing on
+    the request path resolves it against an ``auth_sessions`` row.
+
+    ``sat`` defaults to empty, which is what a password sign-in carries — a
+    test that needs a guild's sign-in policy satisfied passes the provider ids.
+
+    Use :func:`get_legacy_auth_token` where the pre-session scheme is itself
+    the thing under test.
+
+    Example:
+        headers = {"Authorization": f"Bearer {get_auth_token(test_user)}"}
+        response = await client.get("/api/v1/users/me", headers=headers)
     """
     token, _ = mint_access_token(
         user_id=user.id,
@@ -384,6 +376,22 @@ def get_new_access_token(
         else [],
     )
     return token
+
+
+def get_legacy_auth_token(user: User) -> str:
+    """A pre-session-model token: no ``aud``/``iss``, and none of
+    ``sid``/``amr``/``sat``.
+
+    ``decode_session_token`` accepts both schemes, and this is what exercises
+    that half. For tests about the legacy scheme itself — everything else wants
+    :func:`get_auth_token`.
+    """
+    return create_access_token(subject=str(user.id), token_version=user.token_version)
+
+
+def get_legacy_auth_headers(user: User) -> dict[str, str]:
+    """:func:`get_legacy_auth_token` as an Authorization header."""
+    return {"Authorization": f"Bearer {get_legacy_auth_token(user)}"}
 
 
 def get_auth_headers(user: User) -> dict[str, str]:

--- a/backend/app/testing/infrastructure_test.py
+++ b/backend/app/testing/infrastructure_test.py
@@ -9,8 +9,14 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.core.security import AUTH_ACCESS_AUDIENCE, AUTH_TOKEN_ISSUER
 from app.models.platform.user import UserStatus
-from app.testing.factories import create_user, get_auth_headers
+from app.testing.factories import (
+    create_user,
+    get_auth_headers,
+    get_auth_token,
+    get_legacy_auth_token,
+)
 
 
 @pytest.mark.unit
@@ -134,3 +140,60 @@ async def test_unrouted_tenant_write_fails_closed(session: AsyncSession, acting_
     with pytest.raises(RuntimeError, match="not routed to a guild schema"):
         await session.commit()
     await session.rollback()
+
+
+@pytest.mark.unit
+async def test_the_factory_mints_the_token_the_app_issues(session: AsyncSession):
+    """What the suite authenticates with is the shipped session credential, not
+    the pre-session scheme beside it. Every endpoint test rides on this, so it
+    is pinned here rather than left to whichever test happens to notice."""
+    import jwt as pyjwt
+
+    user = await create_user(session, email="factory-token@example.com")
+    claims = pyjwt.decode(
+        get_auth_token(user),
+        options={"verify_signature": False},
+        audience=AUTH_ACCESS_AUDIENCE,
+    )
+
+    assert claims["aud"] == AUTH_ACCESS_AUDIENCE
+    assert claims["iss"] == AUTH_TOKEN_ISSUER
+    assert claims["sub"] == str(user.id)
+    assert claims["ver"] == user.token_version
+    assert claims["sid"]
+    # What a password sign-in carries: a factor, and no provider satisfied.
+    assert claims["amr"] == ["pwd"]
+    assert claims["sat"] == []
+
+
+@pytest.mark.unit
+async def test_a_test_can_still_ask_for_the_legacy_token(session: AsyncSession):
+    """The scheme the app also accepts is reachable by name, for the tests
+    that are about that acceptance."""
+    import jwt as pyjwt
+
+    user = await create_user(session, email="factory-legacy@example.com")
+    claims = pyjwt.decode(
+        get_legacy_auth_token(user), options={"verify_signature": False}
+    )
+
+    assert claims["sub"] == str(user.id)
+    assert "aud" not in claims
+    assert "sid" not in claims
+
+
+@pytest.mark.unit
+async def test_a_factory_token_can_carry_a_satisfied_provider(session: AsyncSession):
+    """A guild's sign-in policy is satisfied by what the token says, so a test
+    of a policy-gated guild states it here."""
+    import jwt as pyjwt
+
+    user = await create_user(session, email="factory-sat@example.com")
+    claims = pyjwt.decode(
+        get_auth_token(user, satisfied_providers=[4, 9], amr=["oidc:corp"]),
+        options={"verify_signature": False},
+        audience=AUTH_ACCESS_AUDIENCE,
+    )
+
+    assert claims["sat"] == [4, 9]
+    assert claims["amr"] == ["oidc:corp"]


### PR DESCRIPTION
## Problem

`get_auth_token` minted the **pre-session** token — no `aud`/`iss`, and none of `sid`/`amr`/`sat`. `get_auth_headers` wraps it, and between them they are how essentially the whole suite authenticates.

Counted on `dev`: **668** references to `get_auth_token`/`get_auth_headers`, against **13** to `get_new_access_token`.

So the credential the app issues to every signed-in browser was exercised by thirteen call sites, and the one we intend to drop was exercised by everything else. Every endpoint test ran with an empty `sat` and no `amr` — which also means the guild sign-in policy gate, and anything else reading those claims, was only ever tested through the handful of places that opted in.

## Changes

**`get_auth_token(user, *, session_id=None, amr=None, satisfied_providers=None)`** now mints the shipped credential. `sid` defaults to a throwaway uuid — nothing on the request path resolves it against an `auth_sessions` row (the access token is stateless; only `ver` is checked), so this needs no database session and no changes at the 668 call sites. `amr` defaults to `["pwd"]` and `sat` to empty, which is what a password sign-in carries.

**`get_new_access_token` folded into it.** With the default flipped, "new" named nothing. Its eight call sites now pass the same keywords to `get_auth_token`.

**`get_legacy_auth_token` / `get_legacy_auth_headers`** added, and used in the four places where the older scheme is itself the thing under test:

- `ws_auth_test` — the two dual-verify arms, which were asserting the *new* scheme and are now the legacy half (renamed to say so, since that is the arm that would otherwise go untested)
- `guild_auth_policy_test` — the socket join that authenticates but is refused by the policy gate, which needs a token carrying no `sat`
- `auth_test` — the upload token's empty satisfied set

**`infrastructure_test`** pins the factory's shape: the token it mints carries `aud`/`iss`/`sid`/`amr`/`sat`, the legacy one carries none of them, and `satisfied_providers`/`amr` reach the claims. Every endpoint test rides on this, so it is asserted somewhere deliberate rather than left to whichever test would have noticed.

## Not a removal

`decode_session_token` still accepts both schemes, and the three production fallbacks that mint legacy tokens are untouched. Nothing needs an observation window, and no client behaviour changes — this is test-only.

It is, though, the precondition for the removal. While the suite itself mints legacy tokens, no counter on the verification path can tell our own traffic from a real client's.

## Testing

```
cd backend && pytest -n 0 app/api/v1/platform_endpoints/auth_test.py \
    app/api/v1/platform_endpoints/guild_auth_policy_test.py \
    app/api/v1/platform_endpoints/users_test.py \
    app/api/v1/platform_endpoints/auth_audit_test.py \
    app/services/platform/ws_auth_test.py \
    app/testing/infrastructure_test.py \
    app/api/v1/tenant_endpoints/documents_test.py \
    app/api/v1/tenant_endpoints/attachments_test.py
```

276 passed — the auth surfaces most likely to notice the change, plus a guild-scoped sample to exercise the `SET ROLE`/RLS path under the new claims. The rest of the suite is what CI is for, and the blast radius here is deliberately the whole of it.

`ruff format`, `ruff check`, `ty check` clean. No production code changed, so no changelog entry and no schema or OpenAPI change.
