### PR TITLE
T67: complete a documented deprecation in the database connection contract

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,7 @@ Initiative connects through **three PostgreSQL logins**, each least-privilege fo
 | **`app_admin`** | Background jobs, startup seeding, bootstrapping endpoints | Yes — the standard Postgres trusted-batch actor, bounded by enumerated per-table `GRANT`s, and never serving a user request as itself. Entering a guild schema requires `SET ROLE`, which **drops** the bypass |
 | **`app_provisioner`** | Migrations and DDL (`CREATE SCHEMA`, `CREATE ROLE`) | No — `NOSUPERUSER CREATEROLE`, and `FORCE ROW LEVEL SECURITY` keeps it policy-bound for data |
 
-**The application never holds Postgres superuser credentials.** A superuser `DATABASE_URL` is deprecated; the app logs a warning at boot, and a future release will refuse to start with one.
+**The application never holds Postgres superuser credentials.** A superuser (or `BYPASSRLS`) `DATABASE_URL` **stops the boot** — every guarantee above is enforced by row-level security, and those attributes are the right to ignore it. The refusal names the one-minute migration to `app_provisioner`. `ALLOW_PRIVILEGED_DATABASE_URL=true` keeps such a deployment booting for one maintenance window; it warns on every boot, and states that the per-guild boundary is not in force while it is set. `DATABASE_URL_BOOTSTRAP` is unaffected — creating the least-privilege roles is the one job that legitimately needs the privilege.
 
 ### No standing bypass, and no superuser account
 

--- a/backend/.venv
+++ b/backend/.venv
@@ -1,0 +1,1 @@
+/Users/tomfisher/src/Morelitea/initiative/backend/.venv

--- a/backend/.venv
+++ b/backend/.venv
@@ -1,1 +1,0 @@
-/Users/tomfisher/src/Morelitea/initiative/backend/.venv

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -167,6 +167,14 @@ class Settings(BaseSettings):
     # Unset it and the app verifies those prerequisites instead of applying
     # them; a deployment that provisions its database out of band never sets it.
     DATABASE_URL_BOOTSTRAP: str | None = None
+    # An escape hatch, not a supported configuration. ``DATABASE_URL`` holding
+    # SUPERUSER or BYPASSRLS voids every row-level-security guarantee in
+    # SECURITY.md -- the tenancy boundary is enforced by RLS, and these two
+    # attributes are exactly the right to ignore it. Startup refuses such a
+    # connection. An operator who cannot migrate in the same maintenance window
+    # can set this to keep booting; it is recorded at WARNING on every boot so
+    # it cannot become the quiet steady state.
+    ALLOW_PRIVILEGED_DATABASE_URL: bool = False
     # Where to hold the realtime signal channel's own connection. ``LISTEN`` is
     # session state and so wants a connection of its own, apart from the pooled
     # engines above. Unset (the common case) it uses ``DATABASE_URL``; set it

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -167,13 +167,14 @@ class Settings(BaseSettings):
     # Unset it and the app verifies those prerequisites instead of applying
     # them; a deployment that provisions its database out of band never sets it.
     DATABASE_URL_BOOTSTRAP: str | None = None
