### PR TITLE
Assert the trash policy over every table

### DIFF
--- a/backend/app/db/guild_rls_test.py
+++ b/backend/app/db/guild_rls_test.py
@@ -384,16 +384,35 @@ def test_every_declared_hop_walks_a_real_column_to_a_real_table():
 
 _GID_QUERY_TRASH = 990_412
 
+#: What ``query_excludes_trash`` has to say, as Postgres normalises it.
+#:
+#: Pinned whole rather than searched for a substring. The three ways this
+#: policy could be wrong while still mentioning the right words are an inverted
+#: comparison, a different setting name, and a missing ``deleted_at IS NULL``
+#: branch — the first two would hide live rows from the screens that manage the
+#: trash, the third would hide nothing from anybody. Equality catches all three;
+#: "contains app.query" catches none of them.
+_QUERY_TRASH_QUAL = (
+    "((deleted_at IS NULL) OR (current_setting('app.query'::text, true)"
+    " IS DISTINCT FROM 'true'::text))"
+)
 
+
+@pytest.mark.database
 async def test_soft_delete_tables_keep_the_trash_out_of_reader_written_sql(engine):
     """Every soft-delete table carries ``query_excludes_trash`` in a freshly
-    provisioned schema — RESTRICTIVE, FOR SELECT.
+    provisioned schema — RESTRICTIVE, FOR SELECT, and saying the same thing.
 
     Over the whole set rather than one table. The rule is that a statement a
     reader wrote reports on live content, and a table that quietly missed the
     policy would answer with deleted rows while every other table did not —
     which is worse than either answer given consistently, and invisible from
     any one dataset's tests.
+
+    What the policy *does* in each direction is proved end to end against real
+    rows in ``query_test.py``: a trashed task is absent from a query, and still
+    present through the endpoint that manages the trash. This is the shape, for
+    every table, so that proof holds for more than the one table it was run on.
     """
     schema = guild_schema_name(_GID_QUERY_TRASH)
     try:
@@ -422,11 +441,10 @@ async def test_soft_delete_tables_keep_the_trash_out_of_reader_written_sql(engin
                 f"narrows every other policy rather than widening one, got "
                 f"{permissive} FOR {cmd}."
             )
-            # It has to read the flag: a policy that only checked deleted_at
-            # would take the trash away from the screens that manage it.
-            assert "app.query" in qual, (
-                f"{tbl}.query_excludes_trash must apply to reader-written SQL "
-                f"only, got: {qual}"
+            assert qual == _QUERY_TRASH_QUAL, (
+                f"{tbl}.query_excludes_trash does not say what it must.\n"
+                f"  expected: {_QUERY_TRASH_QUAL}\n"
+                f"  got:      {qual}"
             )
     finally:
         async with engine.begin() as conn:

--- a/backend/app/db/guild_rls_test.py
+++ b/backend/app/db/guild_rls_test.py
@@ -380,3 +380,54 @@ def test_every_declared_hop_walks_a_real_column_to_a_real_table():
                 )
 
     assert problems == [], problems
+
+
+_GID_QUERY_TRASH = 990_412
+
+
+async def test_soft_delete_tables_keep_the_trash_out_of_reader_written_sql(engine):
+    """Every soft-delete table carries ``query_excludes_trash`` in a freshly
+    provisioned schema — RESTRICTIVE, FOR SELECT.
+
+    Over the whole set rather than one table. The rule is that a statement a
+    reader wrote reports on live content, and a table that quietly missed the
+    policy would answer with deleted rows while every other table did not —
+    which is worse than either answer given consistently, and invisible from
+    any one dataset's tests.
+    """
+    schema = guild_schema_name(_GID_QUERY_TRASH)
+    try:
+        async with engine.begin() as conn:
+            await provision_guild_schema(conn, _GID_QUERY_TRASH)
+        async with engine.connect() as conn:
+            rows = await conn.execute(
+                text(
+                    "SELECT tablename, permissive, cmd, qual FROM pg_policies "
+                    "WHERE schemaname = :s AND policyname = 'query_excludes_trash'"
+                ),
+                {"s": schema},
+            )
+            found = {tbl: (perm, cmd, qual) for tbl, perm, cmd, qual in rows}
+
+        missing = sorted(set(SOFT_DELETE_TABLES) - set(found))
+        assert not missing, (
+            f"these soft-delete tables would answer a reader's statement with "
+            f"deleted rows: {missing}"
+        )
+
+        for tbl in sorted(SOFT_DELETE_TABLES):
+            permissive, cmd, qual = found[tbl]
+            assert (permissive, cmd) == ("RESTRICTIVE", "SELECT"), (
+                f"{tbl}.query_excludes_trash must be RESTRICTIVE FOR SELECT so it "
+                f"narrows every other policy rather than widening one, got "
+                f"{permissive} FOR {cmd}."
+            )
+            # It has to read the flag: a policy that only checked deleted_at
+            # would take the trash away from the screens that manage it.
+            assert "app.query" in qual, (
+                f"{tbl}.query_excludes_trash must apply to reader-written SQL "
+                f"only, got: {qual}"
+            )
+    finally:
+        async with engine.begin() as conn:
+            await drop_guild_schema(conn, _GID_QUERY_TRASH)

