### PR TITLE
Speed up My Tasks and stop its table freezing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **My Tasks stops going dark every time you tick something off** — checking a task off, or moving it to another status, put a translucent "Updating" panel over the whole table and disabled every row in it until three cross-guild requests had come back. The change now shows on the row the moment you make it, and everything else on the page stays live: you can carry on sorting, paging and checking things off while the list catches up behind a thin progress line. Only the row actually saving is held, so it can't be submitted twice, and if the save fails the row goes back to what it was and says so.
+- **My Tasks loads faster** — the page used to fetch every task assigned to you, in every community you belong to, complete with its status, people, tags and properties, and then show twenty of them. It now works out the order first and loads only the rows on the page you asked for, from only the communities that have one, so the work no longer grows with the size of your task list. Your saved filters and sort are also fetched as soon as you sign in rather than when the page opens, which took a round trip out of the wait before the first row could appear.
+
+### Fixed
+
+- **A task opened on a phone is one column again** — the task page put its form and its checklist side by side on any narrow screen, giving each half as little as 152px on a phone and around 280px on a small tablet: a form squeezed into a third of a column nobody would choose to fill in. The two halves now sit one above the other until there is genuinely room for both at full width, which is what they already did between 640px and 824px. Wider windows are unchanged.
+- **A task's title is sized like a title, not a banner** — the heading on the task page was set three steps larger than the page's own headings, so a task with a name of any length took two or three lines before anything about it was visible. It now sits at a size that leaves the task's details on the first screen.
+
 ## [0.68.2] - 2026-09-11
 
 ### Added

