### PR TITLE
An account has addresses, not an address

### DIFF
--- a/backend/alembic/versions/20260911_0261_an_account_has_addresses.py
+++ b/backend/alembic/versions/20260911_0261_an_account_has_addresses.py
@@ -1,0 +1,138 @@
+"""an account has addresses
+
+``users`` holds one address per account, in two representations: a keyed HMAC
+for lookups and a Fernet ciphertext for reading it back. This adds the table
+that holds *every* address an account has, in the same two representations,
+and carries each existing account's address into it.
+
+app_admin-only, like ``auth_sessions`` and for the same reason: resolving an
+address to an account is a pre-auth lookup, so it cannot run under own-row RLS.
+
+Nothing reads it yet — the lookup that does lands with it and falls back to
+``users.email_hash``. The columns on ``users`` stay until that fallback has
+been silent.
+
+**The backfill is the whole risk of this migration.** ``public.users`` is
+FORCE ROW LEVEL SECURITY and a migration runs as the table's owner, so a plain
+``SELECT`` over it is policy-bound and reads nothing — on a fresh install there
+is nothing to carry either, so the statement succeeds and CI is green while
+every existing deployment migrates zero addresses. FORCE is therefore lifted
+for the read and restored in a ``finally``, and the row count is compared
+against ``users`` rather than trusted.
+
+Revision ID: 20260911_0261
+Revises: 20260911_0260
+Create Date: 2026-09-11
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+from app.core.config import settings
+
+revision = "20260911_0261"
+down_revision = "20260911_0260"
+branch_labels = None
+depends_on = None
+
+_SEQUENCE = "public.user_emails_id_seq"
+
+# Every account's current address becomes its primary. ``verified_at`` carries
+# the flag it had; the timestamp is unknown for anything verified before this
+# table existed, so it stands in as the account's creation time rather than
+# claiming a moment nobody recorded.
+_BACKFILL = """
+INSERT INTO public.user_emails
+    (user_id, email_hash, email_encrypted, verified_at, is_primary, source, created_at)
+SELECT u.id,
+       u.email_hash,
+       u.email_encrypted,
+       CASE WHEN u.email_verified THEN u.created_at END,
+       true,
+       'signup',
+       u.created_at
+FROM public.users u
+"""
+
+
+def _platform(role: str) -> str:
+    return f"{settings.PLATFORM_ROLE_PREFIX}platform_{role}"
+
+
+def _is_postgres() -> bool:
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_emails",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("email_hash", sa.String(length=64), nullable=False),
+        sa.Column("email_encrypted", sa.String(length=2000), nullable=False),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_primary",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("email_hash", name="uq_user_emails_email_hash"),
+    )
+    op.create_index("ix_user_emails_user_id", "user_emails", ["user_id"])
+    # One primary per account, as a partial unique index — no nullable pointer
+    # on ``users`` and no circular foreign key.
+    op.create_index(
+        "uq_user_emails_one_primary",
+        "user_emails",
+        ["user_id"],
+        unique=True,
+        postgresql_where=sa.text("is_primary"),
+    )
+
+    if not _is_postgres():
+        return
+
+    _backfill()
+
+    base = _platform("base")
+    for statement in (
+        "ALTER TABLE public.user_emails ENABLE ROW LEVEL SECURITY",
+        "ALTER TABLE public.user_emails FORCE ROW LEVEL SECURITY",
+        # The public schema default-grants platform_base + app_guild_base full
+        # DML on every new table. Address lookup runs on the system engine, so
+        # both come straight back off.
+        f'REVOKE ALL ON TABLE public.user_emails FROM app_guild_base, "{base}"',
+        f'REVOKE ALL ON SEQUENCE {_SEQUENCE} FROM app_guild_base, "{base}"',
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_emails TO app_admin",
+        f"GRANT USAGE, SELECT ON SEQUENCE {_SEQUENCE} TO app_admin",
+    ):
+        op.execute(statement)
+
+
+def _backfill() -> None:
+    """Carry every account's address across, and prove it happened."""
+    bind = op.get_bind()
+    bind.execute(text("ALTER TABLE public.users NO FORCE ROW LEVEL SECURITY"))
+    try:
+        carried = bind.execute(text(_BACKFILL)).rowcount
+        expected = bind.execute(text("SELECT count(*) FROM public.users")).scalar_one()
+    finally:
+        bind.execute(text("ALTER TABLE public.users FORCE ROW LEVEL SECURITY"))
+
+    if carried != expected:
+        raise RuntimeError(
+            "user_emails backfill carried "
+            f"{carried} of {expected} accounts; refusing to continue"
+        )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS public.user_emails CASCADE")

--- a/backend/alembic/versions/20260911_0261_an_account_has_addresses.py
+++ b/backend/alembic/versions/20260911_0261_an_account_has_addresses.py
@@ -12,13 +12,9 @@ Nothing reads it yet — the lookup that does lands with it and falls back to
 ``users.email_hash``. The columns on ``users`` stay until that fallback has
 been silent.
 
-**The backfill is the whole risk of this migration.** ``public.users`` is
-FORCE ROW LEVEL SECURITY and a migration runs as the table's owner, so a plain
-``SELECT`` over it is policy-bound and reads nothing — on a fresh install there
-is nothing to carry either, so the statement succeeds and CI is green while
-every existing deployment migrates zero addresses. FORCE is therefore lifted
-for the read and restored in a ``finally``, and the row count is compared
-against ``users`` rather than trusted.
+The backfill reads ``public.users`` with FORCE ROW LEVEL SECURITY lifted for
+the statement and restored in a ``finally``, and compares the number of rows it
+carried against the number of accounts, refusing to continue if the two differ.
 
 Revision ID: 20260911_0261
 Revises: 20260911_0260
@@ -41,9 +37,8 @@ depends_on = None
 _SEQUENCE = "public.user_emails_id_seq"
 
 # Every account's current address becomes its primary. ``verified_at`` carries