--- a/backend/app/db/guild_rls_test.py
+++ b/backend/app/db/guild_rls_test.py
@@ -386,12 +386,10 @@ _GID_QUERY_TRASH = 990_412
 
 #: What ``query_excludes_trash`` has to say, as Postgres normalises it.
 #:
-#: Pinned whole rather than searched for a substring. The three ways this
-#: policy could be wrong while still mentioning the right words are an inverted
-#: comparison, a different setting name, and a missing ``deleted_at IS NULL``
-#: branch — the first two would hide live rows from the screens that manage the
-#: trash, the third would hide nothing from anybody. Equality catches all three;
-#: "contains app.query" catches none of them.
+#: Pinned whole rather than matched loosely: the policy has to say exactly
+#: this, so the test is an equality against the rendered predicate. Postgres
+#: normalises it the same way for every table, which is what makes that stable
+#: to compare.
 _QUERY_TRASH_QUAL = (
     "((deleted_at IS NULL) OR (current_setting('app.query'::text, true)"
     " IS DISTINCT FROM 'true'::text))"
@@ -403,16 +401,14 @@ async def test_soft_delete_tables_keep_the_trash_out_of_reader_written_sql(engin
     """Every soft-delete table carries ``query_excludes_trash`` in a freshly
     provisioned schema — RESTRICTIVE, FOR SELECT, and saying the same thing.
 
-    Over the whole set rather than one table. The rule is that a statement a
-    reader wrote reports on live content, and a table that quietly missed the
-    policy would answer with deleted rows while every other table did not —
-    which is worse than either answer given consistently, and invisible from
-    any one dataset's tests.
+    Asked of the whole set rather than one table, because the rule is that a
+    statement a reader wrote reports on live content — and that is a statement
+    about every dataset, not about the one a test happened to pick.
 
-    What the policy *does* in each direction is proved end to end against real
-    rows in ``query_test.py``: a trashed task is absent from a query, and still
-    present through the endpoint that manages the trash. This is the shape, for
-    every table, so that proof holds for more than the one table it was run on.
+    What the policy does is proved end to end against real rows in
+    ``query_test.py``: a trashed task is absent from a query, and still there
+    through the endpoint that manages the trash. This is the shape, for every
+    table, so that proof holds for more than the one table it was run on.
     """
     schema = guild_schema_name(_GID_QUERY_TRASH)
     try:
@@ -430,15 +426,13 @@ async def test_soft_delete_tables_keep_the_trash_out_of_reader_written_sql(engin
 
         missing = sorted(set(SOFT_DELETE_TABLES) - set(found))
         assert not missing, (
-            f"these soft-delete tables would answer a reader's statement with "
-            f"deleted rows: {missing}"
+            f"these soft-delete tables have no query_excludes_trash policy: {missing}"
         )
 
         for tbl in sorted(SOFT_DELETE_TABLES):
             permissive, cmd, qual = found[tbl]
             assert (permissive, cmd) == ("RESTRICTIVE", "SELECT"), (
-                f"{tbl}.query_excludes_trash must be RESTRICTIVE FOR SELECT so it "
-                f"narrows every other policy rather than widening one, got "
+                f"{tbl}.query_excludes_trash must be RESTRICTIVE FOR SELECT, got "
                 f"{permissive} FOR {cmd}."
             )
             assert qual == _QUERY_TRASH_QUAL, (


### PR DESCRIPTION
## Problem

Follow-up to #1587, which merged while this was being written — hence a separate PR rather than another commit on that branch.

Greptile's last finding on #1587 was fair: the `query_excludes_trash` policy is meant to cover **every** soft-deletable table, but the integration test exercised only `tasks`, and nothing asserted the policy is actually rendered for the full set. I had verified that by hand during development and never committed it, which is exactly the gap worth closing — a change to the render path could silently leave one dataset's deleted rows queryable, and no single dataset's tests would notice.

That failure mode is also worse than it first sounds: a table that quietly missed the policy would answer a reader's statement with deleted rows *while every other table did not*. Inconsistent is worse than either answer given consistently.

## Changes

One test in [guild_rls_test.py](backend/app/db/guild_rls_test.py), alongside the existing whole-set assertion for `soft_delete_admin_purge` that it mirrors. Over a freshly provisioned schema it checks, for every table in `SOFT_DELETE_TABLES`:

- the policy exists — naming the tables that would answer with deleted rows, rather than failing on one;
- it is `RESTRICTIVE FOR SELECT`, so it narrows every other policy rather than widening one;
- its predicate reads `app.query`, so the rule applies to reader-written SQL only. A policy that merely checked `deleted_at` would pass a weaker test while taking the trash away from the screens that manage it.

## Testing

- `pytest app/db/guild_rls_test.py` — 8 passed, on `dev` with #1587 merged.
- `ruff check app` — clean.
- **Confirmed non-vacuous**: dropping the policy from the initiative-scoped render path fails the test naming all 14 affected tables (the 2 guild-level tables come from the other call site and correctly stay covered) — which is precisely the render-path regression this is here to catch.