-    # An escape hatch, not a supported configuration. ``DATABASE_URL`` holding
-    # SUPERUSER or BYPASSRLS voids every row-level-security guarantee in
-    # SECURITY.md -- the tenancy boundary is enforced by RLS, and these two
-    # attributes are exactly the right to ignore it. Startup refuses such a
-    # connection. An operator who cannot migrate in the same maintenance window
-    # can set this to keep booting; it is recorded at WARNING on every boot so
-    # it cannot become the quiet steady state.
+    # An escape hatch, not a supported configuration. The application's
+    # database connection is meant to be the least-privilege provisioning
+    # login; startup refuses one that is not, because the access rules
+    # described in SECURITY.md are enforced by the database and assume it.
+    #
+    # An operator who cannot migrate in the same maintenance window can set
+    # this to keep booting. It is recorded at WARNING on every boot so it
+    # cannot become the quiet steady state.
     ALLOW_PRIVILEGED_DATABASE_URL: bool = False
     # Where to hold the realtime signal channel's own connection. ``LISTEN`` is
     # session state and so wants a connection of its own, apart from the pooled

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -636,21 +636,19 @@ async def backfill_guild_schemas() -> BackfillSummary:
 async def reject_privileged_database_url() -> None:
     """Refuse to start when DATABASE_URL connects as a SUPERUSER/BYPASSRLS role.
 
-    Every tenancy guarantee in ``SECURITY.md`` is enforced by row-level
-    security, and these two role attributes are precisely the right to ignore
-    it. A deployment wired this way is not a degraded one -- it has no
-    boundary between guilds at all, while the document says it has.
+    The application's own connection is meant to be ``app_provisioner``: the
+    least-privilege login that can run migrations and provision guild schemas.
+    The access rules ``SECURITY.md`` describes are enforced by the database and
+    assume this connection is bound by them.
 
-    This used to be a warning. ``SECURITY.md`` has said since it was written
-    that "a future release will refuse to start with one", and a log line at
-    boot is not a barrier: on the deployment where it matters, nobody reads it.
+    ``SECURITY.md`` has said since it was written that "a future release will
+    refuse to start with one". This is that release; it used to be a warning.
 
-    Migrations and guild provisioning fit in the least-privilege
-    ``app_provisioner`` role (NOSUPERUSER CREATEROLE + CREATE on the database +
-    ownership of the app's objects), so this URL never needs more. Creating
-    that role is :mod:`app.db.bootstrap`'s job, over ``DATABASE_URL_BOOTSTRAP``
-    -- which is the one connection that legitimately holds the privilege, and
-    which this does not touch.
+    Migrations and guild provisioning fit in ``app_provisioner`` (NOSUPERUSER
+    CREATEROLE + CREATE on the database + ownership of the app's objects), so
+    this URL never needs more. Creating that role is :mod:`app.db.bootstrap`'s
+    job, over ``DATABASE_URL_BOOTSTRAP`` -- the one connection that
+    legitimately holds the privilege, and which this does not touch.
 
     ``ALLOW_PRIVILEGED_DATABASE_URL`` keeps such a deployment booting for an
     operator who cannot migrate in the same window. It logs every boot, so it
@@ -684,10 +682,9 @@ async def reject_privileged_database_url() -> None:
         logger.warning(
             "\n%s\n"
             "ALLOW_PRIVILEGED_DATABASE_URL is set, and DATABASE_URL connects\n"
-            "as a %s role. Row-level security does not constrain this\n"
-            "connection, so the per-guild boundary described in SECURITY.md is\n"
-            "NOT in force. This setting exists to buy a maintenance window,\n"
-            "not to be left on. Migrate (about a minute):\n"
+            "as a %s role. The access rules described in SECURITY.md are NOT\n"
+            "in force for this connection. This setting exists to buy a\n"
+            "maintenance window, not to be left on. Migrate (about a minute):\n"
             "\n%s\n%s",
             "=" * 70,
             held,
@@ -699,9 +696,9 @@ async def reject_privileged_database_url() -> None:
     raise SystemExit(
         f"\n{'=' * 70}\n"
         f"REFUSING TO START: DATABASE_URL connects as a {held} role.\n\n"
-        f"The app never needs these privileges, and with them row-level\n"
-        f"security does not constrain this connection -- the per-guild\n"
-        f"boundary described in SECURITY.md would not be in force.\n\n"
+        f"The app never needs these privileges, and the access rules\n"
+        f"described in SECURITY.md are not in force for a connection that\n"
+        f"holds them.\n\n"
         f"Migrate once (about a minute):\n\n"
         f"{migration}\n\n"
         f"To keep booting for one maintenance window, set\n"

--- a/backend/app/db/schema_provisioning.py
+++ b/backend/app/db/schema_provisioning.py
@@ -633,19 +633,28 @@ async def backfill_guild_schemas() -> BackfillSummary:
     )
 
 
-async def warn_if_privileged_database_url() -> None:
-    """Emit a deprecation banner when DATABASE_URL connects as a superuser
-    (or BYPASSRLS) role.
+async def reject_privileged_database_url() -> None:
+    """Refuse to start when DATABASE_URL connects as a SUPERUSER/BYPASSRLS role.
+
+    Every tenancy guarantee in ``SECURITY.md`` is enforced by row-level
+    security, and these two role attributes are precisely the right to ignore
+    it. A deployment wired this way is not a degraded one -- it has no
+    boundary between guilds at all, while the document says it has.
+
+    This used to be a warning. ``SECURITY.md`` has said since it was written
+    that "a future release will refuse to start with one", and a log line at
+    boot is not a barrier: on the deployment where it matters, nobody reads it.
 
     Migrations and guild provisioning fit in the least-privilege
     ``app_provisioner`` role (NOSUPERUSER CREATEROLE + CREATE on the database +
     ownership of the app's objects), so this URL never needs more. Creating
-    that role is :mod:`app.db.bootstrap`'s job, over ``DATABASE_URL_BOOTSTRAP``.
+    that role is :mod:`app.db.bootstrap`'s job, over ``DATABASE_URL_BOOTSTRAP``
+    -- which is the one connection that legitimately holds the privilege, and
+    which this does not touch.
 
-    Superuser DATABASE_URL support is DEPRECATED and a future release will
-    refuse to start with it, so the banner is deliberately loud — a framed
-    multi-line block at WARNING every boot, not a one-liner that scrolls past —
-    to move the remaining legacy deployments before the hard cutoff.
+    ``ALLOW_PRIVILEGED_DATABASE_URL`` keeps such a deployment booting for an
+    operator who cannot migrate in the same window. It logs every boot, so it
+    stays visible rather than becoming the quiet steady state.
     """
     async with db_session.provisioning_engine.connect() as conn:
         rolsuper, rolbypassrls = (
@@ -656,26 +665,49 @@ async def warn_if_privileged_database_url() -> None:
                 )
             )
         ).one()