--- a/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
+++ b/backend/app/api/v1/tenant_endpoints/me_tasks_test.py
@@ -340,6 +340,163 @@ async def test_list_my_tasks_pagination(client: AsyncClient, session: AsyncSessi
 
 
 @pytest.mark.integration
+async def test_list_my_tasks_counts_comments_per_row(
+    client: AsyncClient, session: AsyncSession
+):
+    """Each row carries its own comment count.
+
+    The count is selected alongside the task rather than fetched for the page as
+    a group, so it is worth pinning that it lands on the right row — including
+    the zero for a task nobody has commented on.
+    """
+    from app.testing.factories import create_comment
+
+    user = await create_user(session, email="user@example.com")
+    _guild, _, project = await _setup_guild_with_project(session, user)
+
+    talked_about = await _create_task(
+        session, project, "talked about", created_by=user.id
+    )
+    quiet = await _create_task(session, project, "quiet", created_by=user.id)
+    for task in (talked_about, quiet):
+        await _assign(session, task, user.id)
+    for _ in range(3):
+        await create_comment(session, user, task=talked_about)
+
+    response = await client.get("/api/v1/me/tasks", headers=get_auth_headers(user))
+    assert response.status_code == 200, response.text
+    counts = {t["title"]: t["comment_count"] for t in response.json()["items"]}
+    assert counts == {"talked about": 3, "quiet": 0}
+
+
+@pytest.mark.integration
+async def test_list_my_tasks_paged_page_interleaves_guilds(
+    client: AsyncClient, session: AsyncSession
+):
+    """A page drawn from several guilds comes back in the sort's order.
+
+    The endpoint orders the whole matching set from lightweight per-guild rows
+    and then loads only the ids on the requested page — so the rows are fetched
+    guild by guild and have to be put back into the global order, and a guild
+    that contributes nothing to this page must still count toward
+    ``total_count``. Interleaving the due dates across two guilds means guild
+    order and sort order disagree on every page.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+
+    user = await create_user(session, email="user@example.com")
+    _guild1, _, project1 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 1"
+    )
+    _guild2, _, project2 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 2"
+    )
+
+    # The soonest task is in the LATER guild, so concatenating each guild's rows
+    # in guild order gets every page wrong: guild 2 holds days 1 and 3, guild 1
+    # days 2 and 4.
+    plan = [
+        (project2, "first", 1),
+        (project1, "second", 2),
+        (project2, "third", 3),
+        (project1, "fourth", 4),
+    ]
+    for project, title, days in plan:
+        task = await _create_task(
+            session,
+            project,
+            title,
+            created_by=user.id,
+            due_date=now + timedelta(days=days),
+        )
+        await _assign(session, task, user.id)
+
+    headers = get_auth_headers(user)
+    sorting = json.dumps([{"field": "due_date", "dir": "asc"}])
+
+    response = await client.get(
+        f"/api/v1/me/tasks?sorting={sorting}&page=1&page_size=2&tz=UTC", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    first = response.json()
+    assert [t["title"] for t in first["items"]] == ["first", "second"]
+    assert first["total_count"] == 4
+    assert first["has_next"] is True
+
+    response = await client.get(
+        f"/api/v1/me/tasks?sorting={sorting}&page=2&page_size=2&tz=UTC", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    second = response.json()
+    assert [t["title"] for t in second["items"]] == ["third", "fourth"]
+    assert second["total_count"] == 4
+    assert second["has_next"] is False
+
+    # The hydrated rows carry everything the list shape promises, including the
+    # relationship-backed fields the second pass is responsible for loading.
+    row = second["items"][0]
+    assert row["project_id"] == project2.id
+    assert row["task_status"]["id"] is not None
+    assert row["guild_name"] == "Guild 2"
+
+
+@pytest.mark.integration
+async def test_list_my_tasks_page_from_one_guild_only(
+    client: AsyncClient, session: AsyncSession
+):
+    """Guilds off the requested page are skipped, and still counted.
+
+    The hydration pass visits only the guilds holding ids on this page. A guild
+    whose tasks all sort onto a later page must contribute to ``total_count``
+    without appearing in ``items``.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+
+    user = await create_user(session, email="user@example.com")
+    _guild1, _, project1 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 1"
+    )
+    _guild2, _, project2 = await _setup_guild_with_project(
+        session, user, guild_name="Guild 2"
+    )
+
+    for title, days in (("g1 soon", 1), ("g1 next", 2)):
+        task = await _create_task(
+            session,
+            project1,
+            title,
+            created_by=user.id,
+            due_date=now + timedelta(days=days),
+        )
+        await _assign(session, task, user.id)
+    for title, days in (("g2 late", 30), ("g2 latest", 60)):
+        task = await _create_task(
+            session,
+            project2,
+            title,
+            created_by=user.id,
+            due_date=now + timedelta(days=days),
+        )
+        await _assign(session, task, user.id)
+
+    headers = get_auth_headers(user)
+    sorting = json.dumps([{"field": "due_date", "dir": "asc"}])
+    response = await client.get(
+        f"/api/v1/me/tasks?sorting={sorting}&page=1&page_size=2&tz=UTC", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert [t["title"] for t in data["items"]] == ["g1 soon", "g1 next"]
+    assert {t["guild_name"] for t in data["items"]} == {"Guild 1"}
+    assert data["total_count"] == 4
+    assert data["has_next"] is True
+
+
+@pytest.mark.integration
 async def test_list_my_tasks_date_group_sorted_across_guilds(
     client: AsyncClient, session: AsyncSession
 ):

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from operator import attrgetter
-from typing import Annotated, List, Optional, Sequence
+from typing import Annotated, Any, List, Optional, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
 
 from sqlalchemy import and_, func, or_
@@ -128,7 +128,7 @@ TASK_DEFAULT_SORT = [(Task.position, "asc"), (Task.id, "asc")]
 # Attribute sorters for the cross-guild merge. attrgetter is faster than a
 # lambda and avoids per-row closure overhead on large result sets. ``priority``
 # and ``date_group`` need custom handling (enum order / SQL-carried value) and
-# are resolved separately in _sort_global_task_reads.
+# are resolved separately in _sort_global_task_keys.
 _GLOBAL_SORT_ATTRGETTERS = {
     "position": attrgetter("position"),
     "title": attrgetter("title"),
@@ -144,45 +144,70 @@ _GLOBAL_SORT_ATTRGETTERS = {
 _PRIORITY_SORT_ORDER = {p: i for i, p in enumerate(TaskPriority)}
 
 
-def _sort_global_task_reads(
-    items: list[tuple[TaskListRead, int]],
+def _global_ordering_selectables(tz: str | None = None):
+    """The columns the cross-guild ordering pass selects.
+
+    Every sort key the /me task views accept is a plain ``tasks`` column (plus
+    the SQL-computed ``date_group``), so the whole matching set can be ordered
+    from rows this narrow — no relationships, no annotations. Labelled with the
+    sort field names so :func:`_sort_global_task_keys` reads a row by the name
+    the caller sorted on.
+    """
+    return (
+        Task.id.label("id"),
+        _date_group_expression(tz).label("date_group"),
+        Task.position.label("position"),
+        Task.title.label("title"),
+        Task.due_date.label("due_date"),
+        Task.start_date.label("start_date"),
+        Task.created_at.label("created_at"),
+        Task.updated_at.label("updated_at"),
+        Task.priority.label("priority"),
+    )
+
+
+def _sort_global_task_keys(
+    items: list[tuple[int, Any]],
     sort_fields: list | None,
-) -> list[TaskListRead]:
-    """Order the merged cross-guild rows and drop the carried date_group.
+) -> list[tuple[int, Any]]:
+    """Order the merged cross-guild ordering rows.
 
     Cross-schema results can't be ordered by a single SQL query, so this is the
     *only* sort for the /me task views (the per-guild queries deliberately skip
-    ORDER BY). ``items`` are ``(TaskListRead, date_group)`` pairs where the
-    date_group was computed in SQL — the same :func:`_date_group_expression`
-    used by the guild-scoped endpoint, so there is one source of truth.
+    ORDER BY). ``items`` are ``(guild_id, row)`` pairs where ``row`` is a
+    :func:`_global_ordering_selectables` row — the guild id travels alongside
+    because task ids are unique per schema, not across them.
 
     Matches the guild-scoped list's ordering conventions: NULLs sort last
     regardless of direction, and ``id`` ascending breaks ties.
     """
-    reads = [read for read, _ in items]
+    rows = list(items)
     if not sort_fields:
         # Deterministic default when the caller doesn't sort. position is
         # per-guild so it can't truly order across guilds, but the id tiebreaker
         # keeps the merge stable; mirrors the SQL endpoint's position-then-id.
-        reads.sort(key=attrgetter("position", "id"))
-        return reads
-
-    date_groups = {id(read): group for read, group in items}
+        rows.sort(key=lambda pair: (pair[1].position, pair[1].id))
+        return rows
 
     def _getter(field):
         if field == "date_group":
-            return lambda r: date_groups[id(r)]
+            return lambda pair: pair[1].date_group
         if field == "priority":
             # None priority → None so the nulls-last partition applies it in
             # both directions (mirrors apply_sorting()'s nulls_last()).
-            return lambda r: (
-                _PRIORITY_SORT_ORDER.get(r.priority) if r.priority is not None else None
+            return lambda pair: (
+                _PRIORITY_SORT_ORDER.get(pair[1].priority)
+                if pair[1].priority is not None
+                else None
             )
-        return _GLOBAL_SORT_ATTRGETTERS.get(field)
+        base = _GLOBAL_SORT_ATTRGETTERS.get(field)
+        if base is None:
+            return None
+        return lambda pair: base(pair[1])
 
     # Stable radix sort: apply the least-significant key first. ``id`` asc is the
     # final tiebreaker, so it sorts first here.
-    reads.sort(key=attrgetter("id"))
+    rows.sort(key=lambda pair: pair[1].id)
     for sf in reversed(sort_fields):
         getter = _getter(sf.field)
         if getter is None:
@@ -190,11 +215,11 @@ def _sort_global_task_reads(
             # absent from allowed_fields.
             continue
         reverse = sf.dir == SortDir.desc
-        non_null = [r for r in reads if getter(r) is not None]
-        nulls = [r for r in reads if getter(r) is None]
+        non_null = [r for r in rows if getter(r) is not None]
+        nulls = [r for r in rows if getter(r) is None]
         non_null.sort(key=getter, reverse=reverse)
-        reads = non_null + nulls
-    return reads
+        rows = non_null + nulls
+    return rows
 
 
 def _build_task_filter_fields(
@@ -302,25 +327,50 @@ async def _rebalance_if_needed(
     return changed
 
 
-async def _annotate_tasks(session: SessionDep, tasks: list[Task]) -> None:
+def _comment_count_expression():
+    """A task's comment count, as a column on the row that carries the task.
+
+    For a read that is bounded by round trips rather than by rows — the
+    cross-guild lists pay per guild they touch — the count travels with the
+    task instead of costing a query of its own. Correlated on ``Task``, so it
+    resolves against whichever ``tasks`` the caller's search_path names.
+    """
+    return (
+        select(func.count(Comment.id))
+        .where(Comment.task_id == Task.id)
+        .correlate(Task)
+        .scalar_subquery()
+        .label("comment_count")
+    )
+
+
+async def _annotate_tasks(
+    session: SessionDep,
+    tasks: list[Task],
+    *,
+    comment_counts: dict[int, int] | None = None,
+) -> None:
     """Annotate tasks with comment counts and checklist progress.
 
     Checklist progress is read from the column the row already carries, so only
-    the comment count needs a query.
+    the comment count needs a query — and ``comment_counts`` skips even that,
+    for a caller that selected the counts alongside the rows
+    (:func:`_comment_count_expression`).
     """
     task_ids = [task.id for task in tasks if task.id is not None]
     if not task_ids:
         return
 
-    ids_tuple = tuple(task_ids)
+    if comment_counts is None:
+        ids_tuple = tuple(task_ids)
 
-    stmt = (
-        select(Comment.task_id, func.count(Comment.id))
-        .where(Comment.task_id.in_(ids_tuple))
-        .group_by(Comment.task_id)
-    )
-    result = await session.exec(stmt)
-    comment_counts: dict[int, int] = {row[0]: row[1] for row in result.all()}
+        stmt = (
+            select(Comment.task_id, func.count(Comment.id))
+            .where(Comment.task_id.in_(ids_tuple))
+            .group_by(Comment.task_id)
+        )
+        result = await session.exec(stmt)
+        comment_counts = {row[0]: row[1] for row in result.all()}
 
     for task in tasks:
         object.__setattr__(task, "comment_count", comment_counts.get(task.id, 0))
@@ -794,10 +844,18 @@ async def _allowed_project_ids(
 
 
 def _global_task_options():
+    """Loaders for the hydration pass of a cross-guild task list.
+
+    project → initiative → guild is a chain of many-to-one links, so it is
+    joined onto the row rather than fetched with a query per level: a
+    ``selectinload`` there cost three extra round trips per guild the page draws
+    from, and this endpoint is bounded by round trips. The collections stay on
+    ``selectinload``, which is what it is for.
+    """
     return (
-        selectinload(Task.project)
-        .selectinload(Project.initiative)
-        .selectinload(Initiative.guild),
+        joinedload(Task.project)
+        .joinedload(Project.initiative)
+        .joinedload(Initiative.guild),
         selectinload(Task.assignees),
         selectinload(Task.task_status),
         selectinload(Task.property_values).selectinload(
@@ -816,44 +874,95 @@ async def _gather_global_task_reads(
     page: int,
     page_size: int,
     sort_fields: list | None = None,
+    tz: str | None = None,
 ) -> tuple[list[TaskListRead], int, int]:
     """Run a per-guild task query across every guild the user belongs to and
     merge into TaskListReads.
 
-    A single SQL query can't order across guild schemas, so ``build_query`` emits
-    ``(Task, date_group)`` rows *without* ORDER BY and the merged set is sorted
-    once, globally, by :func:`_sort_global_task_reads` before pagination.
-    Annotation + conversion happen inside each guild's routed context.
+    Two passes, because a single SQL query can't order across guild schemas and
+    the ordering has to see the whole matching set before anything can be paged:
 
-    ``build_query`` receives the guild id so it can compile the guild-local
-    filter fields (tag/property subqueries resolve against that guild's schema).
+    1. **Order.** Each guild returns :func:`_global_ordering_selectables` rows —
+       the sort keys and the id, nothing else — *without* ORDER BY, and the
+       merged set is sorted once, globally, by :func:`_sort_global_task_keys`
+       and then sliced to the requested page.
+    2. **Hydrate.** Only the ids on that page are loaded with their
+       relationships and annotations, and only from the guilds that actually
+       contribute to it.
+
+    The split is what keeps the cost of this endpoint proportional to the page
+    rather than to everything the filter matches: a reader with hundreds of
+    assigned tasks across half a dozen guilds used to pay the relationship
+    loads, comment counts, tag and property annotation for every one of them to
+    show twenty.
+
+    ``build_query(guild_id, *selectables)`` receives the guild id so it can
+    compile the guild-local filter fields (tag/property subqueries resolve
+    against that guild's schema), and what to select so both passes share one
+    definition of the filtered set.
     """
     target_guilds = await member_guild_ids(
         session, current_user.id, restrict_to=guild_ids
     )
 
-    async def _fetch(
-        guild_session: AsyncSession, _guild_id: int
-    ) -> list[tuple[TaskListRead, int]]:
-        rows = list((await guild_session.exec(build_query(_guild_id))).all())
-        tasks = [row[0] for row in rows]
-        await _annotate_tasks(guild_session, tasks)
-        await tags_service.annotate_tags(guild_session, tasks)
-        _annotate_task_properties(tasks)
-        # row[1] is the SQL-computed date_group, carried for the global sort.
-        return [(_task_to_list_read(task), row[1]) for task, row in zip(tasks, rows)]
+    ordering = _global_ordering_selectables(tz)
 
-    items = await gather_across_guilds(session, current_user.id, target_guilds, _fetch)
+    async def _order_keys(
+        guild_session: AsyncSession, _guild_id: int
+    ) -> list[tuple[int, Any]]:
+        rows = (await guild_session.exec(build_query(_guild_id, *ordering))).all()
+        return [(_guild_id, row) for row in rows]
+
+    keys = await gather_across_guilds(
+        session, current_user.id, target_guilds, _order_keys
+    )
     # Sort across ALL guilds before slicing — the per-guild queries return rows
     # unordered, so this is where global ordering is established.
-    items = _sort_global_task_reads(items, sort_fields)
-    total_count = len(items)
+    keys = _sort_global_task_keys(keys, sort_fields)
+    total_count = len(keys)
     actual_page = clamp_page(page, page_size, total_count)
     # One slicing rule for every page_size, including the windowed
     # page_size<=0 "fetch all" protocol (bounded response, nothing
     # unreachable — the caller walks pages until has_next is false).
-    items = paginate_sequence(items, actual_page, page_size)
-    return items, total_count, actual_page
+    window = paginate_sequence(keys, actual_page, page_size)
+    if not window:
+        return [], total_count, actual_page
+
+    # (guild, task) -> where it sits on the page, so the hydrated rows come back
+    # in the order the global sort established rather than in guild order.
+    placement: dict[tuple[int, int], int] = {}
+    wanted: dict[int, list[int]] = {}
+    for index, (guild_id, row) in enumerate(window):
+        wanted.setdefault(guild_id, []).append(row.id)
+        placement[(guild_id, row.id)] = index
+
+    async def _hydrate(
+        guild_session: AsyncSession, _guild_id: int
+    ) -> list[tuple[int, TaskListRead]]:
+        ids = wanted.get(_guild_id)
+        if not ids:
+            return []
+        statement = (
+            build_query(_guild_id, Task, _comment_count_expression())
+            .where(Task.id.in_(tuple(ids)))
+            .options(*_global_task_options())
+        )
+        rows = list((await guild_session.exec(statement)).unique().all())
+        tasks = [row[0] for row in rows]
+        comment_counts = {row[0].id: row[1] for row in rows}
+        await _annotate_tasks(guild_session, tasks, comment_counts=comment_counts)
+        await tags_service.annotate_tags(guild_session, tasks)
+        _annotate_task_properties(tasks)
+        return [
+            (placement[(_guild_id, task.id)], _task_to_list_read(task))
+            for task in tasks
+        ]
+
+    hydrated = await gather_across_guilds(
+        session, current_user.id, sorted(wanted), _hydrate
+    )
+    hydrated.sort(key=lambda pair: pair[0])
+    return [read for _, read in hydrated], total_count, actual_page
 
 
 async def _list_global_tasks(
@@ -892,16 +1001,17 @@ async def _list_global_tasks(
     if window is not None:
         base_conditions.append(window)
 
-    def _build(guild_id: int):
-        # Carry the SQL-computed date_group out for the cross-guild sort; ORDER
-        # BY is omitted because _sort_global_task_reads orders the merged set.
+    def _build(guild_id: int, *selectables):
+        # One definition of the filtered set, selected two ways: the ordering
+        # pass asks for the sort keys, the hydration pass for the Task itself.
+        # ORDER BY is omitted either way — _sort_global_task_keys orders the
+        # merged set, which no single schema's query can do.
         stmt = (
-            select(Task, _date_group_expression(tz).label("date_group"))
+            select(*selectables)
             .join(TaskAssignee, TaskAssignee.task_id == Task.id)
             .join(Task.project)
             .join(Project.initiative)
             .where(*base_conditions)
-            .options(*_global_task_options())
         )
         return apply_filters(
             stmt,
@@ -923,6 +1033,7 @@ async def _list_global_tasks(
         page=page,
         page_size=page_size,
         sort_fields=sort_fields,
+        tz=tz,
     )
 
 
@@ -952,15 +1063,16 @@ async def _list_global_created_tasks(
     if not include_archived:
         base_conditions.append(Task.archived_at.is_(None))
 
-    def _build(guild_id: int):
-        # Carry the SQL-computed date_group out for the cross-guild sort; ORDER
-        # BY is omitted because _sort_global_task_reads orders the merged set.
+    def _build(guild_id: int, *selectables):
+        # One definition of the filtered set, selected two ways: the ordering
+        # pass asks for the sort keys, the hydration pass for the Task itself.
+        # ORDER BY is omitted either way — _sort_global_task_keys orders the
+        # merged set, which no single schema's query can do.
         stmt = (
-            select(Task, _date_group_expression(tz).label("date_group"))
+            select(*selectables)
             .join(Task.project)
             .join(Project.initiative)
             .where(*base_conditions)
-            .options(*_global_task_options())
         )
         return apply_filters(
             stmt,
@@ -982,6 +1094,7 @@ async def _list_global_created_tasks(
         page=page,
         page_size=page_size,
         sort_fields=sort_fields,
+        tz=tz,
     )
 
 

--- a/backend/app/api/v1/tenant_endpoints/tasks.py
+++ b/backend/app/api/v1/tenant_endpoints/tasks.py
@@ -888,7 +888,8 @@ async def _gather_global_task_reads(
        and then sliced to the requested page.
     2. **Hydrate.** Only the ids on that page are loaded with their
        relationships and annotations, and only from the guilds that actually
-       contribute to it.
+       contribute to it. By id alone: the filters are not re-applied, so a
+       concurrent edit cannot drop a row the ordering pass already counted.
 
     The split is what keeps the cost of this endpoint proportional to the page
     rather than to everything the filter matches: a reader with hundreds of
@@ -898,8 +899,7 @@ async def _gather_global_task_reads(
 
     ``build_query(guild_id, *selectables)`` receives the guild id so it can
     compile the guild-local filter fields (tag/property subqueries resolve
-    against that guild's schema), and what to select so both passes share one
-    definition of the filtered set.
+    against that guild's schema), and what to select.
     """
     target_guilds = await member_guild_ids(
         session, current_user.id, restrict_to=guild_ids
@@ -942,8 +942,17 @@ async def _gather_global_task_reads(
         ids = wanted.get(_guild_id)
         if not ids:
             return []
+        # By id ALONE — deliberately not through ``build_query``. Re-applying
+        # the filters here would let a concurrent edit drop a row the ordering
+        # pass already counted: a task that goes done, gets reassigned or is
+        # archived between the two statements would stop matching, and the page
+        # would come back a row short of the ``total_count`` and ``has_next``
+        # computed from the first pass. Access does not rest on those filters —
+        # it rests on the guild schema this session is routed into and on
+        # ``initiative_access``, and both apply to this statement exactly as
+        # they did to the one that chose the ids a moment ago.
         statement = (
-            build_query(_guild_id, Task, _comment_count_expression())
+            select(Task, _comment_count_expression())
             .where(Task.id.in_(tuple(ids)))
             .options(*_global_task_options())
         )
@@ -1002,10 +1011,9 @@ async def _list_global_tasks(
         base_conditions.append(window)
 
     def _build(guild_id: int, *selectables):
-        # One definition of the filtered set, selected two ways: the ordering
-        # pass asks for the sort keys, the hydration pass for the Task itself.
-        # ORDER BY is omitted either way — _sort_global_task_keys orders the
-        # merged set, which no single schema's query can do.
+        # Defines the filtered set for the ordering pass, which selects the
+        # sort keys from it. ORDER BY is omitted — _sort_global_task_keys orders
+        # the merged set, which no single schema's query can do.
         stmt = (
             select(*selectables)
             .join(TaskAssignee, TaskAssignee.task_id == Task.id)
@@ -1064,10 +1072,9 @@ async def _list_global_created_tasks(
         base_conditions.append(Task.archived_at.is_(None))
 
     def _build(guild_id: int, *selectables):
-        # One definition of the filtered set, selected two ways: the ordering
-        # pass asks for the sort keys, the hydration pass for the Task itself.
-        # ORDER BY is omitted either way — _sort_global_task_keys orders the
-        # merged set, which no single schema's query can do.
+        # Defines the filtered set for the ordering pass, which selects the
+        # sort keys from it. ORDER BY is omitted — _sort_global_task_keys orders
+        # the merged set, which no single schema's query can do.
         stmt = (
             select(*selectables)
             .join(Task.project)

--- a/backend/app/services/cross_guild.py
+++ b/backend/app/services/cross_guild.py
@@ -25,6 +25,10 @@ from app.models.platform.user import User, UserStatus
 
 T = TypeVar("T")
 
+#: Where this session remembers each guild's "Full access" initiative ids. On
+#: ``session.info``, so its lifetime is the session's — i.e. the request's.
+_OVERRIDES_CACHE_KEY = "cross_guild_sharing_overrides"
+
 
 async def member_guild_ids(
     session: AsyncSession,
@@ -127,6 +131,12 @@ async def gather_across_guilds(
         for gid, role, status, shows_names, _caller in role_rows
     }
 
+    # Keyed by guild within this session, which is this request. A second pass
+    # over the same guild reuses the answer rather than asking again.
+    overrides_cache: dict[int, frozenset[int]] = session.info.setdefault(
+        _OVERRIDES_CACHE_KEY, {}
+    )
+
     results: list[T] = []
     try:
         for guild_id in guild_ids:
@@ -173,12 +183,21 @@ async def gather_across_guilds(
             set_active_role(guild_id, role_value)
             # And the per-initiative "Full access" override for this guild, so a
             # full-access PM's restricted content surfaces in cross-guild views too.
-            from app.services import rls as rls_service
+            # Remembered for the session: one request can visit the same guild
+            # more than once (a list that orders across guilds and then loads
+            # only the page's rows does), and the answer — this user's
+            # full-access roles in this schema — cannot change in between.
+            override_ids = overrides_cache.get(guild_id)
+            if override_ids is None:
+                from app.services import rls as rls_service
 
-            override_ids = await rls_service.override_sharing_initiative_ids(
-                session, user_id=user_id
-            )
-            set_override_sharing_initiatives(frozenset(override_ids))
+                override_ids = frozenset(
+                    await rls_service.override_sharing_initiative_ids(
+                        session, user_id=user_id
+                    )
+                )
+                overrides_cache[guild_id] = override_ids
+            set_override_sharing_initiatives(override_ids)
             results.extend(await fetch(session, guild_id))
     finally:
         # Don't let the last guild's role/override/read-only set linger in the

--- a/backend/app/services/cross_guild.py
+++ b/backend/app/services/cross_guild.py
@@ -25,8 +25,11 @@ from app.models.platform.user import User, UserStatus
 
 T = TypeVar("T")
 
-#: Where this session remembers each guild's "Full access" initiative ids. On
-#: ``session.info``, so its lifetime is the session's — i.e. the request's.
+#: Where this session remembers each (user, guild)'s "Full access" initiative
+#: ids. On ``session.info``, so its lifetime is the session's — i.e. the
+#: request's. Keyed by user as well as guild because this function takes the
+#: user as an argument: one session may legitimately gather for more than one
+#: of them, and a guild-only key would hand the second the first's overrides.
 _OVERRIDES_CACHE_KEY = "cross_guild_sharing_overrides"
 
 
@@ -131,9 +134,9 @@ async def gather_across_guilds(
         for gid, role, status, shows_names, _caller in role_rows
     }
 
-    # Keyed by guild within this session, which is this request. A second pass
-    # over the same guild reuses the answer rather than asking again.
-    overrides_cache: dict[int, frozenset[int]] = session.info.setdefault(
+    # Keyed by (user, guild) within this session, which is this request. A
+    # second pass over the same guild reuses the answer rather than asking again.
+    overrides_cache: dict[tuple[int, int], frozenset[int]] = session.info.setdefault(
         _OVERRIDES_CACHE_KEY, {}
     )
 
@@ -187,7 +190,8 @@ async def gather_across_guilds(
             # more than once (a list that orders across guilds and then loads
             # only the page's rows does), and the answer — this user's
             # full-access roles in this schema — cannot change in between.
-            override_ids = overrides_cache.get(guild_id)
+            cache_key = (user_id, guild_id)
+            override_ids = overrides_cache.get(cache_key)
             if override_ids is None:
                 from app.services import rls as rls_service
 
@@ -196,7 +200,7 @@ async def gather_across_guilds(
                         session, user_id=user_id
                     )
                 )
-                overrides_cache[guild_id] = override_ids
+                overrides_cache[cache_key] = override_ids
             set_override_sharing_initiatives(override_ids)
             results.extend(await fetch(session, guild_id))
     finally:

--- a/frontend/src/components/tasks/FocusSummary.test.tsx
+++ b/frontend/src/components/tasks/FocusSummary.test.tsx
@@ -64,7 +64,7 @@ function renderFocus(prefs: Partial<FocusPreferences> = {}, stored?: unknown) {
         focus={focus}
         activeGuildId={1}
         changeTaskStatus={changeTaskStatus}
-        isUpdatingTaskStatus={false}
+        isUpdatingTask={() => false}
       />
     );
   };

--- a/frontend/src/components/tasks/FocusSummary.tsx
+++ b/frontend/src/components/tasks/FocusSummary.tsx
@@ -27,7 +27,9 @@ export type FocusSummaryProps = {
   activeGuildId: number | null;
   /** Reused from the page's table so status resolution has one implementation. */
   changeTaskStatus: (task: TaskListRead, category: TaskStatusCategory) => Promise<void>;
-  isUpdatingTaskStatus: boolean;
+  /** Whether THIS task has a status change in flight, so one row saving leaves
+   *  the rest of the section usable. */
+  isUpdatingTask: (task: TaskListRead) => boolean;
 };
 
 const taskHref = (task: TaskListRead, activeGuildId: number | null) => {
@@ -175,7 +177,7 @@ export const FocusSummary = ({
   focus,
   activeGuildId,
   changeTaskStatus,
-  isUpdatingTaskStatus,
+  isUpdatingTask,
 }: FocusSummaryProps) => {
   const { t } = useTranslation(["tasks", "common"]);
   const { pinned, upcoming, completedToday, truncated, doneCount, totalCount, prefs } = focus;
@@ -191,7 +193,7 @@ export const FocusSummary = ({
       isPinned={focus.isPinned(task)}
       onTogglePin={() => focus.togglePin(task)}
       onToggleDone={() => void changeTaskStatus(task, done ? "in_progress" : "done")}
-      disabled={isUpdatingTaskStatus}
+      disabled={isUpdatingTask(task)}
       done={done}
     />
   );

--- a/frontend/src/components/tasks/TaskForm.tsx
+++ b/frontend/src/components/tasks/TaskForm.tsx
@@ -367,7 +367,7 @@ export const TaskForm = ({
         autoFocus={autoFocusTitle}
         className={
           layout === "page"
-            ? "h-auto border-0 px-0 font-semibold text-3xl tracking-tight shadow-none focus-visible:ring-0 md:text-3xl"
+            ? "h-auto border-0 px-0 font-semibold text-lg tracking-tight shadow-none focus-visible:ring-0 md:text-xl"
             : undefined
         }
       />

--- a/frontend/src/components/tasks/globalTaskColumns.tsx
+++ b/frontend/src/components/tasks/globalTaskColumns.tsx
@@ -27,7 +27,9 @@ import type { TranslateFn } from "@/types/i18n";
 
 interface GlobalTaskColumnsOptions {
   activeGuildId: number | null;
-  isUpdatingTaskStatus: boolean;
+  /** Whether THIS row has a status change in flight — one row saving must not
+   *  disable the rest of the table. */
+  isUpdatingTask: (task: TaskListRead) => boolean;
   changeTaskStatus: (task: TaskListRead, category: TaskStatusCategory) => Promise<void>;
   changeTaskStatusById: (task: TaskListRead, statusId: number) => Promise<void>;
   fetchProjectStatuses: (projectId: number, guildId: number | null) => Promise<TaskStatusRead[]>;
@@ -45,7 +47,7 @@ interface GlobalTaskColumnsOptions {
 
 export function globalTaskColumns({
   activeGuildId,
-  isUpdatingTaskStatus,
+  isUpdatingTask,
   changeTaskStatus,
   changeTaskStatusById,
   fetchProjectStatuses,
@@ -114,14 +116,14 @@ export function globalTaskColumns({
           <Checkbox
             checked={task.task_status.category === "done"}
             onCheckedChange={(value) => {
-              if (isUpdatingTaskStatus) {
+              if (isUpdatingTask(task)) {
                 return;
               }
               const targetCategory: TaskStatusCategory = value ? "done" : "in_progress";
               void changeTaskStatus(task, targetCategory);
             }}
             className="h-6 w-6"
-            disabled={isUpdatingTaskStatus}
+            disabled={isUpdatingTask(task)}
             aria-label={
               task.task_status.category === "done"
                 ? t("checkbox.markInProgress")
@@ -332,7 +334,7 @@ export function globalTaskColumns({
           <TaskPrioritySelector
             task={task}
             guildId={task.guild_id ?? activeGuildId}
-            disabled={isUpdatingTaskStatus}
+            disabled={isUpdatingTask(task)}
           />
         );
       },
@@ -375,7 +377,7 @@ export function globalTaskColumns({
             <TaskStatusSelector
               task={task}
               activeGuildId={activeGuildId}
-              isUpdatingTaskStatus={isUpdatingTaskStatus}
+              isUpdatingTaskStatus={isUpdatingTask(task)}
               changeTaskStatusById={changeTaskStatusById}
               fetchProjectStatuses={fetchProjectStatuses}
               projectStatusCache={projectStatusCache}

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -40,6 +40,7 @@ import {
 import { queryClient } from "@/lib/queryClient";
 import { getItem, removeItem, setItem } from "@/lib/storage";
 import { clearUploadToken } from "@/lib/uploadToken";
+import { prefetchViewPreferences } from "@/lib/viewPreferences";
 
 interface LoginPayload {
   email: string;
@@ -150,6 +151,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setUserState(nextUser);
       setHasActiveSession(nextUser !== null);
       rememberIdentity(nextUser);
+      // The first screen's list query waits on the saved filters and sort, so
+      // ask for them from here rather than from the screen: knowing who is
+      // signed in is the only prerequisite, and this is where that happens.
+      if (nextUser) prefetchViewPreferences();
     },
     [rememberIdentity]
   );
@@ -168,6 +173,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       );
       setHasActiveSession(true);
       rememberIdentity(nextUser);
+      // Signing in lands here rather than in setUser; the map is still fresh
+      // from any earlier call, so a re-read costs nothing.
+      prefetchViewPreferences();
     },
     [rememberIdentity]
   );

--- a/frontend/src/hooks/useGlobalTasksTable.ts
+++ b/frontend/src/hooks/useGlobalTasksTable.ts
@@ -76,6 +76,18 @@ const sanitizeStoredPrefs = (raw: unknown): StoredPrefs => {
 
 const PAGE_SIZE = 20;
 
+/**
+ * Prefix shared by every `/me/tasks` cache entry — the table's page, the focus
+ * summary's rule and pin queries. A status change patches all of them at once,
+ * so the row it touched updates wherever it is on screen without waiting for
+ * three cross-guild aggregates to come back.
+ */
+const MY_TASKS_QUERY_PREFIX = getListMyTasksApiV1MeTasksGetQueryKey();
+
+/** Task ids repeat across guilds, so an in-flight row is addressed by both. */
+const taskKey = (task: Pick<TaskListRead, "id" | "guild_id">) =>
+  `${task.guild_id ?? "none"}:${task.id}`;
+
 /** Map DataTable column IDs to backend sort field names */
 const SORT_FIELD_MAP: Record<string, string> = {
   title: "title",
@@ -293,15 +305,68 @@ export function useGlobalTasksTable() {
   );
 
   // --- Status mutation ---
-  const { mutateAsync: updateTaskStatusMutate, isPending: isUpdatingTaskStatus } =
-    useUpdateTaskInGuild({
-      onSuccess: (updatedTask) => {
-        const cached = projectStatusCache.current.get(updatedTask.project_id);
-        if (cached && !cached.statuses.some((status) => status.id === updatedTask.task_status.id)) {
-          cached.statuses.push(updatedTask.task_status);
+  const { mutateAsync: updateTaskStatusMutate } = useUpdateTaskInGuild({
+    onSuccess: (updatedTask) => {
+      const cached = projectStatusCache.current.get(updatedTask.project_id);
+      if (cached && !cached.statuses.some((status) => status.id === updatedTask.task_status.id)) {
+        cached.statuses.push(updatedTask.task_status);
+      }
+    },
+  });
+
+  // Which rows have a status change in flight. Per task rather than one flag for
+  // the mutation, because the shared `isPending` disabled every row on the page
+  // — and the focus summary's rows with them — while a single checkbox was
+  // saving.
+  const [updatingTasks, setUpdatingTasks] = useState<ReadonlySet<string>>(() => new Set());
+  const isUpdatingTask = useCallback(
+    (task: Pick<TaskListRead, "id" | "guild_id">) => updatingTasks.has(taskKey(task)),
+    [updatingTasks]
+  );
+
+  /**
+   * Rewrite one row's status in every `/me/tasks` page the cache holds.
+   *
+   * Only that row is touched — not a snapshot of the whole page — so two rows
+   * changed at once don't undo each other when one of them fails.
+   */
+  const writeStatusToCache = useCallback(
+    (task: Pick<TaskListRead, "id" | "guild_id">, status: TaskStatusRead) => {
+      const key = taskKey(task);
+      localQueryClient.setQueriesData<TaskListResponse>(
+        { queryKey: MY_TASKS_QUERY_PREFIX },
+        (old) => {
+          if (!old?.items?.some((item) => taskKey(item) === key)) return old;
+          return {
+            ...old,
+            items: old.items.map((item) =>
+              taskKey(item) === key
+                ? { ...item, task_status_id: status.id, task_status: status }
+                : item
+            ),
+          };
         }
-      },
-    });
+      );
+    },
+    [localQueryClient]
+  );
+
+  /**
+   * Show the new status now, and hand back the undo.
+   *
+   * The check lands the moment it is clicked instead of after the refetch the
+   * mutation's invalidation kicks off. A task that has just moved out of the
+   * filtered set stays put until that refetch drops it, which reads as
+   * completing work rather than as the row vanishing mid-click.
+   */
+  const applyStatusLocally = useCallback(
+    (task: TaskListRead, status: TaskStatusRead) => {
+      const previous = task.task_status;
+      writeStatusToCache(task, status);
+      return () => writeStatusToCache(task, previous);
+    },
+    [writeStatusToCache]
+  );
 
   // --- Task items + status cache hydration ---
   const tasks = useMemo(() => tasksQuery.data?.items ?? [], [tasksQuery.data]);
@@ -369,6 +434,15 @@ export function useGlobalTasksTable() {
         toast.error(t("errors.guildContext"));
         return;
       }
+      // The status the row is moving to is already in hand whenever the caller
+      // resolved it through this project's statuses, which is every path that
+      // reaches here; without it the row simply waits for the refetch.
+      const target = projectStatusCache.current
+        .get(task.project_id)
+        ?.statuses.find((status) => status.id === targetStatusId);
+      const rollback = target ? applyStatusLocally(task, target) : null;
+      const key = taskKey(task);
+      setUpdatingTasks((prev) => new Set(prev).add(key));
       try {
         await updateTaskStatusMutate({
           taskId: task.id,
@@ -378,11 +452,18 @@ export function useGlobalTasksTable() {
           guildId: targetGuildId,
         });
       } catch (error) {
+        rollback?.();
         console.error(error);
         toast.error(getErrorMessage(error, "tasks:errors.statusUpdate"));
+      } finally {
+        setUpdatingTasks((prev) => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
       }
     },
-    [activeGuildId, updateTaskStatusMutate, t]
+    [activeGuildId, applyStatusLocally, updateTaskStatusMutate, t]
   );
 
   const changeTaskStatus = useCallback(
@@ -463,7 +544,7 @@ export function useGlobalTasksTable() {
     fetchProjectStatuses,
     resolveStatusIdForCategory,
     projectStatusCache,
-    isUpdatingTaskStatus,
+    isUpdatingTask,
 
     // Display data
     displayTasks,

--- a/frontend/src/hooks/useViewPreference.ts
+++ b/frontend/src/hooks/useViewPreference.ts
@@ -21,21 +21,19 @@ import { useCallback, useEffect } from "react";
 
 import type { UserViewPreferencesMap } from "@/api/generated/initiativeAPI.schemas";
 import {
-  getListViewPreferencesApiV1UserViewPreferencesGetQueryKey,
   listViewPreferencesApiV1UserViewPreferencesGet,
   putViewPreferenceApiV1UserViewPreferencesScopeKeyPut,
 } from "@/api/generated/user-view-preferences/user-view-preferences";
 import { useAuth } from "@/hooks/useAuth";
+import { PREFERENCES_STALE_TIME_MS, VIEW_PREFERENCES_QUERY_KEY } from "@/lib/viewPreferences";
 
 /** Coalesce rapid edits into one PUT after the user pauses for this long. */
 const WRITE_DEBOUNCE_MS = 400;
 
-/**
- * The cache key for the full preferences map. Exported so the one-shot
- * localStorage migration can prime the cache before the query runs.
- */
-export const VIEW_PREFERENCES_QUERY_KEY =
-  getListViewPreferencesApiV1UserViewPreferencesGetQueryKey();
+// Re-exported so the many callers that read the map's cache key from this hook
+// keep working; it lives in lib/ because useAuth warms the map and cannot
+// import a module that imports useAuth back.
+export { VIEW_PREFERENCES_QUERY_KEY } from "@/lib/viewPreferences";
 
 /**
  * Module-level debounce map keyed by `scope_key`. Lifting this out of
@@ -79,7 +77,7 @@ export function useViewPreference<T>(
     // the source of truth in this client and write through, so a long
     // stale time is fine. Refetches on focus would clobber an optimistic
     // value if a PUT was still in flight.
-    staleTime: 5 * 60 * 1000,
+    staleTime: PREFERENCES_STALE_TIME_MS,
     refetchOnWindowFocus: false,
   });
 

--- a/frontend/src/lib/viewPreferences.ts
+++ b/frontend/src/lib/viewPreferences.ts
@@ -1,0 +1,51 @@
+/**
+ * The user's view-preference map, addressed outside React.
+ *
+ * The cache key and the eager fetch live here rather than in
+ * `@/hooks/useViewPreference` so that `useAuth` — which starts the fetch the
+ * moment it knows who is signed in — does not have to import a module that
+ * imports `useAuth` back.
+ */
+
+import type { UserViewPreferencesMap } from "@/api/generated/initiativeAPI.schemas";
+import {
+  getListViewPreferencesApiV1UserViewPreferencesGetQueryKey,
+  listViewPreferencesApiV1UserViewPreferencesGet,
+} from "@/api/generated/user-view-preferences/user-view-preferences";
+import { queryClient } from "@/lib/queryClient";
+
+/**
+ * The cache key for the full preferences map. Exported so the one-shot
+ * localStorage migration can prime the cache before the query runs.
+ */
+export const VIEW_PREFERENCES_QUERY_KEY =
+  getListViewPreferencesApiV1UserViewPreferencesGetQueryKey();
+
+/**
+ * Filter state changes rarely from the server's perspective; this client owns
+ * the source of truth and writes through, so a long stale time is fine.
+ */
+export const PREFERENCES_STALE_TIME_MS = 5 * 60 * 1000;
+
+/**
+ * Start the preference map fetch without waiting for a screen to ask for it.
+ *
+ * Consumers that gate a list query on their saved filters — My Tasks holds its
+ * table back until its sort is in hand, because the table seeds its headers at
+ * mount — otherwise turn this into a serial hop: authenticate, then fetch
+ * preferences, then fetch the list. Called as soon as the signed-in account is
+ * known, the map is already in flight (usually already answered) by the time
+ * the landing page mounts, and `useViewPreference`'s own query dedupes onto it.
+ *
+ * Errors are swallowed: nothing waits on this, and every consumer falls back to
+ * its defaults when the map cannot be read.
+ */
+export const prefetchViewPreferences = (): void => {
+  void queryClient
+    .prefetchQuery<UserViewPreferencesMap>({
+      queryKey: VIEW_PREFERENCES_QUERY_KEY,
+      queryFn: ({ signal }) => listViewPreferencesApiV1UserViewPreferencesGet(undefined, signal),
+      staleTime: PREFERENCES_STALE_TIME_MS,
+    })
+    .catch(() => {});
+};

--- a/frontend/src/pages/TaskEditPage.tsx
+++ b/frontend/src/pages/TaskEditPage.tsx
@@ -681,8 +681,17 @@ export const TaskEditPage = () => {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-6">
-        <Card className="flex-1 shadow-sm sm:min-w-100">
+      {/* Two columns once there is room for both at their full 25rem, one
+          otherwise. The track definition decides that from the CONTAINER's
+          width, so it holds wherever this page is mounted and at whatever
+          width the sidebar leaves — and `min(25rem,100%)` lets the single
+          column shrink below 25rem on a phone instead of overflowing, which is
+          what a bare min-width could not do. It replaces a flex row that wrapped
+          only because each half claimed a min-width above `sm`: between 468px
+          and 639px nothing claimed one, so the halves sat side by side at a
+          width neither was meant to be used at. */}
+      <div className="grid gap-6 [grid-template-columns:repeat(auto-fit,minmax(min(25rem,100%),1fr))]">
+        <Card className="shadow-sm">
           <CardContent className="pt-6">
             {isReadOnly && readOnlyMessage ? (
               <p className="rounded-md border border-border bg-muted/50 px-3 py-2 text-muted-foreground text-sm">
@@ -803,7 +812,7 @@ export const TaskEditPage = () => {
           </CardContent>
         </Card>
 
-        <div className="flex-1 space-y-4 sm:min-w-100">
+        <div className="space-y-4">
           <TaskChecklist
             taskId={parsedTaskId}
             items={task?.checklist ?? []}

--- a/frontend/src/pages/user/MyTasksPage.test.tsx
+++ b/frontend/src/pages/user/MyTasksPage.test.tsx
@@ -99,3 +99,119 @@ describe("MyTasksPage grouping", () => {
     await waitFor(() => expect(groupSelect()).toHaveTextContent(/none/i));
   });
 });
+
+describe("MyTasksPage status changes", () => {
+  /**
+   * One task per guild so the per-row rules are observable: checking either
+   * must not take the other away.
+   */
+  function stubTwoTasksAndStatuses({ patchDelayMs = 0 } = {}) {
+    const todo = {
+      id: 10,
+      project_id: 5,
+      name: "To Do",
+      category: "todo" as const,
+      position: 0,
+      is_default: true,
+    };
+    const done = {
+      id: 11,
+      project_id: 5,
+      name: "Done",
+      category: "done" as const,
+      position: 1,
+      is_default: false,
+    };
+    const items = [
+      buildTask({
+        id: 101,
+        title: "Write the thing",
+        guild_id: 3,
+        project_id: 5,
+        task_status_id: todo.id,
+        task_status: todo,
+      }),
+      buildTask({
+        id: 102,
+        title: "Read the thing",
+        guild_id: 3,
+        project_id: 5,
+        task_status_id: todo.id,
+        task_status: todo,
+      }),
+    ];
+    let patched = 0;
+    server.use(
+      // Only the table's page carries these rows. The focus summary reads the
+      // same endpoint with a page size of its own, and answering it too would
+      // put a second copy of every row on the screen.
+      http.get("/api/v1/me/tasks", ({ request }) => {
+        const forTable = new URL(request.url).searchParams.get("page_size") === "20";
+        return HttpResponse.json({
+          items: forTable ? items : [],
+          total_count: forTable ? items.length : 0,
+          page: 1,
+          page_size: 20,
+          has_next: false,
+        });
+      }),
+      http.get("/api/v1/g/:guildId/projects/:projectId/task-statuses", () =>
+        HttpResponse.json([todo, done])
+      ),
+      http.patch("/api/v1/g/:guildId/tasks/:taskId", async () => {
+        patched += 1;
+        if (patchDelayMs > 0) await delay(patchDelayMs);
+        return HttpResponse.json({
+          ...items[0],
+          task_status_id: done.id,
+          task_status: done,
+          assignees: [],
+        });
+      })
+    );
+    return { patchCount: () => patched };
+  }
+
+  /** The table's Done checkboxes, in row order. */
+  const doneBoxes = () =>
+    within(screen.getByRole("table")).getAllByRole("checkbox", {
+      name: /mark task as (done|in progress)/i,
+    });
+
+  /** A row title, looked for in the table rather than anywhere on the page. */
+  const rowTitle = (title: string) => within(screen.getByRole("table")).findByText(title);
+
+  it("shows the row checked before the server answers", async () => {
+    const user = userEvent.setup();
+    stubTwoTasksAndStatuses({ patchDelayMs: 1_000 });
+    renderMyTasks();
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    await rowTitle("Write the thing");
+    const [first] = doneBoxes();
+    expect(first).not.toBeChecked();
+
+    await user.click(first);
+
+    // The check lands on the optimistic write, with the PATCH still in flight
+    // and the cross-guild list not yet refetched.
+    await waitFor(() => expect(doneBoxes()[0]).toBeChecked());
+  });
+
+  it("leaves every other row usable while one is saving", async () => {
+    const user = userEvent.setup();
+    stubTwoTasksAndStatuses({ patchDelayMs: 1_000 });
+    renderMyTasks();
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    await rowTitle("Read the thing");
+    await user.click(doneBoxes()[0]);
+
+    // The row being saved is held so it can't be double-submitted; the other
+    // one — and the table around it — stays live. The old blocking overlay
+    // disabled the whole page for the length of the request.
+    await waitFor(() => expect(doneBoxes()[0]).toBeDisabled());
+    expect(doneBoxes()[1]).toBeEnabled();
+    await rowTitle("Read the thing");
+  });
+});

--- a/frontend/src/pages/user/MyTasksPage.test.tsx
+++ b/frontend/src/pages/user/MyTasksPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { delay, HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
-import { buildTask } from "@/__tests__/factories";
+import { buildProjectTaskStatus, buildTask } from "@/__tests__/factories";
 import { server } from "@/__tests__/helpers/msw-server";
 import { createTestQueryClient, renderPage } from "@/__tests__/helpers/render";
 import { VIEW_PREFERENCES_QUERY_KEY } from "@/hooks/useViewPreference";
@@ -106,22 +106,21 @@ describe("MyTasksPage status changes", () => {
    * must not take the other away.
    */
   function stubTwoTasksAndStatuses({ patchDelayMs = 0 } = {}) {
-    const todo = {
+    const todo = buildProjectTaskStatus({
       id: 10,
       project_id: 5,
       name: "To Do",
-      category: "todo" as const,
+      category: "todo",
       position: 0,
       is_default: true,
-    };
-    const done = {
+    });
+    const done = buildProjectTaskStatus({
       id: 11,
       project_id: 5,
       name: "Done",
-      category: "done" as const,
+      category: "done",
       position: 1,
-      is_default: false,
-    };
+    });
     const items = [
       buildTask({
         id: 101,

--- a/frontend/src/pages/user/MyTasksPage.tsx
+++ b/frontend/src/pages/user/MyTasksPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { CalendarDays, Loader2, Table2 } from "lucide-react";
+import { CalendarDays, Table2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -94,7 +94,7 @@ export const MyTasksPage = () => {
   const columns = useMemo(() => {
     const base = globalTaskColumns({
       activeGuildId: table.activeGuildId,
-      isUpdatingTaskStatus: table.isUpdatingTaskStatus,
+      isUpdatingTask: table.isUpdatingTask,
       changeTaskStatus: table.changeTaskStatus,
       changeTaskStatusById: table.changeTaskStatusById,
       fetchProjectStatuses: table.fetchProjectStatuses,
@@ -109,7 +109,7 @@ export const MyTasksPage = () => {
     return [...base.slice(0, tagsIdx + 1), ...propertyColumns, ...base.slice(tagsIdx + 1)];
   }, [
     table.activeGuildId,
-    table.isUpdatingTaskStatus,
+    table.isUpdatingTask,
     table.changeTaskStatus,
     table.changeTaskStatusById,
     table.fetchProjectStatuses,
@@ -193,7 +193,7 @@ export const MyTasksPage = () => {
           focus={focus}
           activeGuildId={table.activeGuildId}
           changeTaskStatus={table.changeTaskStatus}
-          isUpdatingTaskStatus={table.isUpdatingTaskStatus}
+          isUpdatingTask={table.isUpdatingTask}
         />
 
         {viewMode === "table" && (
@@ -215,14 +215,23 @@ export const MyTasksPage = () => {
             />
 
             <div className="relative">
+              {/* A refetch is a background event: a status change has already
+                  been applied to the rows optimistically, and the reader can go
+                  on sorting, paging and checking things off while the
+                  cross-guild aggregate catches up. So this says a refresh is
+                  running and takes nothing away — no cover, no pointer events,
+                  no dimming of rows that are already correct. */}
               {table.isRefetching ? (
-                <div className="absolute inset-0 z-10 flex items-start justify-center bg-background/60 pt-4">
-                  <div className="flex items-center gap-2 rounded-md border border-border bg-background px-4 py-2 shadow-sm">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span className="text-muted-foreground text-sm">{t("updating")}</span>
-                  </div>
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-x-0 top-0 z-10 h-0.5 overflow-hidden rounded-full bg-primary/15"
+                >
+                  <div className="h-full w-1/3 animate-indeterminate-sweep rounded-full bg-primary/60" />
                 </div>
               ) : null}
+              <span aria-live="polite" className="sr-only">
+                {table.isRefetching ? t("updating") : ""}
+              </span>
               {/* The saved sort has to be in hand before the table mounts: it
                   seeds its headers once, so a table built on the defaults would
                   keep claiming them while the rows came back in the saved

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -570,3 +570,26 @@ html.pride [data-slot="button"].bg-primary:hover {
   width: 6px;
   height: 6px;
 }
+
+/* An indeterminate sliver that crosses its track and repeats — for work
+   happening behind a surface that stays usable, where nothing is waiting on it
+   so it reports rather than blocks. Honours a reduced-motion preference by
+   holding still rather than disappearing: the bar is the only sign the refresh
+   is running. */
+@keyframes indeterminate-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+.animate-indeterminate-sweep {
+  animation: indeterminate-sweep 1.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-indeterminate-sweep {
+    animation: none;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Problem

Opening **My Tasks** took a couple of seconds, and every status change greyed
the whole table out behind an "Updating" spinner.

Two independent causes:

1. **The load.** The page fires *three* `/api/v1/me/tasks` requests (the table's
   page, plus the focus summary's rule and pin queries). Each fanned out
   sequentially through every guild and fully hydrated **every** matching task —
   status, assignees, tags, properties, comment counts — to return twenty. On top
   of that all three waited on a serial chain: authenticate → fetch saved
   filters/sort → fetch tasks.
2. **The freeze.** A status change invalidated all three queries, and the page
   rendered a translucent cover over the table for the duration *and* disabled
   every row's controls via the mutation's shared `isPending` — in the table and
   the focus summary alike.

While checking the Tailwind setup for a related layout fix, I also found that
`tailwind.config.ts` is **not loaded at all**: the app is on Tailwind 4 CSS-first
(`@import "tailwindcss"` in `styles.css`) with no `@config` directive.

## Changes

### Backend — cost follows the page, not the task list

- [tasks.py](backend/app/api/v1/tenant_endpoints/tasks.py) — `_gather_global_task_reads`
  is now two passes: **order** the whole matching set from narrow per-guild rows
  (ids + sort keys only), slice to the requested page, then **hydrate** only those
  ids, from only the guilds that contribute to the page.
- Profiling showed **~87% of the time waiting on round trips**, not on rows, so
  three more trips per guild went with it: `joinedload` for the
  project → initiative → guild many-to-one chain (was 3 `selectinload` queries),
  the comment count folded into the row's own `SELECT`, and the per-guild
  "Full access" lookup remembered on the session ([cross_guild.py](backend/app/services/cross_guild.py))
  now that a request visits a guild twice.

Measured on a 6-guild account, 20-row page, mean of 15 runs:

| assigned tasks | before | after |
|---|---|---|
| 30 | 328ms | 357ms |
| 240 | 609ms | 526ms |
| 1200 | 2056ms | **1139ms** |

82 → 73 statements per request. At 30 tasks it is a wash or marginally worse (the
second routing pass); the gain scales with the task list, which is the case that
was actually slow.

### Frontend — the table stays live

- [useGlobalTasksTable.ts](frontend/src/hooks/useGlobalTasksTable.ts) — a status
  change writes to every `/me/tasks` cache entry immediately and rolls back **that
  row only** on failure, so two rows changed at once cannot undo each other.
- `isUpdatingTaskStatus: boolean` → `isUpdatingTask: (task) => boolean`, so only
  the row actually saving is held ([globalTaskColumns.tsx](frontend/src/components/tasks/globalTaskColumns.tsx),
  [FocusSummary.tsx](frontend/src/components/tasks/FocusSummary.tsx)).
- [MyTasksPage.tsx](frontend/src/pages/user/MyTasksPage.tsx) — the blocking cover
  becomes a non-blocking progress line plus an `aria-live` announcement.
- [lib/viewPreferences.ts](frontend/src/lib/viewPreferences.ts) (new) — the
  preference map is fetched as soon as auth resolves, removing a serial hop before
  the first row. It lives in `lib/` because `useAuth` warms it and cannot import a
  module that imports `useAuth` back.

### Task page — one column on narrow screens

- [TaskEditPage.tsx](frontend/src/pages/TaskEditPage.tsx) — the form and checklist
  sat **side by side on any narrow screen** (152px each at 375px) because the flex
  row only wrapped when each half claimed a min-width above `sm`. Replaced with one
  grid track definition that decides from the **container**:
  `repeat(auto-fit,minmax(min(25rem,100%),1fr))` — and `min(25rem,100%)` is what
  lets the single column shrink on a phone instead of overflowing, which is why the
  `sm:` guard existed. **Behaviour at 640px and above is unchanged** (the old
  min-width already enforced the same 824px requirement).
- [TaskForm.tsx](frontend/src/components/tasks/TaskForm.tsx) — the task title comes
  down from `text-3xl`, three steps above the page's own headings.

### Tailwind 4

- The sweep animation is defined in [styles.css](frontend/src/styles.css) following
  the existing `.animate-chester-*` pattern, with a `prefers-reduced-motion` branch
  that fills the track rather than vanishing. **`tailwind.config.ts` is not loaded**
  — it is still in the repo and still in `tsconfig.json`'s `include`, so it looks
  live but silently does nothing. Worth deleting or wiring up with `@config`;
  deliberately not in this PR.

## Testing

- `cd backend && pytest app/api/v1/tenant_endpoints/ app/services/ app/db/` →
  **4412 passed**, 119 skipped. 18 failures under `-n auto` all pass serially (the
  known #1048 `.env` credential flake); the 19th,
  `app/services/platform/guilds_test.py::test_reorder_memberships`, **fails
  identically on a clean `dev`** with these changes stashed — pre-existing, not from
  this PR.
- `cd frontend && pnpm test:run` → **3274 passed** / 299 files.
- `pnpm typecheck`, `pnpm biome check`, `ruff check app`, `pnpm build` → clean.
- Verified both new CSS rules reach the built bundle (`dist/assets/*.css`).
- Layout verified in real Chromium at 12 widths, old CSS vs new — 2 columns at
  360–639px before, 1 column after, identical at 640px+.

New tests:
- Cross-guild paging returns the page in **sort order, not guild order** — verified
  it fails if the reassembly step is removed.
- A page drawn from one guild still counts the others in `total_count`.
- The row-level comment count now that it comes from the row's own `SELECT`.
- The optimistic check landing before the server answers — verified it fails
  without the optimistic write.
- Other rows staying enabled while one saves.

## Known follow-up (not in this PR)

The task title is an `<input>`, so a long title **cannot wrap** — it scrolls
sideways inside the field, and since the title *is* the page heading you can only
read it by scrubbing. Fixing it means an auto-growing `<textarea>`
(`field-sizing: content` plus a `scrollHeight` fallback for Safari/iOS) and
intercepting Enter so a title never contains a newline. Deferred deliberately: the
Enter/IME/native-keyboard behaviour is a real behaviour change, not styling.