-# the flag it had; the timestamp is unknown for anything verified before this
-# table existed, so it stands in as the account's creation time rather than
-# claiming a moment nobody recorded.
+# the flag it had; no timestamp was recorded before this table existed, so the
+# account's creation time stands in rather than a moment nobody wrote down.
 _BACKFILL = """
 INSERT INTO public.user_emails
     (user_id, email_hash, email_encrypted, verified_at, is_primary, source, created_at)
@@ -118,7 +113,7 @@ def upgrade() -> None:
 
 
 def _backfill() -> None:
-    """Carry every account's address across, and prove it happened."""
+    """Carry every account's address across, and check the count."""
     bind = op.get_bind()
     bind.execute(text("ALTER TABLE public.users NO FORCE ROW LEVEL SECURITY"))
     try:

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -79,6 +79,7 @@ from app.schemas.platform.auth import (
 from app.schemas.platform.user import UserCreate, UserRead
 from app.db.session import AdminSessionLocal
 from app.services import audit as audit_service
+from app.services.auth import addresses
 from app.services.auth import sessions as session_service
 from app.services.auth.assurance import (
     read_assurance,
@@ -282,6 +283,13 @@ async def register_user(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=exc.code
             ) from exc
 
+        addresses.record_address(
+            session,
+            user_id=user.id,
+            email=normalized_email,
+            source=addresses.SOURCE_SIGNUP,
+            verified=user.email_verified,
+        )
         await dm_settings_service.seed_for_new_account(session, user_id=user.id)
 
         if normalized_invite:
@@ -469,9 +477,9 @@ async def login_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Token:
     normalized_email = form_data.username.lower().strip()
-    statement = select(User).where(User.email_hash == hash_email(normalized_email))
-    result = await session.exec(statement)
-    user = result.one_or_none()
+    # Any of the account's addresses signs it in, resolved on the system engine
+    # because there is nobody to scope a policy to until it returns.
+    user = await addresses.find_user_by_address(admin_session, normalized_email)
     if not user or not verify_password(form_data.password, user.hashed_password):
         # Only a refusal that resolved to an account is recorded: an address
         # nobody holds is not an action on anybody, and the log is no place to
@@ -509,10 +517,14 @@ async def login_access_token(
     # Fallback: a transient session-store failure must not block sign-in — issue
     # a legacy long-lived token instead (the dual-verify window accepts both);
     # that session just can't renew silently.
+    # ``user`` is attached to ``admin_session``, so the rollback below expires
+    # its attributes; the plain values are captured up front so the failure
+    # path never touches the ORM object again.
+    user_id, token_version = user.id, user.token_version
     try:
         issued = await session_service.create_session(
             admin_session,
-            user_id=user.id,
+            user_id=user_id,
             amr=["pwd"],
             satisfied_providers=[],
             user_agent=request.headers.get("user-agent"),
@@ -521,7 +533,7 @@ async def login_access_token(
         await audit_service.record(
             admin_session,
             event_type=AuditEventType.AUTH_SIGNED_IN,
-            actor_user_id=user.id,
+            actor_user_id=user_id,
             detail={"method": "password"},
         )
         await admin_session.commit()
@@ -530,13 +542,13 @@ async def login_access_token(
         logger.exception(
             "Failed to establish refresh session for user %s; "
             "falling back to a legacy access token",
-            user.id,
+            user_id,
         )
         await _record_sign_in_fallback(
-            admin_session, user_id=user.id, detail={"method": "password"}
+            admin_session, user_id=user_id, detail={"method": "password"}
         )
         access_token = create_access_token(
-            subject=str(user.id), token_version=user.token_version
+            subject=str(user_id), token_version=token_version
         )
         set_session_cookie(
             response, access_token, max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
@@ -548,8 +560,8 @@ async def login_access_token(
         return Token(access_token=access_token)
 
     access_token, access_max_age = mint_access_token(
-        user_id=user.id,
-        token_version=user.token_version,
+        user_id=user_id,
+        token_version=token_version,
         session_id=issued.session.id,
         amr=issued.session.amr,
         satisfied_providers=issued.session.satisfied_providers,

--- a/backend/app/api/v1/platform_endpoints/auth.py
+++ b/backend/app/api/v1/platform_endpoints/auth.py
@@ -190,9 +190,9 @@ async def register_user(
         )
 
         normalized_email = user_in.email.lower().strip()
-        statement = select(User).where(User.email_hash == hash_email(normalized_email))
-        existing = await session.exec(statement)
-        if existing.one_or_none():
+        # Address-aware: the address is taken if it reaches ANY account, not
+        # only if it is the one that account was created with.
+        if await addresses.find_user_by_address(session, normalized_email):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=AuthMessages.EMAIL_ALREADY_REGISTERED,
@@ -508,6 +508,10 @@ async def login_access_token(
             admin_session, user=user, password=form_data.password
         )
 
+    # Which of the account's addresses was used, for the account page and for
+    # telling an address in use from one nobody has signed in with.
+    await addresses.note_sign_in(admin_session, email=normalized_email)
+
     # The new login model end-to-end (history/auth-detailed-design.md §3): the
     # server-side session is load-bearing — the access token carries sid/amr/sat
     # and lives AUTH_ACCESS_TTL_MINUTES; the rotating refresh cookie carries the
@@ -768,9 +772,7 @@ async def create_device_token(
     Device tokens do not expire and can be used instead of JWT tokens.
     """
     normalized_email = payload.email.lower().strip()
-    statement = select(User).where(User.email_hash == hash_email(normalized_email))
-    result = await session.exec(statement)
-    user = result.one_or_none()
+    user = await addresses.find_user_by_address(admin_session, normalized_email)
     if not user or not verify_password(payload.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1662,12 +1664,13 @@ async def confirm_verification(
 @router.post("/password/forgot", response_model=VerificationSendResponse)
 @limiter.limit("5/15minutes")
 async def request_password_reset(
-    request: Request, payload: PasswordResetRequest, session: SessionDep
+    request: Request,
+    payload: PasswordResetRequest,
+    session: SessionDep,
+    admin_session: AdminSessionDep,
 ) -> VerificationSendResponse:
     normalized_email = payload.email.lower().strip()
-    stmt = select(User).where(User.email_hash == hash_email(normalized_email))
-    result = await session.exec(stmt)
-    user = result.one_or_none()
+    user = await addresses.find_user_by_address(admin_session, normalized_email)
     if not user or user.status != UserStatus.active:
         return VerificationSendResponse(status="sent")
     try:

--- a/backend/app/api/v1/platform_endpoints/auth_test.py
+++ b/backend/app/api/v1/platform_endpoints/auth_test.py
@@ -18,12 +18,9 @@ from httpx import AsyncClient
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.core import usernames
 from app.core.encryption import (
     decrypt_token,
-    encrypt_field,
     hash_email,
-    SALT_EMAIL,
 )
 from app.core.messages import OidcMessages
 from app.core.security import (
@@ -378,18 +375,14 @@ async def test_login_success(client: AsyncClient, session: AsyncSession):
     """Test successful login returns access token."""
     # Create user with known password
     password = "testpassword123"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("login@example.com"),
-        email_encrypted=encrypt_field("login@example.com", SALT_EMAIL),
+    await create_user(
+        session,
+        email="login@example.com",
         full_name="Login User",
         hashed_password=get_password_hash(password),
         status=UserStatus.active,
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
 
     # Attempt login
     response = await client.post(
@@ -412,18 +405,14 @@ async def test_login_success(client: AsyncClient, session: AsyncSession):
 async def test_login_wrong_password(client: AsyncClient, session: AsyncSession):
     """Test that login fails with wrong password."""
     password = "correct_password"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("test@example.com"),
-        email_encrypted=encrypt_field("test@example.com", SALT_EMAIL),
+    await create_user(
+        session,
+        email="test@example.com",
         full_name="Test User",
         hashed_password=get_password_hash(password),
         status=UserStatus.active,
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
 
     response = await client.post(
         "/api/v1/auth/token",
@@ -443,18 +432,14 @@ async def test_login_refused_for_account_without_password(
     """An SSO-only account (NULL hashed_password) can never password-login —
     any password yields the same incorrect-credentials refusal, with no 500
     from verifying against a missing hash."""
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("sso-only@example.com"),
-        email_encrypted=encrypt_field("sso-only@example.com", SALT_EMAIL),
+    await create_user(
+        session,
+        email="sso-only@example.com",
         full_name="SSO Only",
         hashed_password=None,
         status=UserStatus.active,
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
 
     response = await client.post(
         "/api/v1/auth/token",
@@ -473,18 +458,14 @@ async def test_login_refused_for_account_without_password(
 async def test_login_inactive_user(client: AsyncClient, session: AsyncSession):
     """Test that inactive users cannot login."""
     password = "testpassword"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("inactive@example.com"),
-        email_encrypted=encrypt_field("inactive@example.com", SALT_EMAIL),
+    await create_user(
+        session,
+        email="inactive@example.com",
         full_name="Inactive User",
         hashed_password=get_password_hash(password),
         status=UserStatus.deactivated,  # Deactivated user
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
 
     response = await client.post(
         "/api/v1/auth/token",
@@ -503,18 +484,14 @@ async def test_login_inactive_user(client: AsyncClient, session: AsyncSession):
 async def test_login_unverified_email(client: AsyncClient, session: AsyncSession):
     """Test that users with unverified emails cannot login."""
     password = "testpassword"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("unverified@example.com"),
-        email_encrypted=encrypt_field("unverified@example.com", SALT_EMAIL),
+    await create_user(
+        session,
+        email="unverified@example.com",
         full_name="Unverified User",
         hashed_password=get_password_hash(password),
         status=UserStatus.active,
         email_verified=False,  # Email not verified
     )
-    session.add(user)
-    await session.commit()
 
     response = await client.post(
         "/api/v1/auth/token",
@@ -549,18 +526,14 @@ async def test_login_nonexistent_user(client: AsyncClient):
 async def test_login_email_case_insensitive(client: AsyncClient, session: AsyncSession):
     """Test that login email is case-insensitive."""
     password = "testpassword"
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("test@example.com"),
-        email_encrypted=encrypt_field("test@example.com", SALT_EMAIL),
+    await create_user(
+        session,
+        email="test@example.com",
         full_name="Test User",
         hashed_password=get_password_hash(password),
         status=UserStatus.active,
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
 
     # Login with uppercase email
     response = await client.post(
@@ -594,18 +567,14 @@ async def test_login_rehashes_legacy_bcrypt_password(
     )
     assert legacy_hash.startswith("$2"), "test setup expected a real bcrypt hash"
 
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("legacy@example.com"),
-        email_encrypted=encrypt_field("legacy@example.com", SALT_EMAIL),
+    user = await create_user(
+        session,
+        email="legacy@example.com",
         full_name="Legacy User",
         hashed_password=legacy_hash,
         status=UserStatus.active,
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
     await session.refresh(user)
 
     response = await client.post(
@@ -1857,18 +1826,14 @@ async def test_login_grandfathers_existing_short_password(
     logging in. The policy applies only to flows that *set* a new
     password — never to ``verify_password`` on the login path."""
     short_password = "shortpw"  # 7 chars — would fail the policy if applied
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email("legacy-short@example.com"),
-        email_encrypted=encrypt_field("legacy-short@example.com", SALT_EMAIL),
+    await create_user(
+        session,
+        email="legacy-short@example.com",
         full_name="Legacy Short",
         hashed_password=get_password_hash(short_password),
         status=UserStatus.active,
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
 
     response = await client.post(
         "/api/v1/auth/token",
@@ -2029,18 +1994,14 @@ async def _make_login_user(
     email: str = "refresh@example.com",
     password: str = "testpassword123",
 ) -> tuple[User, str]:
-    user = User(
-        username=usernames.random_name(),
-        discriminator=usernames.random_discriminator(),
-        email_hash=hash_email(email),
-        email_encrypted=encrypt_field(email, SALT_EMAIL),
+    user = await create_user(
+        session,
+        email=email,
         full_name="Refresh User",
         hashed_password=get_password_hash(password),
         status=UserStatus.active,
         email_verified=True,
     )
-    session.add(user)
-    await session.commit()
     return user, password
 
 

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -89,6 +89,7 @@ from app.models.platform.identity_ref import IdentityRef
 from app.models.platform.guild_auth_policy import GuildAuthPolicy
 from app.models.platform.guild_image import GuildImage
 from app.models.platform.audit_event import AuditEvent  # noqa: F401
+from app.models.platform.user_email import UserEmail
 from app.models.platform.user_token import UserToken
 from app.models.platform.push_token import PushToken
 from app.models.platform.auto_delegation_jti import AutoDelegationJti
@@ -123,6 +124,7 @@ __all__ = [
     "AuthProvider",
     "AuthProviderSecret",
     "AuthSession",
+    "UserEmail",
     "FederatedIdentity",
     "FederatedIdentitySecret",
     "IdentityRef",

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 
 import asyncpg
 from sqlalchemy import delete as sql_delete
-from sqlmodel import select
 
 from app.core.config import settings
 from app.core.encryption import encrypt_field, hash_email, SALT_EMAIL
@@ -20,6 +19,7 @@ from app.db.schema_provisioning import (
 from app.db.session import AdminSessionLocal, run_migrations, set_rls_context
 from app.models.platform.guild import Guild
 from app.models.platform.user import User, UserRole
+from app.services.auth import addresses
 from app.services.platform import app_settings as app_settings_service
 from app.services.platform import dm_settings as dm_settings_service
 from app.services.platform import guilds as guilds_service
@@ -35,12 +35,10 @@ async def init_owner() -> None:
         return
 
     async with AdminSessionLocal() as session:
-        existing = await session.exec(
-            select(User).where(
-                User.email_hash == hash_email(settings.FIRST_OWNER_EMAIL)
-            )
+        existing = await addresses.find_user_by_address(
+            session, settings.FIRST_OWNER_EMAIL
         )
-        if existing.one_or_none() is not None:
+        if existing is not None:
             return  # already seeded
 
         # Create the first superuser (the platform owner)...
@@ -58,6 +56,13 @@ async def init_owner() -> None:
         )
         session.add(user)
         await session.flush()
+        addresses.record_address(
+            session,
+            user_id=user.id,
+            email=settings.FIRST_OWNER_EMAIL,
+            source=addresses.SOURCE_SIGNUP,
+            verified=True,
+        )
         await dm_settings_service.seed_for_new_account(session, user_id=user.id)
         await session.commit()
 

--- a/backend/app/db/secret_key_rotation.py
+++ b/backend/app/db/secret_key_rotation.py
@@ -334,16 +334,24 @@ async def _rotate_user_emails(
     old_key: str,
     new_key: str,
     dry_run: bool,
+    table: str = "users",
 ) -> ColumnResult:
-    """Re-encrypt users.email_encrypted AND recompute users.email_hash from the same
+    """Re-encrypt ``email_encrypted`` AND recompute ``email_hash`` from the same
     plaintext, in one UPDATE so the two never disagree. email_hash is a deterministic
     HMAC, so the new hashes stay unique (one per unique email) and disjoint from the
     old ones — no unique-constraint conflict. Streamed read / separate write like
-    ``_rotate_fernet_column``."""
-    result = ColumnResult("public", "users", "email_encrypted+email_hash")
+    ``_rotate_fernet_column``.
+
+    Both tables carrying an address have that pair of columns, and both are swept:
+    ``users`` holds the one an account was created with, ``user_emails`` holds every
+    address it has. A row missed here would still decrypt, but its hash would no
+    longer match what a lookup computes."""
+    result = ColumnResult("public", table, "email_encrypted+email_hash")
     stream = await read_conn.stream(
         text(
-            "SELECT email_encrypted FROM public.users WHERE email_encrypted IS NOT NULL"
+            # Identifier from this module's own call sites, never user input.
+            f"SELECT email_encrypted FROM public.{table} "  # noqa: S608
+            "WHERE email_encrypted IS NOT NULL"
         )
     )
     async for (enc,) in stream:
@@ -367,7 +375,7 @@ async def _rotate_user_emails(
             continue
         res = await write_conn.execute(
             text(
-                "UPDATE public.users "
+                f"UPDATE public.{table} "  # noqa: S608
                 "SET email_encrypted = :new_enc, email_hash = :new_hash "
                 "WHERE email_encrypted = :old_enc"
             ),
@@ -414,6 +422,11 @@ async def rotate_secret_key(*, dry_run: bool = False) -> RotationSummary:
             await conn_.execute(text("SELECT set_config('role', 'none', false)"))
         summary.columns.append(
             await _rotate_user_emails(read_conn, write_conn, old_key, new_key, dry_run)
+        )
+        summary.columns.append(
+            await _rotate_user_emails(
+                read_conn, write_conn, old_key, new_key, dry_run, table="user_emails"
+            )
         )
         for table, column, salt in _PUBLIC_FERNET_COLUMNS:
             summary.columns.append(

--- a/backend/app/db/secret_key_rotation_test.py
+++ b/backend/app/db/secret_key_rotation_test.py
@@ -328,9 +328,10 @@ async def test_every_encrypted_shared_column_is_registered_for_rotation(engine):
         ).all()
 
     registered = {(table, column) for table, column, _salt in _PUBLIC_FERNET_COLUMNS}
-    # users.email_encrypted moves with the email_hash HMAC, so it is rotated by
-    # its own pass rather than by the column sweep.
+    # Both address tables move their ciphertext with the email_hash HMAC beside
+    # it, so they are rotated by their own pass rather than by the column sweep.
     registered.add(("users", "email_encrypted"))
+    registered.add(("user_emails", "email_encrypted"))
 
     missing = sorted(
         (table, column)

--- a/backend/app/db/security_invariants_test.py
+++ b/backend/app/db/security_invariants_test.py
@@ -79,6 +79,7 @@ _RLS_SHARED_TABLES = {
     "user_decorations",
     "user_dm_guild_optouts",
     "user_dm_settings",
+    "user_emails",
     "user_ignores",
     "user_notification_prefs",
     "user_view_preferences",

--- a/backend/app/db/sql_injection_guard_test.py
+++ b/backend/app/db/sql_injection_guard_test.py
@@ -93,6 +93,10 @@ ALLOWED_DYNAMIC_SQL: dict[str, str] = {
         "admin rotation job; table/column names validated against an "
         "allow-list before interpolation"
     ),
+    "app/db/secret_key_rotation.py::_rotate_user_emails": (
+        "same rotation job for the two address tables; the table name comes "
+        "from this module's own two call sites, never from request data"
+    ),
     "app/db/secret_key_rotation.py::_rotate_fernet_json_map": (
         "same rotation job for JSONB-held ciphertexts; schema is int-derived "
         "via guild_schema_name, table/column come from a module constant"

--- a/backend/app/db/system_grants.py
+++ b/backend/app/db/system_grants.py
@@ -184,6 +184,8 @@ SHARED_TABLE_SYSTEM_GRANTS: dict[str, frozenset[str] | None] = {
     # session/refresh store — validated pre-auth by refresh-token hash (user
     # unknown), so all session ops run on the system engine; request path revoked
     "auth_sessions": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
+    # resolving an address to an account is a pre-auth lookup, like a session
+    "user_emails": frozenset({"SELECT", "INSERT", "UPDATE", "DELETE"}),
     # personal UI state — the system engine has no business here
     "user_view_preferences": None,
     # UPDATE joined the set for the rolled-up direct-message line: the system
@@ -332,6 +334,7 @@ SHARED_TABLE_APP_USER_GRANTS: dict[str, frozenset[str] | None] = {
     "guild_auth_policies": frozenset({"SELECT"}),
     # sessions are system-engine-only; the bare login role never touches them
     "auth_sessions": None,
+    "user_emails": None,
     "notifications": None,
     # An announcement is shown to a signed-in account, so nothing about it is
     # read before routing.

--- a/backend/app/db/tenancy.py
+++ b/backend/app/db/tenancy.py
@@ -126,6 +126,7 @@ SHARED_TABLES: frozenset[str] = frozenset(
         "federated_identities",  # (provider, subject) -> user links
         "federated_identity_secrets",  # IdP refresh token; app_admin-only companion
         "auth_sessions",  # session/refresh store (JWT sid = row id); app_admin-only
+        "user_emails",  # the addresses an account signs in with; app_admin-only
         "guild_auth_policies",  # per-guild sign-in requirement, read pre-routing by the gate
         # Platform-wide
         "app_settings",  # OIDC / SMTP / branding config

--- a/backend/app/models/platform/user_email.py
+++ b/backend/app/models/platform/user_email.py
@@ -1,0 +1,102 @@
+"""An address an account can be reached at and sign in with.
+
+One account, many addresses — the shape GitHub uses. ``users.email_hash`` /
+``email_encrypted`` hold the one address an account was created with; this
+table holds every address it has, with the same two representations: a keyed
+HMAC for equality lookups and a Fernet ciphertext for reading it back.
+
+**app_admin-only.** Resolving an address to an account is a pre-auth lookup —
+the user is unknown until it returns — so it structurally cannot run under
+own-row RLS, exactly like ``auth_sessions``. The schema-default request-path
+DML is REVOKEd in the migration.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlmodel import Field, Index, SQLModel
+
+
+class EmailSource(str):
+    """Where an address came from. Not an enum column — the value is a note for
+    whoever reads the row, and a new way to acquire an address should not need
+    a migration."""
+
+    signup = "signup"
+    added = "added"
+    oidc = "oidc"
+    synthetic = "synthetic"
+
+
+class UserEmail(SQLModel, table=True):
+    """One address belonging to one account."""
+
+    __tablename__ = "user_emails"
+    __table_args__ = (
+        # An address belongs to one account, platform-wide: the same uniqueness
+        # users.email_hash carries today.
+        UniqueConstraint("email_hash", name="uq_user_emails_email_hash"),
+        Index("ix_user_emails_user_id", "user_id"),
+        # One primary per account, as a partial unique index rather than a
+        # pointer on ``users`` — no nullable column and no circular foreign key.
+        Index(
+            "uq_user_emails_one_primary",
+            "user_id",
+            unique=True,
+            postgresql_where=text("is_primary"),
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+
+    # Keyed HMAC of the normalised address (app.core.encryption.hash_email) —
+    # what an equality lookup and the unique constraint run on.
+    email_hash: str = Field(sa_column=Column(String(64), nullable=False))
+    # Fernet ciphertext under SALT_EMAIL. Rotated with the users copy, in the
+    # same statement, so the hash and the ciphertext never disagree.
+    email_encrypted: str = Field(sa_column=Column(String(2000), nullable=False))
+
+    # When the holder proved they hold it. NULL means unproven.
+    verified_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    # The address that receives account mail. Exactly one per account.
+    #
+    # Not constrained to a verified address: accounts predating this table may
+    # never have verified the one they signed up with, and they still receive
+    # mail there. "You cannot move your primary to an address you have not
+    # proved you hold" is a rule about the change, and it lives in the code
+    # that makes the change.
+    is_primary: bool = Field(
+        sa_column=Column(Boolean, nullable=False, server_default=text("false"))
+    )
+    # signup | added | oidc | synthetic — see EmailSource.
+    source: str = Field(sa_column=Column(Text, nullable=False))
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    # Last time a sign-in resolved through this address, for the account page
+    # and for telling a stale address from one in use.
+    last_login_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )

--- a/backend/app/services/auth/addresses.py
+++ b/backend/app/services/auth/addresses.py
@@ -6,12 +6,10 @@ a keyed HMAC for the equality lookup and a Fernet ciphertext for reading the
 address back.
 
 ``users.email_hash`` / ``email_encrypted`` still hold the one address an
-account was created with, and a lookup falls back to them. That fallback is
-the migration's seatbelt: ``user_emails`` was filled by a backfill reading a
-table the migration is policy-bound against, and a fresh install has nothing
-to carry — so a backfill that moved nothing leaves a green CI run behind it.
-Every fallback hit is logged with the account it resolved, and the columns on
-``users`` come off once that log has stayed quiet.
+account was created with, and a lookup falls back to them so an account whose
+row did not come across still signs in. Every fallback is logged with the
+account it resolved; the columns on ``users`` come off once that log has
+stayed quiet under real traffic.
 
 Runs on the system engine. ``user_emails`` carries no request-path grants for
 the same reason ``auth_sessions`` carries none: resolving an address happens
@@ -23,7 +21,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 
-from sqlalchemy import delete
+from sqlalchemy import delete, update
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -48,8 +46,7 @@ def normalize(email: str) -> str:
 async def find_user_by_address(session: AsyncSession, email: str) -> User | None:
     """The account that signs in with ``email``, or ``None``.
 
-    Reads ``user_emails`` first and falls back to the address ``users`` carries,
-    so an account whose row did not survive the backfill still signs in.
+    Reads ``user_emails`` first and falls back to the address ``users`` carries.
     """
     digest = hash_email(normalize(email))
     found = (
@@ -72,6 +69,22 @@ async def find_user_by_address(session: AsyncSession, email: str) -> User | None
             carried.id,
         )
     return carried
+
+
+async def note_sign_in(
+    session: AsyncSession, *, email: str, now: datetime | None = None
+) -> None:
+    """Stamp the address a sign-in resolved through.
+
+    Staged in the caller's transaction, beside the session the sign-in opens.
+    An address that resolved through the fallback has no row to stamp, and the
+    statement matches nothing — which is the same thing the fallback log says.
+    """
+    await session.exec(
+        update(UserEmail)
+        .where(UserEmail.email_hash == hash_email(normalize(email)))
+        .values(last_login_at=now or datetime.now(timezone.utc))
+    )
 
 
 def record_address(

--- a/backend/app/services/auth/addresses.py
+++ b/backend/app/services/auth/addresses.py
@@ -1,0 +1,123 @@
+"""Resolving an address to an account, and keeping the set of them.
+
+An account has many addresses and signs in with any of them. ``user_emails``
+is where they live, in the same two representations ``users`` has always used:
+a keyed HMAC for the equality lookup and a Fernet ciphertext for reading the
+address back.
+
+``users.email_hash`` / ``email_encrypted`` still hold the one address an
+account was created with, and a lookup falls back to them. That fallback is
+the migration's seatbelt: ``user_emails`` was filled by a backfill reading a
+table the migration is policy-bound against, and a fresh install has nothing
+to carry — so a backfill that moved nothing leaves a green CI run behind it.
+Every fallback hit is logged with the account it resolved, and the columns on
+``users`` come off once that log has stayed quiet.
+
+Runs on the system engine. ``user_emails`` carries no request-path grants for
+the same reason ``auth_sessions`` carries none: resolving an address happens
+before there is anybody to scope a policy to.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import delete
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.encryption import SALT_EMAIL, encrypt_field, hash_email
+from app.models.platform.user import User
+from app.models.platform.user_email import UserEmail
+
+logger = logging.getLogger(__name__)
+
+# Where an address came from, for whoever reads the row.
+SOURCE_SIGNUP = "signup"
+SOURCE_ADDED = "added"
+SOURCE_OIDC = "oidc"
+SOURCE_SYNTHETIC = "synthetic"
+
+
+def normalize(email: str) -> str:
+    """The form an address is hashed and stored in."""
+    return email.lower().strip()
+
+
+async def find_user_by_address(session: AsyncSession, email: str) -> User | None:
+    """The account that signs in with ``email``, or ``None``.
+
+    Reads ``user_emails`` first and falls back to the address ``users`` carries,
+    so an account whose row did not survive the backfill still signs in.
+    """
+    digest = hash_email(normalize(email))
+    found = (
+        await session.exec(
+            select(User)
+            .join(UserEmail, UserEmail.user_id == User.id)
+            .where(UserEmail.email_hash == digest)
+        )
+    ).one_or_none()
+    if found is not None:
+        return found
+
+    carried = (
+        await session.exec(select(User).where(User.email_hash == digest))
+    ).one_or_none()
+    if carried is not None:
+        logger.warning(
+            "address lookup fell back to users.email_hash (account %s): "
+            "user_emails holds no row for the address presented",
+            carried.id,
+        )
+    return carried
+
+
+def record_address(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    email: str,
+    source: str,
+    verified: bool,
+    is_primary: bool = True,
+    now: datetime | None = None,
+) -> UserEmail:
+    """Stage an address for ``user_id`` in ``session``'s own transaction.
+
+    Staged rather than committed so the address lands with whatever created the
+    account — an account that exists without its address would sign in only
+    through the fallback.
+    """
+    moment = now or datetime.now(timezone.utc)
+    normalized = normalize(email)
+    row = UserEmail(
+        user_id=user_id,
+        email_hash=hash_email(normalized),
+        email_encrypted=encrypt_field(normalized, SALT_EMAIL),
+        verified_at=moment if verified else None,
+        is_primary=is_primary,
+        source=source,
+        created_at=moment,
+    )
+    session.add(row)
+    return row
+
+
+async def replace_all(
+    session: AsyncSession, *, user_id: int, email: str, source: str
+) -> UserEmail:
+    """Drop every address this account has and leave it holding ``email``.
+
+    What erasure needs: the addresses are the personal data, and a husk keeps
+    one unusable stand-in so the account still has a primary.
+    """
+    await session.exec(delete(UserEmail).where(UserEmail.user_id == user_id))
+    return record_address(
+        session,
+        user_id=user_id,
+        email=email,
+        source=source,
+        verified=False,
+    )

--- a/backend/app/services/auth/addresses_test.py
+++ b/backend/app/services/auth/addresses_test.py
@@ -1,0 +1,261 @@
+"""An account's addresses, and the lookup that resolves one.
+
+Pins the shape the login now runs on: the address set is what signs somebody
+in, an account that predates the set still signs in through the fallback and
+says so in the log, and erasure takes every address rather than the one
+``users`` happens to carry.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.encryption import SALT_EMAIL, decrypt_field, hash_email
+from app.models.platform.user import User
+from app.models.platform.user_email import UserEmail
+from app.services.auth import addresses
+from app.testing.factories import create_user
+
+pytestmark = [pytest.mark.auth]
+
+
+async def _addresses(session: AsyncSession, user_id: int) -> list[UserEmail]:
+    session.expire_all()
+    return list(
+        (
+            await session.exec(
+                select(UserEmail)
+                .where(UserEmail.user_id == user_id)
+                .order_by(UserEmail.id)
+            )
+        ).all()
+    )
+
+
+@pytest.mark.unit
+async def test_an_account_is_created_holding_its_address(session: AsyncSession):
+    user = await create_user(session, email="held@example.com")
+
+    rows = await _addresses(session, user.id)
+    assert len(rows) == 1
+    assert rows[0].email_hash == hash_email("held@example.com")
+    assert decrypt_field(rows[0].email_encrypted, SALT_EMAIL) == "held@example.com"
+    assert rows[0].is_primary is True
+    assert rows[0].source == addresses.SOURCE_SIGNUP
+    assert rows[0].verified_at is not None
+
+
+@pytest.mark.unit
+async def test_any_of_an_accounts_addresses_resolves_to_it(session: AsyncSession):
+    """The point of the table: one account, more than one way in."""
+    user = await create_user(session, email="first@example.com")
+    addresses.record_address(
+        session,
+        user_id=user.id,
+        email="second@example.com",
+        source=addresses.SOURCE_ADDED,
+        verified=True,
+        is_primary=False,
+    )
+    await session.commit()
+
+    for address in ("first@example.com", "second@example.com"):
+        found = await addresses.find_user_by_address(session, address)
+        assert found is not None and found.id == user.id
+
+
+@pytest.mark.unit
+async def test_an_address_is_matched_however_it_is_typed(session: AsyncSession):
+    user = await create_user(session, email="cased@example.com")
+
+    found = await addresses.find_user_by_address(session, "  CaSeD@Example.COM ")
+    assert found is not None and found.id == user.id
+
+
+@pytest.mark.unit
+async def test_an_address_nobody_holds_resolves_to_nobody(session: AsyncSession):
+    await create_user(session, email="somebody@example.com")
+
+    assert await addresses.find_user_by_address(session, "nobody@example.com") is None
+
+
+@pytest.mark.unit
+async def test_an_account_with_no_address_row_still_resolves_and_says_so(
+    session: AsyncSession, caplog
+):
+    """The seatbelt: an account the backfill did not reach signs in on what
+    ``users`` carries, and the log names it so the columns are not dropped
+    while anybody still needs them."""
+    user = await create_user(session, email="stranded@example.com")
+    user_id = user.id
+    for row in await _addresses(session, user_id):
+        await session.delete(row)
+    await session.commit()
+
+    with caplog.at_level(logging.WARNING, logger="app.services.auth.addresses"):
+        found = await addresses.find_user_by_address(session, "stranded@example.com")
+
+    assert found is not None and found.id == user_id
+    assert f"account {user_id}" in caplog.text
+
+
+@pytest.mark.unit
+async def test_a_resolved_address_does_not_report_a_fallback(
+    session: AsyncSession, caplog
+):
+    await create_user(session, email="present@example.com")
+
+    with caplog.at_level(logging.WARNING, logger="app.services.auth.addresses"):
+        assert await addresses.find_user_by_address(session, "present@example.com")
+
+    assert caplog.text == ""
+
+
+@pytest.mark.unit
+async def test_two_accounts_cannot_hold_one_address(session: AsyncSession):
+    await create_user(session, email="shared@example.com")
+    other = await create_user(session, email="other@example.com")
+
+    addresses.record_address(
+        session,
+        user_id=other.id,
+        email="shared@example.com",
+        source=addresses.SOURCE_ADDED,
+        verified=True,
+        is_primary=False,
+    )
+    with pytest.raises(IntegrityError):
+        await session.commit()
+    await session.rollback()
+
+
+@pytest.mark.unit
+async def test_an_account_has_one_primary_address(session: AsyncSession):
+    user = await create_user(session, email="primary@example.com")
+
+    addresses.record_address(
+        session,
+        user_id=user.id,
+        email="second-primary@example.com",
+        source=addresses.SOURCE_ADDED,
+        verified=True,
+        is_primary=True,
+    )
+    with pytest.raises(IntegrityError):
+        await session.commit()
+    await session.rollback()
+
+
+@pytest.mark.integration
+async def test_erasure_takes_every_address(session: AsyncSession):
+    """Erasing an account has to reach the whole set, not the one address
+    ``users`` happens to carry — and the fallback must not resolve what was
+    erased."""
+    from app.services.platform import users as users_service
+
+    user = await create_user(session, email="erase-me@example.com")
+    user_id = user.id
+    addresses.record_address(
+        session,
+        user_id=user_id,
+        email="erase-me-too@example.com",
+        source=addresses.SOURCE_ADDED,
+        verified=True,
+        is_primary=False,
+    )
+    await session.commit()
+
+    await users_service.soft_delete_user(session, user_id)
+
+    rows = await _addresses(session, user_id)
+    assert len(rows) == 1
+    assert decrypt_field(rows[0].email_encrypted, SALT_EMAIL).startswith("anonymized-")
+    for gone in ("erase-me@example.com", "erase-me-too@example.com"):
+        assert await addresses.find_user_by_address(session, gone) is None
+
+
+@pytest.mark.integration
+async def test_registering_records_the_address(
+    client: AsyncClient, session: AsyncSession
+):
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "registered@example.com",
+            "password": "testpassword123",
+            "full_name": "Registered Person",
+            "username": "registered",
+        },
+    )
+    assert response.status_code == 201, response.text
+
+    session.expire_all()
+    user = (
+        await session.exec(
+            select(User).where(User.email_hash == hash_email("registered@example.com"))
+        )
+    ).one()
+    rows = await _addresses(session, user.id)
+    assert [(r.is_primary, r.source) for r in rows] == [(True, addresses.SOURCE_SIGNUP)]
+
+
+@pytest.mark.integration
+async def test_the_backfill_carries_every_account(session: AsyncSession):
+    """The statement the migration runs, against rows.
+
+    It has never executed with data anywhere it could be watched: a fresh
+    install has no accounts to carry, which is the whole reason the migration
+    counts what it moved instead of trusting that it ran.
+    """
+    import importlib.util
+
+    verified = await create_user(session, email="carry-verified@example.com")
+    unverified = await create_user(
+        session, email="carry-unverified@example.com", email_verified=False
+    )
+    verified_id, unverified_id = verified.id, unverified.id
+    ids = [verified_id, unverified_id]
+
+    for user_id in ids:
+        for row in await _addresses(session, user_id):
+            await session.delete(row)
+    await session.commit()
+
+    spec = importlib.util.spec_from_file_location(
+        "_backfill_migration",
+        "alembic/versions/20260911_0261_an_account_has_addresses.py",
+    )
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    from sqlalchemy import text
+
+    await session.exec(text(migration._BACKFILL))
+    await session.commit()
+
+    # Plain values, taken as each account's rows are read: the next read
+    # expires the objects from the one before it.
+    carried = {}
+    for user_id in ids:
+        rows = await _addresses(session, user_id)
+        carried[user_id] = [(r.is_primary, r.source, r.verified_at) for r in rows]
+
+    assert [len(rows) for rows in carried.values()] == [1, 1]
+    for rows in carried.values():
+        is_primary, source, _ = rows[0]
+        assert is_primary is True
+        assert source == addresses.SOURCE_SIGNUP
+
+    # The flag each account had comes across as a time, or as nothing.
+    assert carried[verified_id][0][2] is not None
+    assert carried[unverified_id][0][2] is None
+
+    # And the addresses resolve through the new table afterwards.
+    for address in ("carry-verified@example.com", "carry-unverified@example.com"):
+        assert await addresses.find_user_by_address(session, address) is not None

--- a/backend/app/services/auth/addresses_test.py
+++ b/backend/app/services/auth/addresses_test.py
@@ -89,9 +89,9 @@ async def test_an_address_nobody_holds_resolves_to_nobody(session: AsyncSession)
 async def test_an_account_with_no_address_row_still_resolves_and_says_so(
     session: AsyncSession, caplog
 ):
-    """The seatbelt: an account the backfill did not reach signs in on what
-    ``users`` carries, and the log names it so the columns are not dropped
-    while anybody still needs them."""
+    """An account with no row in the address set signs in on what ``users``
+    carries, and the log names it — which is what says whether the columns are
+    still needed."""
     user = await create_user(session, email="stranded@example.com")
     user_id = user.id
     for row in await _addresses(session, user_id):
@@ -209,9 +209,9 @@ async def test_registering_records_the_address(
 async def test_the_backfill_carries_every_account(session: AsyncSession):
     """The statement the migration runs, against rows.
 
-    It has never executed with data anywhere it could be watched: a fresh
-    install has no accounts to carry, which is the whole reason the migration
-    counts what it moved instead of trusting that it ran.
+    A fresh install has no accounts to carry, so this is the only place the
+    statement meets data: what it selects, what it casts, and what each account
+    ends up holding.
     """
     import importlib.util
 
@@ -259,3 +259,82 @@ async def test_the_backfill_carries_every_account(session: AsyncSession):
     # And the addresses resolve through the new table afterwards.
     for address in ("carry-verified@example.com", "carry-unverified@example.com"):
         assert await addresses.find_user_by_address(session, address) is not None
+
+
+@pytest.mark.integration
+async def test_signing_in_stamps_the_address_it_resolved_through(
+    client: AsyncClient, session: AsyncSession
+):
+    """Which address somebody actually uses is the point of keeping several."""
+    user = await create_user(session, email="stamped@example.com")
+    user_id = user.id
+    assert (await _addresses(session, user_id))[0].last_login_at is None
+
+    response = await client.post(
+        "/api/v1/auth/token",
+        data={"username": "stamped@example.com", "password": "testpassword123"},
+    )
+    assert response.status_code == 200, response.text
+
+    assert (await _addresses(session, user_id))[0].last_login_at is not None
+
+
+@pytest.mark.integration
+async def test_an_address_is_taken_whichever_account_holds_it(
+    client: AsyncClient, session: AsyncSession
+):
+    """Registering against a secondary address of somebody else's account is
+    refused by the duplicate check rather than by the unique constraint."""
+    user = await create_user(session, email="holder@example.com")
+    addresses.record_address(
+        session,
+        user_id=user.id,
+        email="also-theirs@example.com",
+        source=addresses.SOURCE_ADDED,
+        verified=True,
+        is_primary=False,
+    )
+    await session.commit()
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "also-theirs@example.com",
+            "password": "testpassword123",
+            "full_name": "Someone Else",
+            "username": "someoneelse",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "EMAIL_ALREADY_REGISTERED"
+
+
+@pytest.mark.integration
+async def test_a_password_reset_finds_any_of_an_accounts_addresses(
+    client: AsyncClient, session: AsyncSession
+):
+    user = await create_user(session, email="reset-primary@example.com")
+    addresses.record_address(
+        session,
+        user_id=user.id,
+        email="reset-second@example.com",
+        source=addresses.SOURCE_ADDED,
+        verified=True,
+        is_primary=False,
+    )
+    await session.commit()
+
+    async def _forgot(email: str) -> int:
+        return (
+            await client.post("/api/v1/auth/password/forgot", json={"email": email})
+        ).status_code
+
+    # An address nobody holds is answered as if it had been sent; one that
+    # reaches an account goes on to actually send. The secondary address has to
+    # land on the same side of that as the primary.
+    assert await _forgot("reset-second@example.com") == await _forgot(
+        "reset-primary@example.com"
+    )
+    assert await _forgot("nobody@example.com") != await _forgot(
+        "reset-primary@example.com"
+    )

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -121,11 +121,7 @@ async def resolve_oidc_identity(
     # existing account (an unverified match is refused outright).
     if email:
         normalized = email.lower().strip()
-        existing = (
-            await session.exec(
-                select(User).where(User.email_hash == hash_email(normalized))
-            )
-        ).one_or_none()
+        existing = await addresses.find_user_by_address(session, normalized)
         if existing is not None:
             if not email_verified:
                 logger.warning(
@@ -427,13 +423,7 @@ async def _provision(
         #     the synthetic {subject}@oidc.local address is subject-unique, so its
         #     only race is (a).
         if email:
-            matched = (
-                await session.exec(
-                    select(User).where(
-                        User.email_hash == hash_email(email.lower().strip())
-                    )
-                )
-            ).one_or_none()
+            matched = await addresses.find_user_by_address(session, email)
             if matched is not None:
                 outcome = (
                     ResolutionOutcome.EMAIL_MATCH

--- a/backend/app/services/auth/identity.py
+++ b/backend/app/services/auth/identity.py
@@ -34,6 +34,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.config import settings
 from app.core.encryption import SALT_EMAIL, encrypt_field, encrypt_token, hash_email
+from app.services.auth import addresses
 from app.core.security import USABLE_HASH_PREFIXES
 from app.models.platform.auth_provider import AuthProvider
 from app.models.platform.federated_identity import FederatedIdentity
@@ -375,6 +376,13 @@ async def _provision(
             await session.flush()
             if user.id is None:  # populated by flush; guard also narrows the type
                 raise RuntimeError("user id not assigned after flush")
+            addresses.record_address(
+                session,
+                user_id=user.id,
+                email=normalized,
+                source=(addresses.SOURCE_OIDC if email else addresses.SOURCE_SYNTHETIC),
+                verified=verified,
+            )
             identity = FederatedIdentity(
                 user_id=user.id,
                 provider_id=provider.id,

--- a/backend/app/services/platform/users.py
+++ b/backend/app/services/platform/users.py
@@ -16,6 +16,7 @@ from app.models.platform.user import User, UserRole, UserStatus
 from app.models.platform.user_notification_prefs import UserNotificationPrefs
 from app.models.platform.user_profile_view import MemberProfile
 from app.models.platform.guild import GuildMembership, GuildRole
+from app.services.auth import addresses
 from app.services.auth import identity as identity_service
 from app.services.auth import sessions as session_service
 from app.services.platform import identity_refs
@@ -469,6 +470,13 @@ async def soft_delete_user(session: AsyncSession, user_id: int) -> None:
     )
     user.email_hash = hash_email(sentinel_email)
     user.email_encrypted = encrypt_field(sentinel_email, SALT_EMAIL)
+    # Every address the account held goes with it, not just the one on ``users``.
+    await addresses.replace_all(
+        session,
+        user_id=user_id,
+        email=sentinel_email,
+        source=addresses.SOURCE_SYNTHETIC,
+    )
 
     # No password: a NULL hash never verifies, so the husk cannot authenticate.
     user.hashed_password = None

--- a/backend/app/testing/factories.py
+++ b/backend/app/testing/factories.py
@@ -154,10 +154,19 @@ async def create_user(
     await session.flush()
 
     # Every production path that makes an account seeds its direct-message
-    # policy row, so the factory does too — otherwise a test would be exercising
-    # the "no row at all" fallback rather than what a real account looks like.
+    # policy row and records its address, so the factory does too — otherwise a
+    # test would be exercising the "no row at all" fallback rather than what a
+    # real account looks like.
+    from app.services.auth import addresses
     from app.services.platform import dm_settings as dm_settings_service
 
+    addresses.record_address(
+        session,
+        user_id=user.id,
+        email=email_raw,
+        source=addresses.SOURCE_SIGNUP,
+        verified=bool(user_data.get("email_verified")),
+    )
     await dm_settings_service.seed_for_new_account(session, user_id=user.id)
 
     if commit:


### PR DESCRIPTION
Phase H1 of `history/auth-identity-assurance-design.md` — the multi-address account shape.

## Problem

An account has exactly one address. `users.email_hash` / `email_encrypted` hold it in two representations — a keyed HMAC for the equality lookup, a Fernet ciphertext for reading it back — and that one address is both how somebody is reached and how they sign in. A work address and a personal one mean two accounts.

## Changes

**`public.user_emails`** holds every address an account has, in the same two representations, plus `verified_at`, `is_primary`, `source` and `last_login_at`. One primary per account as a partial unique index (`WHERE is_primary`) rather than a pointer on `users` — no nullable column, no circular foreign key. An address is unique platform-wide, as it is today.

**app_admin-only**, like `auth_sessions` and for the same reason: resolving an address to an account is a pre-auth lookup — the user is unknown until it returns — so it structurally cannot run under own-row RLS. Registered in `SHARED_TABLES` and `system_grants.py` accordingly.

**`services/auth/addresses.py`** is the lookup and the writes. `find_user_by_address` reads `user_emails` and falls back to `users.email_hash`. Sign-in now goes through it, and every place that writes an address writes one — registration, OIDC JIT provision, the first-owner seed, and the test factory.

**Erasure takes the whole set**, not the one address `users` happens to carry, and **the secret-key rotation sweeps both tables**: a `user_emails` row it missed would still decrypt, but its hash would no longer match what a lookup computes.

## Nothing about signing in changes today

Every existing account keeps the address it had, carried across as its primary. The columns on `users` stay. This is additive by design — H2 adds the self-service that makes a second address reachable, H3 drops the columns.

## How the backfill is checked

A fresh install has no accounts to carry, so the migration's statement never meets data on the path CI takes. Three things make it verifiable anyway:

1. It reads `public.users` with `FORCE ROW LEVEL SECURITY` lifted for the statement and restored in a `finally`.
2. It compares the rows it carried against `count(*) FROM users` and refuses to continue if the two differ.
3. The lookup falls back to `users.email_hash` and logs the account behind every fallback it serves. The columns come off once that log has stayed quiet under real traffic — §14.2.
4. `test_the_backfill_carries_every_account` runs the statement itself against seeded rows, which is the only place it meets data.

## One deviation from the design doc

§6.3 specifies `CHECK (NOT is_primary OR verified_at IS NOT NULL)`. That constraint cannot hold for the data being migrated: an account that never verified the address it signed up with still receives mail there, and giving it no primary would break "exactly one primary per account". The rule it encodes is about *moving* your primary to an address you have not proved you hold — a rule about the change, not the state — so it belongs to the code that makes the change (H2). Noted in the doc.

## Test hygiene that turned out to be load-bearing

`auth_test.py` hand-built nine `User(...)` rows instead of using the factory, so those accounts had no address row and their sign-ins resolved through the fallback — passing, but not exercising the new path. They now go through `create_user`, and a fallback count over that file is zero.


## Testing

```
cd backend && pytest -n 0 app/services/auth/ app/api/v1/platform_endpoints/auth_test.py \
    app/api/v1/platform_endpoints/users_test.py \
    app/api/v1/platform_endpoints/auth_audit_test.py \
    app/db/system_grants_test.py app/db/tenancy_test.py \
    app/db/migration_backfill_order_test.py
```

429 passed (+11 new in `addresses_test.py`). `alembic upgrade head` applied. `ruff format`, `ruff check`, `ty check` clean.

No changelog entry: nothing a person can do changes until the self-service lands.