-    if rolsuper or rolbypassrls:
+    if not (rolsuper or rolbypassrls):
+        return
+
+    held = "SUPERUSER" if rolsuper else "BYPASSRLS"
+    migration = (
+        "  1. Set DATABASE_URL_BOOTSTRAP to this same connection URL.\n"
+        "  2. Point DATABASE_URL at app_provisioner, with a password of\n"
+        "     your choosing, and restart. The bootstrap creates the role\n"
+        "     and hands the app's objects over to it.\n"
+        "  3. Optional: remove DATABASE_URL_BOOTSTRAP and restart again.\n"
+        "\n"
+        "DATABASE_URL_APP / DATABASE_URL_ADMIN are unaffected. See the\n"
+        "deployment docs for details."
+    )
+
+    if settings.ALLOW_PRIVILEGED_DATABASE_URL:
         logger.warning(
             "\n%s\n"
-            "DEPRECATED: DATABASE_URL connects as %s role.\n"
-            "The app never needs these privileges, and a FUTURE RELEASE WILL\n"
-            "REFUSE TO START with them. Migrate once (about a minute):\n"
-            "\n"
-            "  1. Set DATABASE_URL_BOOTSTRAP to this same connection URL.\n"
-            "  2. Point DATABASE_URL at app_provisioner, with a password of\n"
-            "     your choosing, and restart. The bootstrap creates the role\n"
-            "     and hands the app's objects over to it.\n"
-            "  3. Optional: remove DATABASE_URL_BOOTSTRAP and restart again.\n"
-            "\n"
-            "DATABASE_URL_APP / DATABASE_URL_ADMIN are unaffected. See the\n"
-            "deployment docs for details.\n"
-            "%s",
+            "ALLOW_PRIVILEGED_DATABASE_URL is set, and DATABASE_URL connects\n"
+            "as a %s role. Row-level security does not constrain this\n"
+            "connection, so the per-guild boundary described in SECURITY.md is\n"
+            "NOT in force. This setting exists to buy a maintenance window,\n"
+            "not to be left on. Migrate (about a minute):\n"
+            "\n%s\n%s",
             "=" * 70,
-            "a SUPERUSER" if rolsuper else "a BYPASSRLS",
+            held,
+            migration,
             "=" * 70,
         )
+        return
+
+    raise SystemExit(
+        f"\n{'=' * 70}\n"
+        f"REFUSING TO START: DATABASE_URL connects as a {held} role.\n\n"
+        f"The app never needs these privileges, and with them row-level\n"
+        f"security does not constrain this connection -- the per-guild\n"
+        f"boundary described in SECURITY.md would not be in force.\n\n"
+        f"Migrate once (about a minute):\n\n"
+        f"{migration}\n\n"
+        f"To keep booting for one maintenance window, set\n"
+        f"ALLOW_PRIVILEGED_DATABASE_URL=true. It warns on every boot.\n"
+        f"{'=' * 70}\n"
+    )
 
 
 SEARCH_OPCLASS = "tsvector_search_ops"
@@ -1162,8 +1194,9 @@ async def verify_engine_identities() -> None:
     functions, because routed requests ``SET ROLE`` into guild/platform roles
     either way, but the unrouted request surface then runs at the system
     engine's privileges and loses its database-level row-security backstop.
-    Following the ``warn_if_privileged_database_url`` pattern, that wiring
-    gets a framed WARNING naming the recommended split, not a boot stop.
+    That wiring gets a framed WARNING naming the recommended split, not a
+    boot stop. It is a weaker backstop, not an absent boundary --- which is
+    why it warns where ``reject_privileged_database_url`` refuses.
 
     Runs before the heals so the operator sees which login each repair will
     act on. Probes ``session_user`` (the login) rather than ``current_user``

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 import app.db.schema_provisioning as schema_provisioning
+from app.core.config import settings
 from app.db.schema_provisioning import (
     SUPPORT_WRITE_PROTECTED_TABLES,
     apply_template_rls,
@@ -1095,8 +1096,9 @@ async def test_engine_identities_warn_on_shared_app_and_admin_login(
     import app.db.session as db_session
 
     # Point the app engine at the (harness) admin engine: same login, same DB.
-    # Working-but-not-recommended wiring warns loudly and boots (the
-    # warn_if_privileged_database_url pattern), it never stops.
+    # Working-but-not-recommended wiring warns loudly and boots; it never
+    # stops. Contrast reject_privileged_database_url, which does stop --- the
+    # difference is a weakened backstop versus no boundary at all.
     monkeypatch.setattr(db_session, "engine", db_session.admin_engine)
     with caplog.at_level("WARNING", logger="app.db.schema_provisioning"):
         await schema_provisioning.verify_engine_identities()
@@ -1195,3 +1197,98 @@ async def test_effective_grants_fail_closed_for_grantless_admin_login(
     finally:
         await bound_engine.dispose()
         await _drop_login(engine, role)
+
+
+# --- reject_privileged_database_url (T67) ------------------------------------
+#
+# The role attributes are faked rather than created. Whether the harness login
+# happens to be a superuser is a property of the CI database, not of this
+# behaviour, and a test that only runs where the DB is set up a particular way
+# is a test that quietly stops running.
+
+
+class _FakeResult:
+    def __init__(self, row):
+        self._row = row
+
+    def one(self):
+        return self._row
+
+
+class _FakeConnection:
+    def __init__(self, row):
+        self._row = row
+
+    async def execute(self, *_args, **_kwargs):
+        return _FakeResult(self._row)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeEngine:
+    """Stands in for provisioning_engine, reporting fixed role attributes."""
+
+    def __init__(self, *, rolsuper: bool, rolbypassrls: bool):
+        self._row = (rolsuper, rolbypassrls)
+
+    def connect(self):
+        return _FakeConnection(self._row)
+
+
+def _fake_provisioning_engine(monkeypatch, *, rolsuper=False, rolbypassrls=False):
+    import app.db.session as db_session
+
+    monkeypatch.setattr(
+        db_session,
+        "provisioning_engine",
+        _FakeEngine(rolsuper=rolsuper, rolbypassrls=rolbypassrls),
+    )
+
+
+async def test_unprivileged_database_url_starts(monkeypatch):
+    _fake_provisioning_engine(monkeypatch)
+    await schema_provisioning.reject_privileged_database_url()
+
+
+@pytest.mark.parametrize(
+    ("attributes", "named"),
+    [
+        ({"rolsuper": True}, "SUPERUSER"),
+        ({"rolbypassrls": True}, "BYPASSRLS"),
+    ],
+)
+async def test_privileged_database_url_refuses_to_start(monkeypatch, attributes, named):
+    """Both attributes are the right to ignore row-level security, so both
+    stop the boot -- and the message names which one was found, because the
+    operator has to know which to remove."""
+    _fake_provisioning_engine(monkeypatch, **attributes)
+    monkeypatch.setattr(settings, "ALLOW_PRIVILEGED_DATABASE_URL", False)
+
+    with pytest.raises(SystemExit) as exit_info:
+        await schema_provisioning.reject_privileged_database_url()
+
+    message = str(exit_info.value)
+    assert named in message
+    # The refusal has to carry the way out, or it is an outage with no remedy.
+    assert "DATABASE_URL_BOOTSTRAP" in message
+    assert "app_provisioner" in message
+    assert "ALLOW_PRIVILEGED_DATABASE_URL" in message
+
+
+async def test_opt_out_boots_and_says_the_boundary_is_not_in_force(monkeypatch, caplog):
+    """The escape hatch has to stay uncomfortable. It warns every boot, and
+    the warning states the consequence rather than only naming the setting."""
+    _fake_provisioning_engine(monkeypatch, rolsuper=True)
+    monkeypatch.setattr(settings, "ALLOW_PRIVILEGED_DATABASE_URL", True)
+
+    with caplog.at_level("WARNING", logger="app.db.schema_provisioning"):
+        await schema_provisioning.reject_privileged_database_url()
+
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "ALLOW_PRIVILEGED_DATABASE_URL" in joined
+    assert "SECURITY.md" in joined
+    assert "NOT in force" in joined

--- a/backend/app/db/schema_provisioning_test.py
+++ b/backend/app/db/schema_provisioning_test.py
@@ -1262,9 +1262,9 @@ async def test_unprivileged_database_url_starts(monkeypatch):
     ],
 )
 async def test_privileged_database_url_refuses_to_start(monkeypatch, attributes, named):
-    """Both attributes are the right to ignore row-level security, so both
-    stop the boot -- and the message names which one was found, because the
-    operator has to know which to remove."""
+    """Either attribute means the connection is more than the app needs, so
+    both stop the boot. The message names which was found, because the operator
+    has to know which to remove."""
     _fake_provisioning_engine(monkeypatch, **attributes)
     monkeypatch.setattr(settings, "ALLOW_PRIVILEGED_DATABASE_URL", False)
 
@@ -1273,15 +1273,16 @@ async def test_privileged_database_url_refuses_to_start(monkeypatch, attributes,
 
     message = str(exit_info.value)
     assert named in message
-    # The refusal has to carry the way out, or it is an outage with no remedy.
+    # The refusal carries the way out; without it, it is an outage with no
+    # stated remedy.
     assert "DATABASE_URL_BOOTSTRAP" in message
     assert "app_provisioner" in message
     assert "ALLOW_PRIVILEGED_DATABASE_URL" in message
 
 
 async def test_opt_out_boots_and_says_the_boundary_is_not_in_force(monkeypatch, caplog):
-    """The escape hatch has to stay uncomfortable. It warns every boot, and
-    the warning states the consequence rather than only naming the setting."""
+    """The escape hatch warns on every boot, and the warning says what it
+    changes rather than only naming the setting."""
     _fake_provisioning_engine(monkeypatch, rolsuper=True)
     monkeypatch.setattr(settings, "ALLOW_PRIVILEGED_DATABASE_URL", True)
 
@@ -1291,4 +1292,4 @@ async def test_opt_out_boots_and_says_the_boundary_is_not_in_force(monkeypatch, 
     joined = "\n".join(r.getMessage() for r in caplog.records)
     assert "ALLOW_PRIVILEGED_DATABASE_URL" in joined
     assert "SECURITY.md" in joined
-    assert "NOT in force" in joined
+    assert "NOT\nin force" in joined or "NOT in force" in joined

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,10 +82,10 @@ async def lifespan(app: FastAPI):
     from app.db.bootstrap import ensure_database_bootstrap
 
     await ensure_database_bootstrap()
-    # Before any DDL runs: refuse a DATABASE_URL that bypasses row-level
-    # security. This is deliberately ahead of the migrations rather than beside
-    # the other heals below -- a connection that voids the tenancy boundary
-    # should not be the one that reshapes the schema.
+    # Before any DDL runs: check the connection is the least-privilege
+    # provisioning login. Ahead of the migrations rather than beside the other
+    # heals below, so a misconfigured connection is caught before it reshapes
+    # the schema.
     from app.db.schema_provisioning import reject_privileged_database_url
 
     await reject_privileged_database_url()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,6 +82,13 @@ async def lifespan(app: FastAPI):
     from app.db.bootstrap import ensure_database_bootstrap
 
     await ensure_database_bootstrap()
+    # Before any DDL runs: refuse a DATABASE_URL that bypasses row-level
+    # security. This is deliberately ahead of the migrations rather than beside
+    # the other heals below -- a connection that voids the tenancy boundary
+    # should not be the one that reshapes the schema.
+    from app.db.schema_provisioning import reject_privileged_database_url
+
+    await reject_privileged_database_url()
     await check_pre_baseline_db()
     await run_migrations()
     # Re-run the idempotent per-guild provisioning for every guild so any
@@ -95,7 +102,6 @@ async def lifespan(app: FastAPI):
         ensure_system_engine_bypassrls,
         verify_effective_shared_grants,
         verify_engine_identities,
-        warn_if_privileged_database_url,
         backfill_guild_search,
         warn_if_search_operator_missing,
     )
@@ -118,7 +124,6 @@ async def lifespan(app: FastAPI):
     # logins actually hold the audited privileges, stopping with the exact
     # GRANTs when a deployment's URLs connect as other logins.
     await verify_effective_shared_grants()
-    await warn_if_privileged_database_url()
     await warn_if_search_operator_missing()
     if settings.BILLING_URL and not billing_support_handoff_enabled():
         # The Guilds tab shows its billing button whenever a portal URL is set;


### PR DESCRIPTION
Tracked as **T67** in the private `Morelitea/security` repository.

The finding, reasoning, verification, and review notes live there. This description is deliberately minimal because this repository is public.

**Scope:** the database startup contract, typed configuration, operator documentation, and boundary tests.

**Verified:** the amended exact head passes the focused database/startup suites and repository lint, format, type, and diff gates. Reviewers should use T67 / WI-38 in `Morelitea/security` for detail.